### PR TITLE
✨ feat: add total profit display to profitability summary

### DIFF
--- a/dist/Toolasha.user.js
+++ b/dist/Toolasha.user.js
@@ -14315,7 +14315,7 @@
         const marketTax = Math.round(grossRevenue * 0.02);
         const revenue = grossRevenue;
         const costs = Math.round(profitData.drinkCostPerHour + marketTax);
-        const summary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day`;
+        const summary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day | Total profit: 0`;
 
         // ===== Build Detailed Breakdown Content =====
         const detailsContent = document.createElement('div');
@@ -14579,6 +14579,38 @@
         );
         profitSection.id = 'mwi-foraging-profit';
 
+        // Get the summary div to update it dynamically
+        const profitSummaryDiv = profitSection.querySelector('.mwi-section-header + div');
+
+        // Set up listener to update summary with total profit when input changes
+        if (inputField && profitSummaryDiv) {
+            const baseSummary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day`;
+            
+            const updateSummary = (newValue) => {
+                const inputValue = inputField.value;
+                
+                if (inputValue === '∞') {
+                    profitSummaryDiv.textContent = `${baseSummary} | Total profit: ∞`;
+                } else if (newValue > 0) {
+                    // Calculate total profit for selected actions
+                    const efficiencyMultiplier = 1 + (profitData.totalEfficiency / 100);
+                    const actualAttempts = Math.ceil(newValue / efficiencyMultiplier);
+                    const hoursNeeded = actualAttempts / profitData.actionsPerHour;
+                    const totalProfit = Math.round((profitData.profitPerHour) * hoursNeeded);
+                    profitSummaryDiv.textContent = `${baseSummary} | Total profit: ${formatLargeNumber(totalProfit)}`;
+                } else {
+                    profitSummaryDiv.textContent = `${baseSummary} | Total profit: 0`;
+                }
+            };
+
+            // Update summary initially
+            const initialValue = parseInt(inputField.value) || 0;
+            updateSummary(initialValue);
+
+            // Attach listener for future changes
+            attachInputListeners(panel, inputField, updateSummary);
+        }
+
         // Find insertion point - look for existing collapsible sections or drop table
         let insertionPoint = panel.querySelector('.mwi-collapsible-section');
         if (insertionPoint) {
@@ -14644,7 +14676,7 @@
         // Calculate market tax (2% of revenue)
         const marketTax = Math.round(revenue * 0.02);
         const costs = Math.round(profitData.materialCostPerHour + profitData.totalTeaCostPerHour + marketTax);
-        const summary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day`;
+        const summary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day | Total profit: 0`;
 
         // ===== Build Detailed Breakdown Content =====
         const detailsContent = document.createElement('div');
@@ -14962,6 +14994,38 @@
             0
         );
         profitSection.id = 'mwi-production-profit';
+
+        // Get the summary div to update it dynamically
+        const profitSummaryDiv = profitSection.querySelector('.mwi-section-header + div');
+
+        // Set up listener to update summary with total profit when input changes
+        if (inputField && profitSummaryDiv) {
+            const baseSummary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day`;
+            
+            const updateSummary = (newValue) => {
+                const inputValue = inputField.value;
+                
+                if (inputValue === '∞') {
+                    profitSummaryDiv.textContent = `${baseSummary} | Total profit: ∞`;
+                } else if (newValue > 0) {
+                    // Calculate total profit for selected actions
+                    const efficiencyMultiplier = 1 + (profitData.efficiencyBonus / 100);
+                    const actualAttempts = Math.ceil(newValue / efficiencyMultiplier);
+                    const hoursNeeded = actualAttempts / profitData.actionsPerHour;
+                    const totalProfit = Math.round((profitData.profitPerHour) * hoursNeeded);
+                    profitSummaryDiv.textContent = `${baseSummary} | Total profit: ${formatLargeNumber(totalProfit)}`;
+                } else {
+                    profitSummaryDiv.textContent = `${baseSummary} | Total profit: 0`;
+                }
+            };
+
+            // Update summary initially
+            const initialValue = parseInt(inputField.value) || 0;
+            updateSummary(initialValue);
+
+            // Attach listener for future changes
+            attachInputListeners(panel, inputField, updateSummary);
+        }
 
         // Find insertion point - look for existing collapsible sections or drop table
         let insertionPoint = panel.querySelector('.mwi-collapsible-section');

