### PR TITLE
♻️ refactor: consolidate profit calculations into shared helpers

### DIFF
--- a/src/features/actions/production-profit.js
+++ b/src/features/actions/production-profit.js
@@ -76,7 +76,7 @@ export function formatProfitDisplay(profitData) {
         ),
         costs: Math.round(profitData.materialCostPerHour + profitData.totalTeaCostPerHour),
         actionsPerHour: profitData.actionsPerHour,
-        totalEfficiency: profitData.efficiencyBonus,
+        totalEfficiency: profitData.totalEfficiency,
 
         // Output details
         baseOutputItems: profitData.itemsPerHour,

--- a/src/features/tasks/task-profit-calculator.js
+++ b/src/features/tasks/task-profit-calculator.js
@@ -191,8 +191,8 @@ async function calculateGatheringTaskProfit(actionHrid, quantity) {
         };
     }
 
-    // Calculate per-action profit from per-hour profit
-    const profitPerAction = profitData.profitPerHour / profitData.actionsPerHour;
+    // Use pre-calculated profitPerAction from profit calculator
+    const profitPerAction = profitData.profitPerAction;
 
     return {
         totalValue: profitPerAction * quantity,
@@ -240,8 +240,10 @@ async function calculateProductionTaskProfit(actionHrid, quantity) {
         };
     }
 
-    // Calculate per-action values from per-hour values
-    const profitPerAction = profitData.profitPerHour / profitData.actionsPerHour;
+    // Use pre-calculated profitPerAction from profit calculator
+    const profitPerAction = profitData.profitPerAction;
+
+    // Calculate per-action values for breakdown display
     const revenuePerAction =
         (profitData.itemsPerHour * profitData.priceAfterTax + profitData.gourmetBonusItems * profitData.priceAfterTax) /
         profitData.actionsPerHour;
@@ -267,7 +269,7 @@ async function calculateProductionTaskProfit(actionHrid, quantity) {
             actionsPerHour: profitData.actionsPerHour,
             itemsPerAction: profitData.itemsPerHour / profitData.actionsPerHour,
             bonusRevenue: profitData.bonusRevenue, // Pass through bonus revenue data
-            efficiencyMultiplier: profitData.details?.efficiencyMultiplier || 1, // Pass through efficiency multiplier
+            efficiencyMultiplier: profitData.efficiencyMultiplier || 1, // Pass through efficiency multiplier
         },
     };
 }

--- a/src/features/tasks/task-profit-display.js
+++ b/src/features/tasks/task-profit-display.js
@@ -8,9 +8,10 @@ import config from '../../core/config.js';
 import dataManager from '../../core/data-manager.js';
 import domObserver from '../../core/dom-observer.js';
 import webSocketHook from '../../core/websocket.js';
-import { numberFormatter, timeReadable, formatPercentage } from '../../utils/formatters.js';
 import { calculateTaskProfit } from './task-profit-calculator.js';
+import { numberFormatter, timeReadable, formatPercentage } from '../../utils/formatters.js';
 import { GAME, TOOLASHA } from '../../utils/selectors.js';
+import { calculateSecondsForActions } from '../../utils/profit-helpers.js';
 
 // Compiled regex pattern (created once, reused for performance)
 const REGEX_TASK_PROGRESS = /(\d+)\s*\/\s*(\d+)/;
@@ -408,7 +409,7 @@ class TaskProfitDisplay {
 
             // Efficiency reduces the number of actions needed
             const actualActionsNeeded = remainingActions / efficiencyMultiplier;
-            const totalSeconds = (actualActionsNeeded / actionsPerHour) * 3600;
+            const totalSeconds = calculateSecondsForActions(actualActionsNeeded, actionsPerHour);
             timeEstimate = timeReadable(totalSeconds);
         }
 

