### PR TITLE
🐛 fix: correct efficiency double-counting in action queue profit calculations

### DIFF
--- a/dist/Toolasha.user.js
+++ b/dist/Toolasha.user.js
@@ -14433,7 +14433,7 @@
         const baseOutputContent = document.createElement('div');
         if (profitData.baseOutputs && profitData.baseOutputs.length > 0) {
             for (const output of profitData.baseOutputs) {
-                const totalItems = (output.itemsPerHour / profitData.actionsPerHour) * actionsCount;
+                const totalItems = output.itemsPerHour * hoursNeeded;
                 const totalRevenueLine = output.revenuePerHour * hoursNeeded;
                 const line = document.createElement('div');
                 line.style.marginLeft = '8px';
@@ -14741,10 +14741,9 @@
         // Material Costs subsection
         const materialCostsContent = document.createElement('div');
         if (profitData.materialCosts && profitData.materialCosts.length > 0) {
-            const efficiencyMultiplier = 1 + profitData.efficiencyBonus / 100;
             for (const material of profitData.materialCosts) {
-                const totalMaterial = material.amount * actionsCount * efficiencyMultiplier;
-                const totalMaterialCost = material.totalCost * actionsCount * efficiencyMultiplier;
+                const totalMaterial = material.amount * actionsCount;
+                const totalMaterialCost = material.totalCost * actionsCount;
                 const line = document.createElement('div');
                 line.style.marginLeft = '8px';
 
@@ -14752,7 +14751,7 @@
 
                 // Add Artisan reduction info if present
                 if (profitData.artisanBonus > 0 && material.baseAmount && material.amount !== material.baseAmount) {
-                    const baseTotalAmount = material.baseAmount * actionsCount * efficiencyMultiplier;
+                    const baseTotalAmount = material.baseAmount * actionsCount;
                     materialText += ` (${baseTotalAmount.toFixed(1)} base -${formatPercentage(profitData.artisanBonus, 1)} 🍵)`;
                 }
 

--- a/src/features/actions/profit-display.js
+++ b/src/features/actions/profit-display.js
@@ -820,7 +820,7 @@ function buildGatheringActionsBreakdown(profitData, actionsCount) {
     const baseOutputContent = document.createElement('div');
     if (profitData.baseOutputs && profitData.baseOutputs.length > 0) {
         for (const output of profitData.baseOutputs) {
-            const totalItems = (output.itemsPerHour / profitData.actionsPerHour) * actionsCount;
+            const totalItems = output.itemsPerHour * hoursNeeded;
             const totalRevenueLine = output.revenuePerHour * hoursNeeded;
             const line = document.createElement('div');
             line.style.marginLeft = '8px';
@@ -1128,10 +1128,9 @@ function buildProductionActionsBreakdown(profitData, actionsCount) {
     // Material Costs subsection
     const materialCostsContent = document.createElement('div');
     if (profitData.materialCosts && profitData.materialCosts.length > 0) {
-        const efficiencyMultiplier = 1 + profitData.efficiencyBonus / 100;
         for (const material of profitData.materialCosts) {
-            const totalMaterial = material.amount * actionsCount * efficiencyMultiplier;
-            const totalMaterialCost = material.totalCost * actionsCount * efficiencyMultiplier;
+            const totalMaterial = material.amount * actionsCount;
+            const totalMaterialCost = material.totalCost * actionsCount;
             const line = document.createElement('div');
             line.style.marginLeft = '8px';
 
@@ -1139,7 +1138,7 @@ function buildProductionActionsBreakdown(profitData, actionsCount) {
 
             // Add Artisan reduction info if present
             if (profitData.artisanBonus > 0 && material.baseAmount && material.amount !== material.baseAmount) {
-                const baseTotalAmount = material.baseAmount * actionsCount * efficiencyMultiplier;
+                const baseTotalAmount = material.baseAmount * actionsCount;
                 materialText += ` (${baseTotalAmount.toFixed(1)} base -${formatPercentage(profitData.artisanBonus, 1)} 🍵)`;
             }
 


### PR DESCRIPTION
#### Current Behavior
The action queue profit calculator was incorrectly multiplying material costs and item counts by the efficiency multiplier in the breakdown display. This caused the "X actions breakdown" section to show inflated material costs that didn't match the summary totals.

The bug was introduced in commit `aba663a` (Jan 23, 2026) which attempted to fix efficiency handling but incorrectly applied the multiplier to both the per-hour display (correct) and the X actions breakdown (incorrect).

Issue: N/A

#### Changes
- **Gathering breakdown (line 823)**: Changed item calculation from `(output.itemsPerHour / profitData.actionsPerHour) * actionsCount` to `output.itemsPerHour * hoursNeeded`
- **Production breakdown (lines 1132-1142)**: Removed `* efficiencyMultiplier` from material cost calculations
  - `material.amount * actionsCount` (was `* actionsCount * efficiencyMultiplier`)
  - `material.totalCost * actionsCount` (was `* actionsCount * efficiencyMultiplier`)
  - `material.baseAmount * actionsCount` (was `* actionsCount * efficiencyMultiplier`)
- Calculations now correctly align with the profit calculator's per-hour rates where efficiency is already baked into `itemsPerHour` and `materialCostPerHour`

#### Breaking Changes
None