### PR TITLE
✨ feat: auto-fill quantity when buying from missing materials tabs

### DIFF
--- a/src/features/actions/missing-materials-button.js
+++ b/src/features/actions/missing-materials-button.js
@@ -21,6 +21,8 @@ let processedPanels = new WeakSet();
 let inventoryUpdateHandler = null;
 let storedActionHrid = null;
 let storedNumActions = 0;
+let buyModalObserverUnregister = null;
+let activeMissingQuantity = null;
 
 /**
  * Production action types (where button should appear)
@@ -65,6 +67,7 @@ function goToMarketplace(itemHrid, enhancementLevel = 0) {
 export function initialize() {
     console.log('[MissingMats] Initializing missing materials button feature');
     setupMarketplaceCleanupObserver();
+    setupBuyModalObserver();
 
     // Watch for action panels appearing
     domObserverUnregister = domObserver.onClass(
@@ -93,6 +96,12 @@ export function cleanup() {
     if (cleanupObserver) {
         cleanupObserver.disconnect();
         cleanupObserver = null;
+    }
+
+    // Unregister buy modal observer
+    if (buyModalObserverUnregister) {
+        buyModalObserverUnregister();
+        buyModalObserverUnregister = null;
     }
 
     // Remove any existing custom tabs
@@ -396,6 +405,14 @@ function createMissingMaterialTabs(missingMaterials) {
         tabsContainer.style.flexWrap = 'wrap';
     }
 
+    // Add click listeners to regular tabs to clear active quantity
+    const regularTabs = tabsContainer.querySelectorAll('button:not([data-mwi-custom-tab])');
+    regularTabs.forEach((tab) => {
+        tab.addEventListener('click', () => {
+            activeMissingQuantity = null;
+        });
+    });
+
     // Create tab for each missing material
     currentMaterialsTabs = [];
     for (const material of missingMaterials) {
@@ -534,6 +551,7 @@ function createCustomTab(material, referenceTab) {
     // Mark as custom tab for later identification
     tab.setAttribute('data-mwi-custom-tab', 'true');
     tab.setAttribute('data-item-hrid', material.itemHrid);
+    tab.setAttribute('data-missing-quantity', material.missing.toString());
 
     // Color coding:
     // - Red: Missing materials (missing > 0)
@@ -593,6 +611,9 @@ function createCustomTab(material, referenceTab) {
             return;
         }
 
+        // Store the missing quantity for auto-fill when buy modal opens
+        activeMissingQuantity = material.missing;
+
         // Navigate to marketplace using game API
         goToMarketplace(material.itemHrid, 0);
     });
@@ -617,6 +638,7 @@ function removeMissingMaterialTabs() {
     // Clear stored context
     storedActionHrid = null;
     storedNumActions = 0;
+    activeMissingQuantity = null;
 }
 
 /**
@@ -648,6 +670,59 @@ function setupMarketplaceCleanupObserver() {
             subtree: true,
         });
     }
+}
+
+/**
+ * Setup buy modal observer
+ * Watches for buy modals appearing and auto-fills quantity if from missing materials tab
+ */
+function setupBuyModalObserver() {
+    buyModalObserverUnregister = domObserver.onClass(
+        'MissingMaterialsButton-BuyModal',
+        'Modal_modalContainer',
+        (modal) => {
+            handleBuyModal(modal);
+        }
+    );
+}
+
+/**
+ * Handle buy modal appearance
+ * Auto-fills quantity if we have an active missing quantity
+ * @param {HTMLElement} modal - Modal container element
+ */
+function handleBuyModal(modal) {
+    // Check if we have an active missing quantity to fill
+    if (!activeMissingQuantity || activeMissingQuantity <= 0) {
+        return;
+    }
+
+    // Check if this is a "Buy Now" modal
+    const header = modal.querySelector('div[class*="MarketplacePanel_header"]');
+    if (!header) {
+        return;
+    }
+
+    const headerText = header.textContent.trim();
+    if (!headerText.includes('Buy Now') && !headerText.includes('立即购买')) {
+        return;
+    }
+
+    // Find the quantity input
+    const quantityInput = modal.querySelector('input[type="number"]');
+    if (!quantityInput) {
+        return;
+    }
+
+    // Set the quantity value
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+    nativeInputValueSetter.call(quantityInput, activeMissingQuantity.toString());
+
+    // Trigger input event to notify React
+    const inputEvent = new Event('input', { bubbles: true });
+    quantityInput.dispatchEvent(inputEvent);
+
+    console.log('[MissingMats] Auto-filled quantity:', activeMissingQuantity);
 }
 
 export default {


### PR DESCRIPTION
#### Current Behavior
When using the "Missing Mats Marketplace" feature, users must manually enter the quantity needed when clicking the buy button on a "Missing: X" tab. This adds friction to the purchasing workflow, especially when buying multiple missing materials.

Issue: N/A

#### Changes
- Add DOM observer to detect when marketplace buy modals appear
- Store missing quantity when a custom "Missing: X" tab is clicked
- Auto-fill the quantity input field with the missing amount when buy modal opens
- Persist quantity across multiple buy attempts until user switches tabs or leaves marketplace
- Clear active quantity when clicking regular marketplace tabs (Market Listings, My Listings, etc.)
- Clear active quantity when marketplace closes

#### Breaking Changes
None