### PR TITLE
🐛 fix: include efficiency multiplier in material cost line items

### DIFF
--- a/dist/Toolasha.user.js
+++ b/dist/Toolasha.user.js
@@ -14628,18 +14628,19 @@
                 line.style.marginLeft = '8px';
                 // Material structure: { itemName, amount, askPrice, totalCost, baseAmount }
                 const amountPerAction = material.amount || 0;
-                const amountPerHour = amountPerAction * profitData.actionsPerHour;
+                const efficiencyMultiplier = 1 + (profitData.efficiencyBonus / 100);
+                const amountPerHour = amountPerAction * profitData.actionsPerHour * efficiencyMultiplier;
 
                 // Build material line with embedded Artisan information
                 let materialText = `• ${material.itemName}: ${amountPerHour.toFixed(1)}/hr`;
 
                 // Add Artisan reduction info if present (only show if actually reduced)
                 if (profitData.artisanBonus > 0 && material.baseAmount && material.amount !== material.baseAmount) {
-                    const baseAmountPerHour = material.baseAmount * profitData.actionsPerHour;
+                    const baseAmountPerHour = material.baseAmount * profitData.actionsPerHour * efficiencyMultiplier;
                     materialText += ` (${baseAmountPerHour.toFixed(1)} base -${formatPercentage(profitData.artisanBonus, 1)} 🍵)`;
                 }
 
-                materialText += ` @ ${formatWithSeparator(Math.round(material.askPrice))} → ${formatLargeNumber(Math.round(material.totalCost * profitData.actionsPerHour))}/hr`;
+                materialText += ` @ ${formatWithSeparator(Math.round(material.askPrice))} → ${formatLargeNumber(Math.round(material.totalCost * profitData.actionsPerHour * efficiencyMultiplier))}/hr`;
 
                 line.textContent = materialText;
                 materialCostsContent.appendChild(line);
@@ -15117,9 +15118,10 @@
         // Material Costs subsection
         const materialCostsContent = document.createElement('div');
         if (profitData.materialCosts && profitData.materialCosts.length > 0) {
+            const efficiencyMultiplier = 1 + (profitData.efficiencyBonus / 100);
             for (const material of profitData.materialCosts) {
-                const totalMaterial = material.amount * actionsCount;
-                const totalMaterialCost = material.totalCost * actionsCount;
+                const totalMaterial = material.amount * actionsCount * efficiencyMultiplier;
+                const totalMaterialCost = material.totalCost * actionsCount * efficiencyMultiplier;
                 const line = document.createElement('div');
                 line.style.marginLeft = '8px';
 
@@ -15127,7 +15129,7 @@
 
                 // Add Artisan reduction info if present
                 if (profitData.artisanBonus > 0 && material.baseAmount && material.amount !== material.baseAmount) {
-                    const baseTotalAmount = material.baseAmount * actionsCount;
+                    const baseTotalAmount = material.baseAmount * actionsCount * efficiencyMultiplier;
                     materialText += ` (${baseTotalAmount.toFixed(1)} base -${formatPercentage(profitData.artisanBonus, 1)} 🍵)`;
                 }
 

--- a/src/features/actions/profit-display.js
+++ b/src/features/actions/profit-display.js
@@ -471,18 +471,19 @@ export async function displayProductionProfit(panel, actionHrid, dropTableSelect
             line.style.marginLeft = '8px';
             // Material structure: { itemName, amount, askPrice, totalCost, baseAmount }
             const amountPerAction = material.amount || 0;
-            const amountPerHour = amountPerAction * profitData.actionsPerHour;
+            const efficiencyMultiplier = 1 + (profitData.efficiencyBonus / 100);
+            const amountPerHour = amountPerAction * profitData.actionsPerHour * efficiencyMultiplier;
 
             // Build material line with embedded Artisan information
             let materialText = `• ${material.itemName}: ${amountPerHour.toFixed(1)}/hr`;
 
             // Add Artisan reduction info if present (only show if actually reduced)
             if (profitData.artisanBonus > 0 && material.baseAmount && material.amount !== material.baseAmount) {
-                const baseAmountPerHour = material.baseAmount * profitData.actionsPerHour;
+                const baseAmountPerHour = material.baseAmount * profitData.actionsPerHour * efficiencyMultiplier;
                 materialText += ` (${baseAmountPerHour.toFixed(1)} base -${formatPercentage(profitData.artisanBonus, 1)} 🍵)`;
             }
 
-            materialText += ` @ ${formatWithSeparator(Math.round(material.askPrice))} → ${formatLargeNumber(Math.round(material.totalCost * profitData.actionsPerHour))}/hr`;
+            materialText += ` @ ${formatWithSeparator(Math.round(material.askPrice))} → ${formatLargeNumber(Math.round(material.totalCost * profitData.actionsPerHour * efficiencyMultiplier))}/hr`;
 
             line.textContent = materialText;
             materialCostsContent.appendChild(line);
@@ -960,9 +961,10 @@ function buildProductionActionsBreakdown(profitData, actionsCount) {
     // Material Costs subsection
     const materialCostsContent = document.createElement('div');
     if (profitData.materialCosts && profitData.materialCosts.length > 0) {
+        const efficiencyMultiplier = 1 + (profitData.efficiencyBonus / 100);
         for (const material of profitData.materialCosts) {
-            const totalMaterial = material.amount * actionsCount;
-            const totalMaterialCost = material.totalCost * actionsCount;
+            const totalMaterial = material.amount * actionsCount * efficiencyMultiplier;
+            const totalMaterialCost = material.totalCost * actionsCount * efficiencyMultiplier;
             const line = document.createElement('div');
             line.style.marginLeft = '8px';
 
@@ -970,7 +972,7 @@ function buildProductionActionsBreakdown(profitData, actionsCount) {
 
             // Add Artisan reduction info if present
             if (profitData.artisanBonus > 0 && material.baseAmount && material.amount !== material.baseAmount) {
-                const baseTotalAmount = material.baseAmount * actionsCount;
+                const baseTotalAmount = material.baseAmount * actionsCount * efficiencyMultiplier;
                 materialText += ` (${baseTotalAmount.toFixed(1)} base -${formatPercentage(profitData.artisanBonus, 1)} 🍵)`;
             }
 


### PR DESCRIPTION
## Summary

Fixes a bug where material cost line items in the profit display did not include the efficiency multiplier, causing them to not add up to the displayed total.

## Problem

- Material cost **line items** calculated: `material.totalCost * actionsPerHour` (no efficiency)
- Material cost **total** used: `profitData.materialCostPerHour` (includes efficiency)
- With high efficiency (e.g., 109.2%), line items showed ~302.6K but total showed ~710.5K

## Solution

Added efficiency multiplier to material cost line item calculations:
- Per-hour section: multiply by `(1 + efficiencyBonus / 100)`
- Total section: multiply by `(1 + efficiencyBonus / 100)`

Now line items correctly add up to the displayed total.

## Changes

- `src/features/actions/profit-display.js`: Added efficiency multiplier to material cost calculations in both per-hour and total breakdowns
- `dist/Toolasha.user.js`: Built output with the fix

## Testing

With 109.2% efficiency:
- Before: Line items showed 302.6K, total showed 710.5K ❌
- After: Line items show 632.6K, total shows 710.5K (632.6K materials + 40.2K tea + 37.3K tax) ✅

## Notes

This bug existed from the original creation of `profit-display.js` - not related to recent market tax feature.