--- a/src/utils/profit-constants.js
+++ b/src/utils/profit-constants.js
@@ -1,0 +1,57 @@
+/**
+ * Profit Calculation Constants
+ * Shared constants used across profit calculators
+ */
+
+/**
+ * Marketplace tax rate (2%)
+ */
+export const MARKET_TAX = 0.02;
+
+/**
+ * Base drink consumption rate per hour (before Drink Concentration)
+ */
+export const DRINKS_PER_HOUR_BASE = 12;
+
+/**
+ * Seconds per hour (for rate conversions)
+ */
+export const SECONDS_PER_HOUR = 3600;
+
+/**
+ * Hours per day (for daily profit calculations)
+ */
+export const HOURS_PER_DAY = 24;
+
+/**
+ * Gathering skill action types
+ * Skills that gather raw materials from the world
+ */
+export const GATHERING_TYPES = ['/action_types/foraging', '/action_types/woodcutting', '/action_types/milking'];
+
+/**
+ * Production skill action types
+ * Skills that craft items from materials
+ */
+export const PRODUCTION_TYPES = [
+    '/action_types/brewing',
+    '/action_types/cooking',
+    '/action_types/cheesesmithing',
+    '/action_types/crafting',
+    '/action_types/tailoring',
+];
+
+/**
+ * All non-combat skill action types
+ */
+export const ALL_SKILL_TYPES = [...GATHERING_TYPES, ...PRODUCTION_TYPES];
+
+export default {
+    MARKET_TAX,
+    DRINKS_PER_HOUR_BASE,
+    SECONDS_PER_HOUR,
+    HOURS_PER_DAY,
+    GATHERING_TYPES,
+    PRODUCTION_TYPES,
+    ALL_SKILL_TYPES,
+};

