### PR TITLE
🐛 fix: correct pricing mode buy/sell side logic for profit calculations

### DIFF
--- a/src/features/actions/gathering-profit.js
+++ b/src/features/actions/gathering-profit.js
@@ -147,7 +147,7 @@ export async function calculateGatheringProfit(actionHrid) {
         if (!drink || !drink.itemHrid) {
             continue;
         }
-        const drinkPrice = getItemPrice(drink.itemHrid, { context: 'profit' }) || 0;
+        const drinkPrice = getItemPrice(drink.itemHrid, { context: 'profit', side: 'buy' }) || 0;
         const costPerHour = drinkPrice * drinksPerHour;
         drinkCostPerHour += costPerHour;
 
@@ -222,7 +222,7 @@ export async function calculateGatheringProfit(actionHrid) {
     const dropTable = actionDetail.dropTable;
 
     for (const drop of dropTable) {
-        const rawPrice = getItemPrice(drop.itemHrid, { context: 'profit' }) || 0;
+        const rawPrice = getItemPrice(drop.itemHrid, { context: 'profit', side: 'sell' }) || 0;
         const rawPriceAfterTax = rawPrice * 0.98;
 
         // Apply gathering quantity bonus to drop amounts
@@ -270,7 +270,7 @@ export async function calculateGatheringProfit(actionHrid) {
             rawPerAction = processingBonus * rawLeftoverIfProcs + (1 - processingBonus) * rawIfNoProc;
 
             // Revenue per hour = per-action × actionsPerHour × efficiency
-            const processedPrice = getItemPrice(processedItemHrid, { context: 'profit' }) || 0;
+            const processedPrice = getItemPrice(processedItemHrid, { context: 'profit', side: 'sell' }) || 0;
             const processedPriceAfterTax = processedPrice * 0.98;
 
             const rawItemsPerHour = actionsPerHour * drop.dropRate * rawPerAction * efficiencyMultiplier;
@@ -339,7 +339,7 @@ export async function calculateGatheringProfit(actionHrid) {
 
             // Use weighted average price for gourmet bonus
             if (processedItemHrid && processingBonus > 0) {
-                const processedPrice = getItemPrice(processedItemHrid, { context: 'profit' }) || 0;
+                const processedPrice = getItemPrice(processedItemHrid, { context: 'profit', side: 'sell' }) || 0;
                 const processedPriceAfterTax = processedPrice * 0.98;
                 const weightedPrice = (rawPerAction * rawPriceAfterTax + processedPerAction * processedPriceAfterTax) /
                                      (rawPerAction + processedPerAction);

--- a/src/features/market/expected-value-calculator.js
+++ b/src/features/market/expected-value-calculator.js
@@ -179,8 +179,8 @@ class ExpectedValueCalculator {
 
         // Special case: Cowbell (use bag price ÷ 10, with 18% tax)
         if (itemHrid === this.COWBELL_HRID) {
-            // Get Cowbell Bag price using profit context
-            const bagValue = getItemPrice(this.COWBELL_BAG_HRID, { context: 'profit' }) || 0;
+            // Get Cowbell Bag price using profit context (sell side - you're selling the bag)
+            const bagValue = getItemPrice(this.COWBELL_BAG_HRID, { context: 'profit', side: 'sell' }) || 0;
 
             if (bagValue > 0) {
                 // Apply 18% market tax (Cowbell Bag only), then divide by 10
@@ -199,8 +199,8 @@ class ExpectedValueCalculator {
             return this.containerCache.get(itemHrid);
         }
 
-        // Regular market item - get price based on pricing mode
-        const dropPrice = getItemPrice(itemHrid, { enhancementLevel: 0, context: 'profit' });
+        // Regular market item - get price based on pricing mode (sell side - you're selling drops)
+        const dropPrice = getItemPrice(itemHrid, { enhancementLevel: 0, context: 'profit', side: 'sell' });
         return dropPrice > 0 ? dropPrice : null;
     }
 

--- a/src/features/market/profit-calculator.js
+++ b/src/features/market/profit-calculator.js
@@ -241,8 +241,8 @@ class ProfitCalculator {
         const itemPrice = marketAPI.getPrice(itemHrid, 0) || { ask: 0, bid: 0 };
 
         // Get output price based on pricing mode setting
-        // Uses 'profit' context to automatically select correct price
-        const outputPrice = getItemPrice(itemHrid, { context: 'profit' }) || 0;
+        // Uses 'profit' context with 'sell' side to get correct sell price
+        const outputPrice = getItemPrice(itemHrid, { context: 'profit', side: 'sell' }) || 0;
 
         // Apply market tax (2% tax on sales)
         const priceAfterTax = outputPrice * (1 - this.MARKET_TAX);
@@ -362,8 +362,8 @@ class ProfitCalculator {
             const itemDetails = dataManager.getItemDetails(actionDetails.upgradeItemHrid);
 
             if (itemDetails) {
-                // Get material price based on pricing mode (uses 'profit' context)
-                let materialPrice = getItemPrice(actionDetails.upgradeItemHrid, { context: 'profit' }) || 0;
+                // Get material price based on pricing mode (uses 'profit' context with 'buy' side)
+                let materialPrice = getItemPrice(actionDetails.upgradeItemHrid, { context: 'profit', side: 'buy' }) || 0;
 
                 // Special case: Coins have no market price but have face value of 1
                 if (actionDetails.upgradeItemHrid === '/items/coin' && materialPrice === 0) {
@@ -399,8 +399,8 @@ class ProfitCalculator {
                 // Apply artisan reduction
                 const reducedAmount = baseAmount * (1 - artisanBonus);
 
-                // Get material price based on pricing mode (uses 'profit' context)
-                let materialPrice = getItemPrice(input.itemHrid, { context: 'profit' }) || 0;
+                // Get material price based on pricing mode (uses 'profit' context with 'buy' side)
+                let materialPrice = getItemPrice(input.itemHrid, { context: 'profit', side: 'buy' }) || 0;
 
                 // Special case: Coins have no market price but have face value of 1
                 if (input.itemHrid === '/items/coin' && materialPrice === 0) {
@@ -540,8 +540,8 @@ class ProfitCalculator {
             const itemDetails = dataManager.getItemDetails(drink.itemHrid);
             if (!itemDetails) continue;
 
-            // Get tea price based on pricing mode (uses 'profit' context)
-            const teaPrice = getItemPrice(drink.itemHrid, { context: 'profit' }) || 0;
+            // Get tea price based on pricing mode (uses 'profit' context with 'buy' side)
+            const teaPrice = getItemPrice(drink.itemHrid, { context: 'profit', side: 'buy' }) || 0;
 
             // Drink Concentration increases consumption rate: base 12/hour × (1 + DC%)
             const drinksPerHour = 12 * (1 + drinkConcentration);


### PR DESCRIPTION
## Summary

Fixes a critical bug where pricing modes (Conservative/Hybrid/Optimistic) were incorrectly using the same price type for both buying materials and selling output, resulting in inaccurate profit calculations.

## Problem

The profit calculator was using a single price type (ask/bid/average) for all items in a calculation, but different pricing modes require different prices for materials (buy-side) vs output (sell-side):

- **Conservative** should use Ask for materials, Bid for output (instant trading - worst case)
- **Hybrid** should use Ask for materials, Ask for output (instant buy, patient sell)
- **Optimistic** should use Bid for materials, Ask for output (patient trading - best case)

Previously, all three modes were applying the same price to both sides, making Conservative and Optimistic modes calculate incorrectly.

## Solution

Added a `side` parameter (`'buy'` or `'sell'`) to the pricing system to distinguish between:
- **Buy-side pricing**: Materials, consumables, upgrade items (what you pay)
- **Sell-side pricing**: Output items, drops, loot (what you receive)

## Changes

- `src/utils/market-data.js`: Added `side` parameter to `getItemPrice()` and updated `getPricingMode()` logic
- `src/features/market/profit-calculator.js`: Updated all pricing calls with correct `side` values
- `src/features/market/expected-value-calculator.js`: Updated drop/container pricing
- `src/features/actions/gathering-profit.js`: Updated gathering profit calculations

## Testing

After this fix, pricing modes now behave correctly:

| Mode | Materials | Output | Expected Profit |
|------|-----------|--------|-----------------|
| Conservative | Ask (higher cost) | Bid (lower revenue) | Lowest (pessimistic) |
| Hybrid | Ask (higher cost) | Ask (higher revenue) | Medium |
| Optimistic | Bid (lower cost) | Ask (higher revenue) | Highest (optimistic) |

## Impact

- Fixes incorrect profit calculations in Conservative and Optimistic modes
- Backward compatible (defaults to `side: 'sell'` if not specified)
- No breaking changes to existing functionality