--- a/src/features/actions/profit-display.js
+++ b/src/features/actions/profit-display.js
@@ -41,7 +41,7 @@ export async function displayGatheringProfit(panel, actionHrid, dropTableSelecto
     const marketTax = Math.round(grossRevenue * 0.02);
     const revenue = grossRevenue;
     const costs = Math.round(profitData.drinkCostPerHour + marketTax);
-    const summary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day`;
+    const summary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day | Total profit: 0`;
 
     // ===== Build Detailed Breakdown Content =====
     const detailsContent = document.createElement('div');
@@ -305,6 +305,38 @@ export async function displayGatheringProfit(panel, actionHrid, dropTableSelecto
     );
     profitSection.id = 'mwi-foraging-profit';
 
+    // Get the summary div to update it dynamically
+    const profitSummaryDiv = profitSection.querySelector('.mwi-section-header + div');
+
+    // Set up listener to update summary with total profit when input changes
+    if (inputField && profitSummaryDiv) {
+        const baseSummary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day`;
+        
+        const updateSummary = (newValue) => {
+            const inputValue = inputField.value;
+            
+            if (inputValue === '∞') {
+                profitSummaryDiv.textContent = `${baseSummary} | Total profit: ∞`;
+            } else if (newValue > 0) {
+                // Calculate total profit for selected actions
+                const efficiencyMultiplier = 1 + (profitData.totalEfficiency / 100);
+                const actualAttempts = Math.ceil(newValue / efficiencyMultiplier);
+                const hoursNeeded = actualAttempts / profitData.actionsPerHour;
+                const totalProfit = Math.round((profitData.profitPerHour) * hoursNeeded);
+                profitSummaryDiv.textContent = `${baseSummary} | Total profit: ${formatLargeNumber(totalProfit)}`;
+            } else {
+                profitSummaryDiv.textContent = `${baseSummary} | Total profit: 0`;
+            }
+        };
+
+        // Update summary initially
+        const initialValue = parseInt(inputField.value) || 0;
+        updateSummary(initialValue);
+
+        // Attach listener for future changes
+        attachInputListeners(panel, inputField, updateSummary);
+    }
+
     // Find insertion point - look for existing collapsible sections or drop table
     let insertionPoint = panel.querySelector('.mwi-collapsible-section');
     if (insertionPoint) {
@@ -370,7 +402,7 @@ export async function displayProductionProfit(panel, actionHrid, dropTableSelect
     // Calculate market tax (2% of revenue)
     const marketTax = Math.round(revenue * 0.02);
     const costs = Math.round(profitData.materialCostPerHour + profitData.totalTeaCostPerHour + marketTax);
-    const summary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day`;
+    const summary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day | Total profit: 0`;
 
     // ===== Build Detailed Breakdown Content =====
     const detailsContent = document.createElement('div');
@@ -688,6 +720,38 @@ export async function displayProductionProfit(panel, actionHrid, dropTableSelect
         0
     );
     profitSection.id = 'mwi-production-profit';
+
+    // Get the summary div to update it dynamically
+    const profitSummaryDiv = profitSection.querySelector('.mwi-section-header + div');
+
+    // Set up listener to update summary with total profit when input changes
+    if (inputField && profitSummaryDiv) {
+        const baseSummary = `${formatLargeNumber(profit)}/hr, ${formatLargeNumber(profitPerDay)}/day`;
+        
+        const updateSummary = (newValue) => {
+            const inputValue = inputField.value;
+            
+            if (inputValue === '∞') {
+                profitSummaryDiv.textContent = `${baseSummary} | Total profit: ∞`;
+            } else if (newValue > 0) {
+                // Calculate total profit for selected actions
+                const efficiencyMultiplier = 1 + (profitData.efficiencyBonus / 100);
+                const actualAttempts = Math.ceil(newValue / efficiencyMultiplier);
+                const hoursNeeded = actualAttempts / profitData.actionsPerHour;
+                const totalProfit = Math.round((profitData.profitPerHour) * hoursNeeded);
+                profitSummaryDiv.textContent = `${baseSummary} | Total profit: ${formatLargeNumber(totalProfit)}`;
+            } else {
+                profitSummaryDiv.textContent = `${baseSummary} | Total profit: 0`;
+            }
+        };
+
+        // Update summary initially
+        const initialValue = parseInt(inputField.value) || 0;
+        updateSummary(initialValue);
+
+        // Attach listener for future changes
+        attachInputListeners(panel, inputField, updateSummary);
+    }
 
     // Find insertion point - look for existing collapsible sections or drop table
     let insertionPoint = panel.querySelector('.mwi-collapsible-section');


### PR DESCRIPTION
## Summary

Adds dynamic total profit display to the profitability summary line, matching the pattern used by the Action Speed & Time section.

## Changes

- Updated profitability display to always show total profit in summary
- Format: `X/hr, Y/day | Total profit: Z`
- Dynamically updates based on action input value
- Handles three states:
  - No actions selected: `Total profit: 0`
  - Actions selected: `Total profit: 4.7M` (calculated value)
  - Infinity selected: `Total profit: ∞`

## Pattern Matching

Now matches the Action Speed & Time display:
- **Action Speed:** `1406/hr | Total time: 3h 57m 11s`
- **Profitability:** `1.2M/hr, 28.4M/day | Total profit: 4.7M`

## Files Modified

- `src/features/actions/profit-display.js` - Added dynamic summary updates for both gathering and production profit displays
- `dist/Toolasha.user.js` - Built output

## Testing

Tested with:
- Empty/0 input → Shows "Total profit: 0"
- Numeric input (e.g., 100) → Shows calculated total profit
- Infinity (∞) input → Shows "Total profit: ∞"

Applied to both gathering actions (Foraging, Woodcutting, Milking) and production actions (Brewing, Cooking, Crafting, Tailoring, Cheesesmithing).