--- a/src/utils/profit-helpers.js
+++ b/src/utils/profit-helpers.js
@@ -1,0 +1,240 @@
+/**
+ * Profit Calculation Helpers
+ * Pure functions for profit/rate calculations used across features
+ *
+ * These functions consolidate duplicated calculations from:
+ * - profit-calculator.js
+ * - gathering-profit.js
+ * - task-profit-calculator.js
+ * - action-time-display.js
+ * - tooltip-prices.js
+ */
+
+import { SECONDS_PER_HOUR, HOURS_PER_DAY, DRINKS_PER_HOUR_BASE, MARKET_TAX } from './profit-constants.js';
+
+// ============ Rate Conversions ============
+
+/**
+ * Calculate actions per hour from action time
+ * @param {number} actionTimeSeconds - Time per action in seconds
+ * @returns {number} Actions per hour (0 if invalid input)
+ *
+ * @example
+ * calculateActionsPerHour(6) // Returns 600 (3600 / 6)
+ * calculateActionsPerHour(0) // Returns 0 (invalid)
+ */
+export function calculateActionsPerHour(actionTimeSeconds) {
+    if (!actionTimeSeconds || actionTimeSeconds <= 0) {
+        return 0;
+    }
+    return SECONDS_PER_HOUR / actionTimeSeconds;
+}
+
+/**
+ * Calculate hours needed for a number of actions
+ * @param {number} actionCount - Number of actions/attempts
+ * @param {number} actionsPerHour - Actions per hour rate
+ * @returns {number} Hours needed (0 if invalid input)
+ *
+ * @example
+ * calculateHoursForActions(600, 600) // Returns 1
+ * calculateHoursForActions(1200, 600) // Returns 2
+ */
+export function calculateHoursForActions(actionCount, actionsPerHour) {
+    if (!actionsPerHour || actionsPerHour <= 0) {
+        return 0;
+    }
+    return actionCount / actionsPerHour;
+}
+
+/**
+ * Calculate seconds needed for a number of actions
+ * @param {number} actionCount - Number of actions/attempts
+ * @param {number} actionsPerHour - Actions per hour rate
+ * @returns {number} Seconds needed (0 if invalid input)
+ *
+ * @example
+ * calculateSecondsForActions(100, 600) // Returns 600 (100/600 * 3600)
+ */
+export function calculateSecondsForActions(actionCount, actionsPerHour) {
+    return calculateHoursForActions(actionCount, actionsPerHour) * SECONDS_PER_HOUR;
+}
+
+// ============ Efficiency Calculations ============
+
+/**
+ * Calculate efficiency multiplier from efficiency percentage
+ * Efficiency gives bonus action completions per attempt
+ *
+ * @param {number} efficiencyPercent - Efficiency as percentage (e.g., 150 for 150%)
+ * @returns {number} Multiplier (e.g., 2.5 for 150% efficiency)
+ *
+ * @example
+ * calculateEfficiencyMultiplier(0)   // Returns 1.0 (no bonus)
+ * calculateEfficiencyMultiplier(50)  // Returns 1.5
+ * calculateEfficiencyMultiplier(150) // Returns 2.5
+ */
+export function calculateEfficiencyMultiplier(efficiencyPercent) {
+    return 1 + (efficiencyPercent || 0) / 100;
+}
+
+// ============ Profit Calculations ============
+
+/**
+ * Calculate profit per action from hourly profit data
+ *
+ * IMPORTANT: This assumes profitPerHour already includes efficiency.
+ * The formula works because:
+ * - profitPerHour = actionsPerHour × efficiencyMultiplier × profitPerItem
+ * - profitPerHour / actionsPerHour = efficiencyMultiplier × profitPerItem
+ * - This gives profit per ATTEMPT (what the queue shows)
+ *
+ * @param {number} profitPerHour - Profit per hour (includes efficiency)
+ * @param {number} actionsPerHour - Base actions per hour (without efficiency)
+ * @returns {number} Profit per action/attempt (0 if invalid input)
+ *
+ * @example
+ * // With 150% efficiency (2.5x), 600 actions/hr, 50 profit/item:
+ * // profitPerHour = 600 × 2.5 × 50 = 75,000
+ * calculateProfitPerAction(75000, 600) // Returns 125 (profit per attempt)
+ */
+export function calculateProfitPerAction(profitPerHour, actionsPerHour) {
+    if (!actionsPerHour || actionsPerHour <= 0) {
+        return 0;
+    }
+    return profitPerHour / actionsPerHour;
+}
+
+/**
+ * Calculate total profit for a number of actions/attempts
+ *
+ * @param {number} profitPerHour - Profit per hour (includes efficiency)
+ * @param {number} actionsPerHour - Base actions per hour (without efficiency)
+ * @param {number} actionCount - Number of actions/attempts
+ * @returns {number} Total profit (0 if invalid input)
+ *
+ * @example
+ * // Queue shows "Produce 100 times" with 75,000 profit/hr and 600 actions/hr
+ * calculateTotalProfitForActions(75000, 600, 100) // Returns 12,500
+ */
+export function calculateTotalProfitForActions(profitPerHour, actionsPerHour, actionCount) {
+    const profitPerAction = calculateProfitPerAction(profitPerHour, actionsPerHour);
+    return profitPerAction * actionCount;
+}
+
+/**
+ * Calculate profit per day from hourly profit
+ * @param {number} profitPerHour - Profit per hour
+ * @returns {number} Profit per day
+ *
+ * @example
+ * calculateProfitPerDay(10000) // Returns 240,000
+ */
+export function calculateProfitPerDay(profitPerHour) {
+    return profitPerHour * HOURS_PER_DAY;
+}
+
+// ============ Cost Calculations ============
+
+/**
+ * Calculate drink consumption rate with Drink Concentration
+ * @param {number} drinkConcentration - Drink Concentration stat as decimal (e.g., 0.15 for 15%)
+ * @returns {number} Drinks consumed per hour
+ *
+ * @example
+ * calculateDrinksPerHour(0)    // Returns 12 (base rate)
+ * calculateDrinksPerHour(0.15) // Returns 13.8 (12 × 1.15)
+ */
+export function calculateDrinksPerHour(drinkConcentration = 0) {
+    return DRINKS_PER_HOUR_BASE * (1 + drinkConcentration);
+}
+
+/**
+ * Calculate price after marketplace tax
+ * @param {number} price - Price before tax
+ * @returns {number} Price after 2% tax deduction
+ *
+ * @example
+ * calculatePriceAfterTax(100) // Returns 98
+ */
+export function calculatePriceAfterTax(price) {
+    return price * (1 - MARKET_TAX);
+}
+
+// ============ Composite Calculations ============
+
+/**
+ * Calculate complete profit breakdown for queued actions
+ * Takes raw inputs and returns all intermediate + final values
+ *
+ * @param {Object} params - Calculation parameters
+ * @param {number} params.profitPerHour - Profit per hour (from profit calculator)
+ * @param {number} params.actionsPerHour - Base actions per hour (from profit calculator)
+ * @param {number} params.actionCount - Number of queued actions/attempts
+ * @param {number} [params.revenuePerHour] - Revenue per hour (optional, for estimated value mode)
+ * @param {string} [params.valueMode='profit'] - 'profit' or 'estimated_value'
+ * @returns {Object} Profit breakdown with all calculated values
+ *
+ * @example
+ * calculateQueueProfitBreakdown({
+ *     profitPerHour: 75000,
+ *     actionsPerHour: 600,
+ *     actionCount: 100,
+ * })
+ * // Returns: { totalProfit: 12500, profitPerAction: 125, hoursNeeded: 0.167, ... }
+ */
+export function calculateQueueProfitBreakdown({
+    profitPerHour,
+    actionsPerHour,
+    actionCount,
+    revenuePerHour,
+    valueMode = 'profit',
+}) {
+    // Determine which value to use based on mode
+    const valuePerHour =
+        valueMode === 'estimated_value' && revenuePerHour !== undefined ? revenuePerHour : profitPerHour;
+
+    // Calculate derived values
+    const profitPerAction = calculateProfitPerAction(valuePerHour, actionsPerHour);
+    const totalProfit = profitPerAction * actionCount;
+    const hoursNeeded = calculateHoursForActions(actionCount, actionsPerHour);
+    const secondsNeeded = hoursNeeded * SECONDS_PER_HOUR;
+
+    return {
+        // Final values
+        totalProfit,
+        profitPerAction,
+
+        // Time values
+        hoursNeeded,
+        secondsNeeded,
+
+        // Input values (for reference)
+        valuePerHour,
+        actionsPerHour,
+        actionCount,
+        valueMode,
+    };
+}
+
+export default {
+    // Rate conversions
+    calculateActionsPerHour,
+    calculateHoursForActions,
+    calculateSecondsForActions,
+
+    // Efficiency
+    calculateEfficiencyMultiplier,
+
+    // Profit
+    calculateProfitPerAction,
+    calculateTotalProfitForActions,
+    calculateProfitPerDay,
+
+    // Costs
+    calculateDrinksPerHour,
+    calculatePriceAfterTax,
+
+    // Composite
+    calculateQueueProfitBreakdown,
+};

