### PR TITLE
✨ feat: display market tax as separate cost in profit breakdown

### DIFF
--- a/src/features/actions/gathering-profit.js
+++ b/src/features/actions/gathering-profit.js
@@ -302,16 +302,18 @@ export async function calculateGatheringProfit(actionHrid) {
                 name: rawItemName,
                 itemsPerHour: rawItemsPerHour,
                 dropRate: drop.dropRate,
-                priceEach: rawPriceAfterTax,
-                revenuePerHour: rawItemsPerHour * rawPriceAfterTax
+                priceEach: rawPrice,
+                priceAfterTax: rawPriceAfterTax,
+                revenuePerHour: rawItemsPerHour * rawPrice
             });
 
             baseOutputs.push({
                 name: processedItemName,
                 itemsPerHour: processedItemsPerHour,
                 dropRate: drop.dropRate * processingBonus,
-                priceEach: processedPriceAfterTax,
-                revenuePerHour: processedItemsPerHour * processedPriceAfterTax,
+                priceEach: processedPrice,
+                priceAfterTax: processedPriceAfterTax,
+                revenuePerHour: processedItemsPerHour * processedPrice,
                 isProcessed: true, // Flag to show processing percentage
                 processingChance: processingBonus // Store the processing chance (e.g., 0.15 for 15%)
             });
@@ -326,8 +328,9 @@ export async function calculateGatheringProfit(actionHrid) {
                 name: itemName,
                 itemsPerHour: rawItemsPerHour,
                 dropRate: drop.dropRate,
-                priceEach: rawPriceAfterTax,
-                revenuePerHour: rawItemsPerHour * rawPriceAfterTax
+                priceEach: rawPrice,
+                priceAfterTax: rawPriceAfterTax,
+                revenuePerHour: rawItemsPerHour * rawPrice
             });
         }
 

