### PR TITLE
🐛 fix: remove intermediate rounding in time-based queue buttons

### DIFF
--- a/dist/Toolasha.user.js
+++ b/dist/Toolasha.user.js
@@ -18029,7 +18029,7 @@
                             // Queue count (outputs) = Actual attempts × efficiencyMultiplier
                             // Round to whole number (input doesn't accept decimals)
                             const totalSeconds = hours * 60 * 60;
-                            const actualAttempts = Math.round(totalSeconds / actionTime);
+                            const actualAttempts = totalSeconds / actionTime;
                             const actionCount = Math.round(actualAttempts * efficiencyMultiplier);
                             this.setInputValue(numberInput, actionCount);
                         });

--- a/src/features/actions/quick-input-buttons.js
+++ b/src/features/actions/quick-input-buttons.js
@@ -426,7 +426,7 @@ class QuickInputButtons {
                         // Queue count (outputs) = Actual attempts × efficiencyMultiplier
                         // Round to whole number (input doesn't accept decimals)
                         const totalSeconds = hours * 60 * 60;
-                        const actualAttempts = Math.round(totalSeconds / actionTime);
+                        const actualAttempts = totalSeconds / actionTime;
                         const actionCount = Math.round(actualAttempts * efficiencyMultiplier);
                         this.setInputValue(numberInput, actionCount);
                     });


### PR DESCRIPTION
## Summary

Fixes a rounding mismatch where clicking time-based queue buttons (e.g., "1 hour") would queue a different number of actions than displayed in the actions/hr rate.

## Problem

- Display calculation: `Math.round((3600 / actionTime) * efficiencyMultiplier)` → shows 1980/hr
- Button calculation: `Math.round(3600 / actionTime) * efficiencyMultiplier` → queues 1981 actions
- The intermediate `Math.round()` caused the off-by-one error

## Solution

Remove the intermediate rounding on line 429, keeping only the final round:
```javascript
// Before:
const actualAttempts = Math.round(totalSeconds / actionTime);
const actionCount = Math.round(actualAttempts * efficiencyMultiplier);

// After:
const actualAttempts = totalSeconds / actionTime;
const actionCount = Math.round(actualAttempts * efficiencyMultiplier);
```

Now both calculations follow the same pattern and produce matching results.

## Testing

- Build succeeds
- Time-based buttons now queue the exact number shown in the actions/hr display
- No impact on other calculations (isolated fix)