--- a/src/utils/profit-helpers.test.js
+++ b/src/utils/profit-helpers.test.js
@@ -1,0 +1,329 @@
+/**
+ * Tests for Profit Calculation Helpers
+ * Testing profit/rate calculations used across features
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+    calculateActionsPerHour,
+    calculateHoursForActions,
+    calculateSecondsForActions,
+    calculateEfficiencyMultiplier,
+    calculateProfitPerAction,
+    calculateTotalProfitForActions,
+    calculateProfitPerDay,
+    calculateDrinksPerHour,
+    calculatePriceAfterTax,
+    calculateQueueProfitBreakdown,
+} from './profit-helpers.js';
+
+// ============ Rate Conversion Tests ============
+
+describe('calculateActionsPerHour', () => {
+    test('calculates actions per hour from action time', () => {
+        expect(calculateActionsPerHour(6)).toBe(600); // 3600 / 6
+        expect(calculateActionsPerHour(1)).toBe(3600); // 3600 / 1
+        expect(calculateActionsPerHour(60)).toBe(60); // 3600 / 60
+    });
+
+    test('handles fractional action times', () => {
+        expect(calculateActionsPerHour(0.5)).toBe(7200); // 3600 / 0.5
+        expect(calculateActionsPerHour(2.5)).toBe(1440); // 3600 / 2.5
+    });
+
+    test('returns 0 for invalid inputs', () => {
+        expect(calculateActionsPerHour(0)).toBe(0);
+        expect(calculateActionsPerHour(-1)).toBe(0);
+        expect(calculateActionsPerHour(null)).toBe(0);
+        expect(calculateActionsPerHour(undefined)).toBe(0);
+    });
+});
+
+describe('calculateHoursForActions', () => {
+    test('calculates hours needed for actions', () => {
+        expect(calculateHoursForActions(600, 600)).toBe(1);
+        expect(calculateHoursForActions(1200, 600)).toBe(2);
+        expect(calculateHoursForActions(300, 600)).toBe(0.5);
+    });
+
+    test('handles fractional results', () => {
+        expect(calculateHoursForActions(100, 600)).toBeCloseTo(0.167, 2);
+        expect(calculateHoursForActions(1, 600)).toBeCloseTo(0.00167, 4);
+    });
+
+    test('returns 0 for invalid actionsPerHour', () => {
+        expect(calculateHoursForActions(100, 0)).toBe(0);
+        expect(calculateHoursForActions(100, -1)).toBe(0);
+        expect(calculateHoursForActions(100, null)).toBe(0);
+        expect(calculateHoursForActions(100, undefined)).toBe(0);
+    });
+});
+
+describe('calculateSecondsForActions', () => {
+    test('calculates seconds needed for actions', () => {
+        expect(calculateSecondsForActions(600, 600)).toBe(3600); // 1 hour
+        expect(calculateSecondsForActions(100, 600)).toBe(600); // 10 minutes
+        expect(calculateSecondsForActions(60, 3600)).toBe(60); // 1 minute
+    });
+
+    test('returns 0 for invalid inputs', () => {
+        expect(calculateSecondsForActions(100, 0)).toBe(0);
+    });
+});
+
+// ============ Efficiency Tests ============
+
+describe('calculateEfficiencyMultiplier', () => {
+    test('calculates multiplier from efficiency percentage', () => {
+        expect(calculateEfficiencyMultiplier(0)).toBe(1);
+        expect(calculateEfficiencyMultiplier(50)).toBe(1.5);
+        expect(calculateEfficiencyMultiplier(100)).toBe(2);
+        expect(calculateEfficiencyMultiplier(150)).toBe(2.5);
+        expect(calculateEfficiencyMultiplier(250)).toBe(3.5);
+    });
+
+    test('handles null/undefined as 0%', () => {
+        expect(calculateEfficiencyMultiplier(null)).toBe(1);
+        expect(calculateEfficiencyMultiplier(undefined)).toBe(1);
+    });
+
+    test('handles fractional efficiency', () => {
+        expect(calculateEfficiencyMultiplier(33.5)).toBe(1.335);
+    });
+});
+
+// ============ Profit Calculation Tests ============
+
+describe('calculateProfitPerAction', () => {
+    test('calculates profit per action from hourly values', () => {
+        // Simple case: 30,000/hr with 600 actions/hr = 50 per action
+        expect(calculateProfitPerAction(30000, 600)).toBe(50);
+
+        // With efficiency baked in: 75,000/hr with 600 base actions/hr = 125 per action
+        expect(calculateProfitPerAction(75000, 600)).toBe(125);
+    });
+
+    test('handles negative profit (loss)', () => {
+        expect(calculateProfitPerAction(-10000, 600)).toBeCloseTo(-16.67, 1);
+    });
+
+    test('handles zero profit', () => {
+        expect(calculateProfitPerAction(0, 600)).toBe(0);
+    });
+
+    test('returns 0 for invalid actionsPerHour', () => {
+        expect(calculateProfitPerAction(30000, 0)).toBe(0);
+        expect(calculateProfitPerAction(30000, -1)).toBe(0);
+        expect(calculateProfitPerAction(30000, null)).toBe(0);
+    });
+});
+
+describe('calculateTotalProfitForActions', () => {
+    test('calculates total profit for queued actions', () => {
+        // 30,000/hr, 600 actions/hr, 100 queued = 5,000 total
+        expect(calculateTotalProfitForActions(30000, 600, 100)).toBe(5000);
+
+        // With efficiency: 75,000/hr, 600 actions/hr, 100 queued = 12,500 total
+        expect(calculateTotalProfitForActions(75000, 600, 100)).toBe(12500);
+    });
+
+    test('handles large queue counts', () => {
+        expect(calculateTotalProfitForActions(30000, 600, 10000)).toBe(500000);
+    });
+
+    test('handles single action', () => {
+        expect(calculateTotalProfitForActions(30000, 600, 1)).toBe(50);
+    });
+
+    test('handles zero actions', () => {
+        expect(calculateTotalProfitForActions(30000, 600, 0)).toBe(0);
+    });
+
+    test('handles negative profit', () => {
+        expect(calculateTotalProfitForActions(-6000, 600, 100)).toBe(-1000);
+    });
+});
+
+describe('calculateProfitPerDay', () => {
+    test('calculates daily profit from hourly', () => {
+        expect(calculateProfitPerDay(10000)).toBe(240000);
+        expect(calculateProfitPerDay(1000)).toBe(24000);
+        expect(calculateProfitPerDay(0)).toBe(0);
+    });
+
+    test('handles negative profit', () => {
+        expect(calculateProfitPerDay(-5000)).toBe(-120000);
+    });
+});
+
+// ============ Cost Calculation Tests ============
+
+describe('calculateDrinksPerHour', () => {
+    test('returns base rate with no concentration', () => {
+        expect(calculateDrinksPerHour(0)).toBe(12);
+        expect(calculateDrinksPerHour()).toBe(12);
+    });
+
+    test('increases rate with drink concentration', () => {
+        expect(calculateDrinksPerHour(0.15)).toBeCloseTo(13.8, 1); // 12 × 1.15
+        expect(calculateDrinksPerHour(0.3)).toBeCloseTo(15.6, 1); // 12 × 1.30
+        expect(calculateDrinksPerHour(0.5)).toBe(18); // 12 × 1.50
+    });
+});
+
+describe('calculatePriceAfterTax', () => {
+    test('applies 2% marketplace tax', () => {
+        expect(calculatePriceAfterTax(100)).toBe(98);
+        expect(calculatePriceAfterTax(1000)).toBe(980);
+        expect(calculatePriceAfterTax(50)).toBe(49);
+    });
+
+    test('handles zero price', () => {
+        expect(calculatePriceAfterTax(0)).toBe(0);
+    });
+
+    test('handles fractional prices', () => {
+        expect(calculatePriceAfterTax(99.99)).toBeCloseTo(97.99, 2);
+    });
+});
+
+// ============ Composite Calculation Tests ============
+
+describe('calculateQueueProfitBreakdown', () => {
+    test('calculates complete breakdown for production action', () => {
+        const result = calculateQueueProfitBreakdown({
+            profitPerHour: 75000,
+            actionsPerHour: 600,
+            actionCount: 100,
+        });
+
+        expect(result.totalProfit).toBe(12500);
+        expect(result.profitPerAction).toBe(125);
+        expect(result.hoursNeeded).toBeCloseTo(0.167, 2);
+        expect(result.secondsNeeded).toBe(600);
+        expect(result.valueMode).toBe('profit');
+    });
+
+    test('uses revenue in estimated_value mode', () => {
+        const result = calculateQueueProfitBreakdown({
+            profitPerHour: 50000,
+            revenuePerHour: 100000,
+            actionsPerHour: 600,
+            actionCount: 100,
+            valueMode: 'estimated_value',
+        });
+
+        // Should use revenuePerHour (100,000) not profitPerHour (50,000)
+        expect(result.totalProfit).toBeCloseTo(16667, 0);
+        expect(result.profitPerAction).toBeCloseTo(166.67, 1);
+        expect(result.valuePerHour).toBe(100000);
+    });
+
+    test('falls back to profit when revenue undefined in estimated_value mode', () => {
+        const result = calculateQueueProfitBreakdown({
+            profitPerHour: 50000,
+            actionsPerHour: 600,
+            actionCount: 100,
+            valueMode: 'estimated_value',
+        });
+
+        expect(result.valuePerHour).toBe(50000);
+    });
+
+    test('handles negative profit', () => {
+        const result = calculateQueueProfitBreakdown({
+            profitPerHour: -10000,
+            actionsPerHour: 600,
+            actionCount: 100,
+        });
+
+        expect(result.totalProfit).toBeCloseTo(-1667, 0);
+        expect(result.profitPerAction).toBeCloseTo(-16.67, 1);
+    });
+
+    test('handles zero actionsPerHour gracefully', () => {
+        const result = calculateQueueProfitBreakdown({
+            profitPerHour: 75000,
+            actionsPerHour: 0,
+            actionCount: 100,
+        });
+
+        expect(result.totalProfit).toBe(0);
+        expect(result.profitPerAction).toBe(0);
+        expect(result.hoursNeeded).toBe(0);
+    });
+});
+
+// ============ Real-World Scenario Tests ============
+
+describe('Real-world profit scenarios', () => {
+    test('Cheese production with 150% efficiency', () => {
+        // Scenario:
+        // - 6 second action time → 600 base actions/hour
+        // - 150% efficiency → 2.5x multiplier
+        // - Cheese sells for 100, costs 50 in materials
+        // - Profit per cheese = 50
+        // - profitPerHour = 600 × 2.5 × 50 = 75,000 (efficiency already included)
+        // - Queue shows "Produce 100 times"
+
+        const actionsPerHour = calculateActionsPerHour(6);
+        expect(actionsPerHour).toBe(600);
+
+        const efficiencyMultiplier = calculateEfficiencyMultiplier(150);
+        expect(efficiencyMultiplier).toBe(2.5);
+
+        // profitPerHour already includes efficiency (calculated by profit-calculator.js)
+        const profitPerHour = 75000;
+
+        const result = calculateQueueProfitBreakdown({
+            profitPerHour,
+            actionsPerHour,
+            actionCount: 100,
+        });
+
+        // 100 attempts × 125 profit per attempt = 12,500
+        expect(result.totalProfit).toBe(12500);
+        expect(result.profitPerAction).toBe(125); // 50 profit × 2.5 efficiency
+    });
+
+    test('Gathering with 50% efficiency', () => {
+        // Scenario:
+        // - 4 second action time → 900 base actions/hour
+        // - 50% efficiency → 1.5x multiplier
+        // - Average drop value = 20 per action (before efficiency)
+        // - profitPerHour = 900 × 1.5 × 20 = 27,000
+        // - Queue shows "Gather 500 times"
+
+        const actionsPerHour = calculateActionsPerHour(4);
+        expect(actionsPerHour).toBe(900);
+
+        const profitPerHour = 27000;
+
+        const result = calculateQueueProfitBreakdown({
+            profitPerHour,
+            actionsPerHour,
+            actionCount: 500,
+        });
+
+        // 500 attempts × 30 profit per attempt = 15,000
+        expect(result.totalProfit).toBe(15000);
+        expect(result.profitPerAction).toBe(30); // 20 profit × 1.5 efficiency
+    });
+
+    test('Loss-making action (material cost > sale price)', () => {
+        // Scenario:
+        // - 600 actions/hour
+        // - Each action loses 10 gold
+        // - profitPerHour = -6,000
+        // - Queue shows "Produce 200 times"
+
+        const result = calculateQueueProfitBreakdown({
+            profitPerHour: -6000,
+            actionsPerHour: 600,
+            actionCount: 200,
+        });
+
+        expect(result.totalProfit).toBe(-2000);
+        expect(result.profitPerAction).toBe(-10);
+    });
+});


### PR DESCRIPTION
#### Current Behavior
The action queue profit display has two issues:
1. "Estimated Value" mode only changes the label but still shows net profit instead of gross revenue
2. Profit totals use raw queue count instead of actual attempts, causing inflated totals when efficiency grants extra completions

Additionally, profit calculations are duplicated across multiple files with inconsistent naming.

Issue: N/A

#### Changes
- Fix value mode to recalculate totals using revenue/hour when "Estimated Value" is selected
- Fix profit totals to use actual queue attempts (matching time estimates) rather than raw queue count
- Extract shared calculation functions into `profit-helpers.js` with 35 unit tests
- Add `profit-constants.js` for shared constants (MARKET_TAX, DRINKS_PER_HOUR_BASE, etc.)
- Standardize on `totalEfficiency` and `efficiencyMultiplier` naming across all profit calculators
- Update consumers to use pre-calculated `profitPerAction` from profit calculators

#### Breaking Changes
None