### PR TITLE
🐛 fix: dismiss stuck tooltips on scroll and reorder

### DIFF
--- a/dist/Toolasha.user.js
+++ b/dist/Toolasha.user.js
@@ -9399,6 +9399,98 @@
     }
 
     /**
+     * Dismiss all open MUI tooltips by dispatching mouseleave events
+     * Useful when DOM elements are reordered (e.g., sorting action panels)
+     * which can cause tooltips to get "stuck" since no natural mouseleave fires
+     */
+    function dismissTooltips() {
+        const tooltips = document.querySelectorAll('.MuiTooltip-popper');
+        tooltips.forEach((tooltip) => {
+            // Find the element that triggered this tooltip and dispatch mouseleave
+            // MUI tooltips listen for mouseleave on the trigger element
+            const triggerId = tooltip.id?.replace('-tooltip', '');
+            if (triggerId) {
+                const trigger = document.querySelector(`[aria-describedby="${tooltip.id}"]`);
+                if (trigger) {
+                    if (trigger.matches(':hover')) {
+                        return;
+                    }
+                    trigger.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+                    trigger.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+                }
+            }
+        });
+    }
+
+    /**
+     * Set up scroll listener to dismiss tooltips when scrolling
+     * Prevents tooltips from getting stuck when scrolling quickly
+     * @returns {Function} Cleanup function to remove the listener
+     */
+    function setupScrollTooltipDismissal() {
+        let scrollTimeout = null;
+        let lastUserScrollTime = 0;
+        const USER_SCROLL_WINDOW_MS = 200;
+
+        const markUserScroll = () => {
+            lastUserScrollTime = Date.now();
+        };
+
+        const handleUserKeyScroll = (event) => {
+            const key = event.key;
+            if (key === 'ArrowUp' || key === 'ArrowDown' || key === 'PageUp' || key === 'PageDown' || key === ' ') {
+                markUserScroll();
+            }
+        };
+
+        const handleScroll = (event) => {
+            const target = event.target;
+            if (target?.closest?.('.MuiTooltip-tooltip, .MuiTooltip-popper')) {
+                return;
+            }
+
+            if (Date.now() - lastUserScrollTime > USER_SCROLL_WINDOW_MS) {
+                return;
+            }
+
+            // Early exit: skip if no tooltips are visible
+            if (!document.querySelector('.MuiTooltip-popper')) {
+                return;
+            }
+
+            // Debounce: only dismiss after scrolling stops for 50ms
+            // This prevents excessive calls during continuous scrolling
+            if (scrollTimeout) {
+                clearTimeout(scrollTimeout);
+            }
+            scrollTimeout = setTimeout(() => {
+                dismissTooltips();
+                scrollTimeout = null;
+            }, 50);
+        };
+
+        // Listen on document with capture to catch all scroll events
+        // (including scrolls in nested containers)
+        document.addEventListener('scroll', handleScroll, { capture: true, passive: true });
+
+        // Track user-driven scrolling intent
+        document.addEventListener('wheel', markUserScroll, { capture: true, passive: true });
+        document.addEventListener('touchmove', markUserScroll, { capture: true, passive: true });
+        document.addEventListener('keydown', handleUserKeyScroll, { capture: true });
+
+        // Return cleanup function
+        return () => {
+            document.removeEventListener('scroll', handleScroll, { capture: true });
+            document.removeEventListener('wheel', markUserScroll, { capture: true });
+            document.removeEventListener('touchmove', markUserScroll, { capture: true });
+            document.removeEventListener('keydown', handleUserKeyScroll, { capture: true });
+            if (scrollTimeout) {
+                clearTimeout(scrollTimeout);
+            }
+        };
+    }
+
+    /**
      * Fix tooltip overflow to ensure it stays within viewport
      * @param {Element} tooltipElement - The tooltip popper element
      */
@@ -9479,6 +9571,8 @@
         getOriginalText,
         addStyles,
         removeStyles,
+        dismissTooltips,
+        setupScrollTooltipDismissal,
         fixTooltipOverflow,
     };
 
@@ -20539,6 +20633,16 @@
                     originalIndex: containerMap.get(container).length,
                     actionHrid: data.actionHrid,
                 });
+            }
+
+            // Dismiss any open tooltips before reordering (prevents stuck tooltips)
+            // Only dismiss if a tooltip exists and its trigger is not hovered
+            const openTooltip = document.querySelector('.MuiTooltip-popper');
+            if (openTooltip) {
+                const trigger = document.querySelector(`[aria-describedby="${openTooltip.id}"]`);
+                if (!trigger || !trigger.matches(':hover')) {
+                    dismissTooltips();
+                }
             }
 
             // Sort and reorder each container
@@ -45278,6 +45382,9 @@
 
         // CRITICAL: Start centralized DOM observer SECOND, before features initialize
         domObserver.start();
+
+        // Set up scroll listener to dismiss stuck tooltips
+        setupScrollTooltipDismissal();
 
         // Initialize network alert (must be early, before market features)
         networkAlert.initialize();

--- a/src/features/actions/action-panel-sort.js
+++ b/src/features/actions/action-panel-sort.js
@@ -8,6 +8,7 @@
 
 import config from '../../core/config.js';
 import storage from '../../core/storage.js';
+import { dismissTooltips } from '../../utils/dom.js';
 
 class ActionPanelSort {
     constructor() {
@@ -174,6 +175,16 @@ class ActionPanelSort {
                 originalIndex: containerMap.get(container).length,
                 actionHrid: data.actionHrid,
             });
+        }
+
+        // Dismiss any open tooltips before reordering (prevents stuck tooltips)
+        // Only dismiss if a tooltip exists and its trigger is not hovered
+        const openTooltip = document.querySelector('.MuiTooltip-popper');
+        if (openTooltip) {
+            const trigger = document.querySelector(`[aria-describedby="${openTooltip.id}"]`);
+            if (!trigger || !trigger.matches(':hover')) {
+                dismissTooltips();
+            }
         }
 
         // Sort and reorder each container

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ import featureRegistry from './core/feature-registry.js';
 import networkAlert from './features/market/network-alert.js';
 import * as combatSimIntegration from './features/combat/combat-sim-integration.js';
 import settingsUI from './features/settings/settings-ui.js';
+import { setupScrollTooltipDismissal } from './utils/dom.js';
 
 /**
  * Detect if running on Combat Simulator page
@@ -37,6 +38,9 @@ if (isCombatSimulatorPage()) {
 
     // CRITICAL: Start centralized DOM observer SECOND, before features initialize
     domObserver.start();
+
+    // Set up scroll listener to dismiss stuck tooltips
+    setupScrollTooltipDismissal();
 
     // Initialize network alert (must be early, before market features)
     networkAlert.initialize();


### PR DESCRIPTION
#### Current Behavior
Tooltips can remain stuck on screen after action panels reorder or when users scroll quickly.

Issue: N/A

#### Changes
- Add tooltip dismissal helper to close MUI tooltips when triggers are not hovered
- Dismiss tooltips before action panel reordering
- Dismiss tooltips after user-driven scroll events

#### Breaking Changes
None