### PR TITLE
🐛 fix: correct efficiency calculation in actions breakdown

### DIFF
--- a/dist/Toolasha.user.js
+++ b/dist/Toolasha.user.js
@@ -14828,7 +14828,10 @@
      * @returns {HTMLElement} Breakdown section element
      */
     function buildGatheringActionsBreakdown(profitData, actionsCount) {
-        const hoursNeeded = actionsCount / profitData.actionsPerHour;
+        // Calculate actual attempts needed (input is desired output actions)
+        const efficiencyMultiplier = 1 + (profitData.totalEfficiency / 100);
+        const actualAttempts = Math.ceil(actionsCount / efficiencyMultiplier);
+        const hoursNeeded = actualAttempts / profitData.actionsPerHour;
 
         // Calculate totals
         const totalRevenue = Math.round(profitData.revenuePerHour * hoursNeeded);
@@ -15011,7 +15014,10 @@
      * @returns {HTMLElement} Breakdown section element
      */
     function buildProductionActionsBreakdown(profitData, actionsCount) {
-        const hoursNeeded = actionsCount / profitData.actionsPerHour;
+        // Calculate actual attempts needed (input is desired output actions)
+        const efficiencyMultiplier = 1 + (profitData.efficiencyBonus / 100);
+        const actualAttempts = Math.ceil(actionsCount / efficiencyMultiplier);
+        const hoursNeeded = actualAttempts / profitData.actionsPerHour;
 
         // Calculate totals
         const bonusRevenueTotal = profitData.bonusRevenue?.totalBonusRevenue || 0;

--- a/src/features/actions/profit-display.js
+++ b/src/features/actions/profit-display.js
@@ -648,7 +648,10 @@ export async function displayProductionProfit(panel, actionHrid, dropTableSelect
  * @returns {HTMLElement} Breakdown section element
  */
 function buildGatheringActionsBreakdown(profitData, actionsCount) {
-    const hoursNeeded = actionsCount / profitData.actionsPerHour;
+    // Calculate actual attempts needed (input is desired output actions)
+    const efficiencyMultiplier = 1 + (profitData.totalEfficiency / 100);
+    const actualAttempts = Math.ceil(actionsCount / efficiencyMultiplier);
+    const hoursNeeded = actualAttempts / profitData.actionsPerHour;
 
     // Calculate totals
     const totalRevenue = Math.round(profitData.revenuePerHour * hoursNeeded);
@@ -831,7 +834,10 @@ function buildGatheringActionsBreakdown(profitData, actionsCount) {
  * @returns {HTMLElement} Breakdown section element
  */
 function buildProductionActionsBreakdown(profitData, actionsCount) {
-    const hoursNeeded = actionsCount / profitData.actionsPerHour;
+    // Calculate actual attempts needed (input is desired output actions)
+    const efficiencyMultiplier = 1 + (profitData.efficiencyBonus / 100);
+    const actualAttempts = Math.ceil(actionsCount / efficiencyMultiplier);
+    const hoursNeeded = actualAttempts / profitData.actionsPerHour;
 
     // Calculate totals
     const bonusRevenueTotal = profitData.bonusRevenue?.totalBonusRevenue || 0;


### PR DESCRIPTION
## Summary
Fixes incorrect item calculations in the profitability actions breakdown section.

## Problem
The "X actions breakdown" was showing ~1.89x more items than expected because it wasn't properly accounting for efficiency multiplier when converting the input value to time duration.

**Example:**
- Per hour: Base 1405.7/hr, Gourmet 168.7/hr
- 5555 actions over 3h 57m 11s (3.953 hours)
- Expected: 1405.7 × 3.953 = 5,556 items
- Actual (before fix): 10,510 items ❌
- Actual (after fix): 5,556 items ✅

## Root Cause
There was a semantic mismatch between how different sections interpreted the input:
- **Action Speed & Time section**: Treats input as "desired output actions" (includes efficiency bonus) and divides by efficiency to calculate actual attempts
- **Profitability breakdown**: Was treating input as "actual attempts" without accounting for efficiency

## Changes
Updated both `buildProductionActionsBreakdown` and `buildGatheringActionsBreakdown` functions to:
1. Calculate actual attempts needed: `actualAttempts = Math.ceil(actionsCount / efficiencyMultiplier)`
2. Use actual attempts for time calculation: `hoursNeeded = actualAttempts / actionsPerHour`

This makes the profitability breakdown consistent with the Action Speed & Time section's interpretation.

## Testing
- Verified calculations now match between per-hour breakdown and X actions breakdown
- Tested with production actions (cooking, brewing, etc.)
- Tested with gathering actions (foraging, woodcutting, milking)

## Files Changed
- `src/features/actions/profit-display.js` - Fixed hoursNeeded calculation in both breakdown functions
- `dist/Toolasha.user.js` - Rebuilt userscript