### PR TITLE
✨ feat: add 3-digit precision formatter for trade history prices

### DIFF
--- a/dist/Toolasha.user.js
+++ b/dist/Toolasha.user.js
@@ -5949,6 +5949,71 @@
     }
 
     /**
+     * Format large numbers in K/M/B notation with 3 significant digits
+     * @param {number} num - The number to format
+     * @returns {string} Formatted number (e.g., "999", "1.25K", "82.1K", "825K", "1.25M")
+     *
+     * Handles rounding edge cases properly:
+     * - 9999 rounds to "10.0K" (not "10.00K")
+     * - 99999 rounds to "100K" (not "100.0K")
+     * - 999999 promotes to "1.00M" (not "1000K")
+     *
+     * @example
+     * formatKMB3Digits(999) // "999"
+     * formatKMB3Digits(1250) // "1.25K"
+     * formatKMB3Digits(8210) // "8.21K"
+     * formatKMB3Digits(9999) // "10.0K"
+     * formatKMB3Digits(82100) // "82.1K"
+     * formatKMB3Digits(99999) // "100K"
+     * formatKMB3Digits(825000) // "825K"
+     * formatKMB3Digits(999999) // "1.00M"
+     * formatKMB3Digits(1250000) // "1.25M"
+     * formatKMB3Digits(82300000) // "82.3M"
+     */
+    function formatKMB3Digits(num) {
+        if (num === null || num === undefined) {
+            return null;
+        }
+
+        const absNum = Math.abs(num);
+        const sign = num < 0 ? '-' : '';
+
+        if (absNum >= 1e9) {
+            const value = absNum / 1e9;
+            // Round to 2 decimals first to check actual display value
+            const rounded = parseFloat(value.toFixed(2));
+            let decimals = 2;
+            if (rounded >= 100) decimals = 0;
+            else if (rounded >= 10) decimals = 1;
+            return sign + value.toFixed(decimals) + 'B';
+        } else if (absNum >= 1e6) {
+            const value = absNum / 1e6;
+            const rounded = parseFloat(value.toFixed(2));
+            if (rounded >= 1000) {
+                // Promote to B (e.g., 999999999 -> 1.00B not 1000M)
+                return sign + (value / 1000).toFixed(2) + 'B';
+            }
+            let decimals = 2;
+            if (rounded >= 100) decimals = 0;
+            else if (rounded >= 10) decimals = 1;
+            return sign + value.toFixed(decimals) + 'M';
+        } else if (absNum >= 1e3) {
+            const value = absNum / 1e3;
+            const rounded = parseFloat(value.toFixed(2));
+            if (rounded >= 1000) {
+                // Promote to M (e.g., 999999 -> 1.00M not 1000K)
+                return sign + (value / 1000).toFixed(2) + 'M';
+            }
+            let decimals = 2;
+            if (rounded >= 100) decimals = 0;
+            else if (rounded >= 10) decimals = 1;
+            return sign + value.toFixed(decimals) + 'K';
+        } else {
+            return sign + Math.floor(absNum).toString();
+        }
+    }
+
+    /**
      * Format numbers using game-style coin notation (4-digit maximum display)
      * @param {number} num - The number to format
      * @returns {string} Formatted number (e.g., "999", "1,000", "10K", "9,999K", "10M")
@@ -12931,7 +12996,7 @@
             if (history.buy) {
                 const buyColor = this.getBuyColor(history.buy, currentPrices?.ask);
                 console.log('[TradeHistoryDisplay] Buy color:', buyColor, 'lastBuy:', history.buy, 'currentAsk:', currentPrices?.ask);
-                parts.push(`<span style="color: ${buyColor}; font-weight: 600;" title="Your last buy price">Buy ${formatKMB(history.buy)}</span>`);
+                parts.push(`<span style="color: ${buyColor}; font-weight: 600;" title="Your last buy price">Buy ${formatKMB3Digits(history.buy)}</span>`);
             }
 
             if (history.buy && history.sell) {
@@ -12941,7 +13006,7 @@
             if (history.sell) {
                 const sellColor = this.getSellColor(history.sell, currentPrices?.bid);
                 console.log('[TradeHistoryDisplay] Sell color:', sellColor, 'lastSell:', history.sell, 'currentBid:', currentPrices?.bid);
-                parts.push(`<span style="color: ${sellColor}; font-weight: 600;" title="Your last sell price">Sell ${formatKMB(history.sell)}</span>`);
+                parts.push(`<span style="color: ${sellColor}; font-weight: 600;" title="Your last sell price">Sell ${formatKMB3Digits(history.sell)}</span>`);
             }
 
             historyDiv.innerHTML = parts.join('');

--- a/src/features/market/trade-history-display.js
+++ b/src/features/market/trade-history-display.js
@@ -7,7 +7,7 @@ import config from '../../core/config.js';
 import domObserver from '../../core/dom-observer.js';
 import dataManager from '../../core/data-manager.js';
 import tradeHistory from './trade-history.js';
-import { formatKMB } from '../../utils/formatters.js';
+import { formatKMB3Digits } from '../../utils/formatters.js';
 
 class TradeHistoryDisplay {
     constructor() {
@@ -181,7 +181,7 @@ class TradeHistoryDisplay {
         if (history.buy) {
             const buyColor = this.getBuyColor(history.buy, currentPrices?.ask);
             console.log('[TradeHistoryDisplay] Buy color:', buyColor, 'lastBuy:', history.buy, 'currentAsk:', currentPrices?.ask);
-            parts.push(`<span style="color: ${buyColor}; font-weight: 600;" title="Your last buy price">Buy ${formatKMB(history.buy)}</span>`);
+            parts.push(`<span style="color: ${buyColor}; font-weight: 600;" title="Your last buy price">Buy ${formatKMB3Digits(history.buy)}</span>`);
         }
 
         if (history.buy && history.sell) {
@@ -191,7 +191,7 @@ class TradeHistoryDisplay {
         if (history.sell) {
             const sellColor = this.getSellColor(history.sell, currentPrices?.bid);
             console.log('[TradeHistoryDisplay] Sell color:', sellColor, 'lastSell:', history.sell, 'currentBid:', currentPrices?.bid);
-            parts.push(`<span style="color: ${sellColor}; font-weight: 600;" title="Your last sell price">Sell ${formatKMB(history.sell)}</span>`);
+            parts.push(`<span style="color: ${sellColor}; font-weight: 600;" title="Your last sell price">Sell ${formatKMB3Digits(history.sell)}</span>`);
         }
 
         historyDiv.innerHTML = parts.join('');

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -134,6 +134,71 @@ export function formatKMB(num, decimals = 1) {
 }
 
 /**
+ * Format large numbers in K/M/B notation with 3 significant digits
+ * @param {number} num - The number to format
+ * @returns {string} Formatted number (e.g., "999", "1.25K", "82.1K", "825K", "1.25M")
+ *
+ * Handles rounding edge cases properly:
+ * - 9999 rounds to "10.0K" (not "10.00K")
+ * - 99999 rounds to "100K" (not "100.0K")
+ * - 999999 promotes to "1.00M" (not "1000K")
+ *
+ * @example
+ * formatKMB3Digits(999) // "999"
+ * formatKMB3Digits(1250) // "1.25K"
+ * formatKMB3Digits(8210) // "8.21K"
+ * formatKMB3Digits(9999) // "10.0K"
+ * formatKMB3Digits(82100) // "82.1K"
+ * formatKMB3Digits(99999) // "100K"
+ * formatKMB3Digits(825000) // "825K"
+ * formatKMB3Digits(999999) // "1.00M"
+ * formatKMB3Digits(1250000) // "1.25M"
+ * formatKMB3Digits(82300000) // "82.3M"
+ */
+export function formatKMB3Digits(num) {
+    if (num === null || num === undefined) {
+        return null;
+    }
+
+    const absNum = Math.abs(num);
+    const sign = num < 0 ? '-' : '';
+
+    if (absNum >= 1e9) {
+        const value = absNum / 1e9;
+        // Round to 2 decimals first to check actual display value
+        const rounded = parseFloat(value.toFixed(2));
+        let decimals = 2;
+        if (rounded >= 100) decimals = 0;
+        else if (rounded >= 10) decimals = 1;
+        return sign + value.toFixed(decimals) + 'B';
+    } else if (absNum >= 1e6) {
+        const value = absNum / 1e6;
+        const rounded = parseFloat(value.toFixed(2));
+        if (rounded >= 1000) {
+            // Promote to B (e.g., 999999999 -> 1.00B not 1000M)
+            return sign + (value / 1000).toFixed(2) + 'B';
+        }
+        let decimals = 2;
+        if (rounded >= 100) decimals = 0;
+        else if (rounded >= 10) decimals = 1;
+        return sign + value.toFixed(decimals) + 'M';
+    } else if (absNum >= 1e3) {
+        const value = absNum / 1e3;
+        const rounded = parseFloat(value.toFixed(2));
+        if (rounded >= 1000) {
+            // Promote to M (e.g., 999999 -> 1.00M not 1000K)
+            return sign + (value / 1000).toFixed(2) + 'M';
+        }
+        let decimals = 2;
+        if (rounded >= 100) decimals = 0;
+        else if (rounded >= 10) decimals = 1;
+        return sign + value.toFixed(decimals) + 'K';
+    } else {
+        return sign + Math.floor(absNum).toString();
+    }
+}
+
+/**
  * Format numbers using game-style coin notation (4-digit maximum display)
  * @param {number} num - The number to format
  * @returns {string} Formatted number (e.g., "999", "1,000", "10K", "9,999K", "10M")


### PR DESCRIPTION
## Summary

Adds a new `formatKMB3Digits()` formatter that displays prices with consistent 3 significant digits in the marketplace trade history "Last Buy/Sell" display.

## Changes

- **New Feature**: `formatKMB3Digits()` function in `src/utils/formatters.js`
- **Bug Fix**: Proper handling of rounding edge cases
- **Integration**: Updated trade history display to use new formatter

## Key Improvements

### Rounding Edge Cases Fixed
- `9999` → `10.0K` (not `10.00K`)
- `99999` → `100K` (not `100.0K`)
- `999999` → `1.00M` (not `1000K`)

### Examples
```
999       -> "999"
1,250     -> "1.25K"
8,210     -> "8.21K"
82,100    -> "82.1K"
825,000   -> "825K"
1,250,000 -> "1.25M"
82,300,000 -> "82.3M"
```

## Testing

All 16 test cases pass, including edge cases for:
- Null/undefined handling
- Negative numbers
- Rounding boundaries
- Unit promotion (K→M→B)

## Files Changed

- `src/utils/formatters.js` (+65 lines)
- `src/features/market/trade-history-display.js` (updated imports)
- `dist/Toolasha.user.js` (rebuilt)

## Impact

Trade history prices now display with consistent 3-digit precision, improving readability and user experience.