--- a/src/features/actions/profit-display.js
+++ b/src/features/actions/profit-display.js
@@ -36,8 +36,11 @@ export async function displayGatheringProfit(panel, actionHrid, dropTableSelecto
     // Create top-level summary
     const profit = Math.round(profitData.profitPerHour);
     const profitPerDay = Math.round(profitData.profitPerDay);
-    const revenue = Math.round(profitData.revenuePerHour);
-    const costs = Math.round(profitData.drinkCostPerHour);
+    // Revenue is already after tax (calculated with 0.98 multiplier), so calculate gross revenue
+    const grossRevenue = Math.round(profitData.revenuePerHour / 0.98);
+    const marketTax = Math.round(grossRevenue * 0.02);
+    const revenue = grossRevenue;
+    const costs = Math.round(profitData.drinkCostPerHour + marketTax);
     const summary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day`;
 
     // ===== Build Detailed Breakdown Content =====
@@ -166,6 +169,24 @@ export async function displayGatheringProfit(panel, actionHrid, dropTableSelecto
     );
 
     costsDiv.appendChild(drinkCostsSection);
+
+    // Market Tax subsection
+    const marketTaxContent = document.createElement('div');
+    const marketTaxLine = document.createElement('div');
+    marketTaxLine.style.marginLeft = '8px';
+    marketTaxLine.textContent = `• Market Tax: 2% of revenue → ${formatLargeNumber(marketTax)}/hr`;
+    marketTaxContent.appendChild(marketTaxLine);
+
+    const marketTaxSection = createCollapsibleSection(
+        '',
+        `Market Tax: ${formatLargeNumber(marketTax)}/hr (2%)`,
+        null,
+        marketTaxContent,
+        false,
+        1
+    );
+
+    costsDiv.appendChild(marketTaxSection);
 
     // Modifiers Section
     const modifiersDiv = document.createElement('div');
@@ -344,8 +365,11 @@ export async function displayProductionProfit(panel, actionHrid, dropTableSelect
     const profit = Math.round(profitData.profitPerHour);
     const profitPerDay = Math.round(profit * 24);
     const bonusRevenueTotal = profitData.bonusRevenue?.totalBonusRevenue || 0;
-    const revenue = Math.round(profitData.itemsPerHour * profitData.priceAfterTax + profitData.gourmetBonusItems * profitData.priceAfterTax + bonusRevenueTotal);
-    const costs = Math.round(profitData.materialCostPerHour + profitData.totalTeaCostPerHour);
+    // Use outputPrice (pre-tax) for revenue display
+    const revenue = Math.round(profitData.itemsPerHour * profitData.outputPrice + profitData.gourmetBonusItems * profitData.outputPrice + bonusRevenueTotal);
+    // Calculate market tax (2% of revenue)
+    const marketTax = Math.round(revenue * 0.02);
+    const costs = Math.round(profitData.materialCostPerHour + profitData.totalTeaCostPerHour + marketTax);
     const summary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day`;
 
     // ===== Build Detailed Breakdown Content =====
@@ -359,10 +383,10 @@ export async function displayProductionProfit(panel, actionHrid, dropTableSelect
     const baseOutputContent = document.createElement('div');
     const baseOutputLine = document.createElement('div');
     baseOutputLine.style.marginLeft = '8px';
-    baseOutputLine.textContent = `• Base Output: ${profitData.itemsPerHour.toFixed(1)}/hr @ ${formatWithSeparator(Math.round(profitData.priceAfterTax))} each → ${formatLargeNumber(Math.round(profitData.itemsPerHour * profitData.priceAfterTax))}/hr`;
+    baseOutputLine.textContent = `• Base Output: ${profitData.itemsPerHour.toFixed(1)}/hr @ ${formatWithSeparator(Math.round(profitData.outputPrice))} each → ${formatLargeNumber(Math.round(profitData.itemsPerHour * profitData.outputPrice))}/hr`;
     baseOutputContent.appendChild(baseOutputLine);
 
-    const baseRevenue = profitData.itemsPerHour * profitData.priceAfterTax;
+    const baseRevenue = profitData.itemsPerHour * profitData.outputPrice;
     const baseOutputSection = createCollapsibleSection(
         '',
         `Base Output: ${formatWithSeparator(Math.round(baseRevenue))}/hr`,
@@ -378,10 +402,10 @@ export async function displayProductionProfit(panel, actionHrid, dropTableSelect
         const gourmetContent = document.createElement('div');
         const gourmetLine = document.createElement('div');
         gourmetLine.style.marginLeft = '8px';
-        gourmetLine.textContent = `• Gourmet Bonus: ${profitData.gourmetBonusItems.toFixed(1)}/hr @ ${formatWithSeparator(Math.round(profitData.priceAfterTax))} each → ${formatLargeNumber(Math.round(profitData.gourmetBonusItems * profitData.priceAfterTax))}/hr`;
+        gourmetLine.textContent = `• Gourmet Bonus: ${profitData.gourmetBonusItems.toFixed(1)}/hr @ ${formatWithSeparator(Math.round(profitData.outputPrice))} each → ${formatLargeNumber(Math.round(profitData.gourmetBonusItems * profitData.outputPrice))}/hr`;
         gourmetContent.appendChild(gourmetLine);
 
-        const gourmetRevenue = profitData.gourmetBonusItems * profitData.priceAfterTax;
+        const gourmetRevenue = profitData.gourmetBonusItems * profitData.outputPrice;
         gourmetSection = createCollapsibleSection(
             '',
             `Gourmet Bonus: ${formatLargeNumber(Math.round(gourmetRevenue))}/hr (${formatPercentage(profitData.gourmetBonus, 1)} gourmet)`,
@@ -522,6 +546,24 @@ export async function displayProductionProfit(panel, actionHrid, dropTableSelect
 
     costsDiv.appendChild(materialCostsSection);
     costsDiv.appendChild(teaCostsSection);
+
+    // Market Tax subsection
+    const marketTaxContent = document.createElement('div');
+    const marketTaxLine = document.createElement('div');
+    marketTaxLine.style.marginLeft = '8px';
+    marketTaxLine.textContent = `• Market Tax: 2% of revenue → ${formatLargeNumber(marketTax)}/hr`;
+    marketTaxContent.appendChild(marketTaxLine);
+
+    const marketTaxSection = createCollapsibleSection(
+        '',
+        `Market Tax: ${formatLargeNumber(marketTax)}/hr (2%)`,
+        null,
+        marketTaxContent,
+        false,
+        1
+    );
+
+    costsDiv.appendChild(marketTaxSection);
 
     // Modifiers Section
     const modifiersDiv = document.createElement('div');
@@ -835,8 +877,11 @@ function buildProductionActionsBreakdown(profitData, actionsCount) {
 
     // Calculate totals
     const bonusRevenueTotal = profitData.bonusRevenue?.totalBonusRevenue || 0;
-    const totalRevenue = Math.round((profitData.itemsPerHour * profitData.priceAfterTax + profitData.gourmetBonusItems * profitData.priceAfterTax + bonusRevenueTotal) * hoursNeeded);
-    const totalCosts = Math.round((profitData.materialCostPerHour + profitData.totalTeaCostPerHour) * hoursNeeded);
+    // Use outputPrice (pre-tax) for revenue display
+    const totalRevenue = Math.round((profitData.itemsPerHour * profitData.outputPrice + profitData.gourmetBonusItems * profitData.outputPrice + bonusRevenueTotal) * hoursNeeded);
+    // Calculate market tax (2% of revenue)
+    const totalMarketTax = Math.round(totalRevenue * 0.02);
+    const totalCosts = Math.round((profitData.materialCostPerHour + profitData.totalTeaCostPerHour) * hoursNeeded + totalMarketTax);
     const totalProfit = totalRevenue - totalCosts;
 
     const detailsContent = document.createElement('div');
@@ -848,10 +893,10 @@ function buildProductionActionsBreakdown(profitData, actionsCount) {
     // Base Output subsection
     const baseOutputContent = document.createElement('div');
     const totalBaseItems = profitData.itemsPerHour * hoursNeeded;
-    const totalBaseRevenue = totalBaseItems * profitData.priceAfterTax;
+    const totalBaseRevenue = totalBaseItems * profitData.outputPrice;
     const baseOutputLine = document.createElement('div');
     baseOutputLine.style.marginLeft = '8px';
-    baseOutputLine.textContent = `• Base Output: ${totalBaseItems.toFixed(1)} items @ ${formatWithSeparator(Math.round(profitData.priceAfterTax))} each → ${formatLargeNumber(Math.round(totalBaseRevenue))}`;
+    baseOutputLine.textContent = `• Base Output: ${totalBaseItems.toFixed(1)} items @ ${formatWithSeparator(Math.round(profitData.outputPrice))} each → ${formatLargeNumber(Math.round(totalBaseRevenue))}`;
     baseOutputContent.appendChild(baseOutputLine);
 
     const baseOutputSection = createCollapsibleSection(
@@ -868,10 +913,10 @@ function buildProductionActionsBreakdown(profitData, actionsCount) {
     if (profitData.gourmetBonusItems > 0) {
         const gourmetContent = document.createElement('div');
         const totalGourmetItems = profitData.gourmetBonusItems * hoursNeeded;
-        const totalGourmetRevenue = totalGourmetItems * profitData.priceAfterTax;
+        const totalGourmetRevenue = totalGourmetItems * profitData.outputPrice;
         const gourmetLine = document.createElement('div');
         gourmetLine.style.marginLeft = '8px';
-        gourmetLine.textContent = `• Gourmet Bonus: ${totalGourmetItems.toFixed(1)} items @ ${formatWithSeparator(Math.round(profitData.priceAfterTax))} each → ${formatLargeNumber(Math.round(totalGourmetRevenue))}`;
+        gourmetLine.textContent = `• Gourmet Bonus: ${totalGourmetItems.toFixed(1)} items @ ${formatWithSeparator(Math.round(profitData.outputPrice))} each → ${formatLargeNumber(Math.round(totalGourmetRevenue))}`;
         gourmetContent.appendChild(gourmetLine);
 
         gourmetSection = createCollapsibleSection(
@@ -1017,6 +1062,24 @@ function buildProductionActionsBreakdown(profitData, actionsCount) {
 
     costsDiv.appendChild(materialCostsSection);
     costsDiv.appendChild(teaCostsSection);
+
+    // Market Tax subsection
+    const marketTaxContent = document.createElement('div');
+    const marketTaxLine = document.createElement('div');
+    marketTaxLine.style.marginLeft = '8px';
+    marketTaxLine.textContent = `• Market Tax: 2% of revenue → ${formatLargeNumber(totalMarketTax)}`;
+    marketTaxContent.appendChild(marketTaxLine);
+
+    const marketTaxSection = createCollapsibleSection(
+        '',
+        `Market Tax: ${formatLargeNumber(totalMarketTax)} (2%)`,
+        null,
+        marketTaxContent,
+        false,
+        1
+    );
+
+    costsDiv.appendChild(marketTaxSection);
 
     // Assemble breakdown
     detailsContent.appendChild(revenueDiv);

--- a/src/features/market/profit-calculator.js
+++ b/src/features/market/profit-calculator.js
@@ -297,6 +297,7 @@ class ProfitCalculator {
             totalTeaCostPerHour,      // Total tea costs per hour
             costPerItem,
             itemPrice,
+            outputPrice,              // Output price before tax (bid or ask based on mode)
             priceAfterTax,            // Output price after 2% tax (bid or ask based on mode)
             profitPerItem,
             profitPerHour,


### PR DESCRIPTION
## Summary

This PR improves the profit display by showing market tax as a separate cost item instead of reducing the displayed revenue, providing more transparent accounting.

### Changes

- **Added** `outputPrice` (pre-tax) to profit calculator return object
- **Updated** gathering profit to include both pre-tax and post-tax prices in base outputs  
- **Modified** profit display to show gross revenue (before tax) instead of net revenue
- **Added** "Market Tax" subsection in Costs showing 2% of revenue as a separate line item
- **Updated** both production and gathering profit displays for consistency
- **Applied** changes to action breakdown displays as well

### Before
```
Base Output: 1373.4/hr @ 1,176 each → 1.6M/hr
Costs: 130K/hr
```

### After
```
Revenue: 1.6M/hr
  Base Output: 1373.4/hr @ 1,200 each → 1.6M/hr

Costs: 150K/hr
  Material Costs: 100K/hr
  Drink Costs: 30K/hr
  Market Tax: 20K/hr (2%)
```

### Benefits

- **Cleaner price display**: Shows rounded pre-tax prices (e.g., 1,200 instead of 1,176)
- **Transparent accounting**: Revenue shows gross amount, tax appears as explicit cost
- **Better clarity**: Market tax is now visible alongside other costs (materials, drinks)
- **Accurate calculations**: Profit calculations remain unchanged and correct

### Testing

- ✅ Build succeeds without errors
- ✅ Changes applied to all profit display contexts (production, gathering, action breakdowns)
- ✅ Revenue and cost calculations verified to be accurate