### PR TITLE
🐛 fix: correct alchemy material count extraction from DOM

### DIFF
--- a/dist/Toolasha.user.js
+++ b/dist/Toolasha.user.js
@@ -41730,10 +41730,21 @@
                     const countElements = document.querySelectorAll(
                         '[class*="SkillActionDetail_itemRequirements"] [class*="SkillActionDetail_inputCount"]'
                     );
+
                     if (countElements[index]) {
                         const text = countElements[index].textContent.trim();
-                        const cleaned = text.replace(/,/g, '');
-                        result.count = parseFloat(cleaned) || 1;
+                        // Extract number after the "/" character (format: "/ 2" or "/ 450")
+                        const match = text.match(/\/\s*([\d,]+)/);
+                        let parsedCount = 1;
+
+                        if (match) {
+                            const cleaned = match[1].replace(/,/g, '');
+                            parsedCount = parseFloat(cleaned);
+                        }
+
+                        result.count = parsedCount || 1;
+                    } else {
+                        result.count = 1;
                     }
                 } else if (!isRequirement) {
                     // Extract count and drop rate from drop by matching item HRID

--- a/src/features/alchemy/alchemy-profit.js
+++ b/src/features/alchemy/alchemy-profit.js
@@ -772,10 +772,21 @@ class AlchemyProfit {
                 const countElements = document.querySelectorAll(
                     '[class*="SkillActionDetail_itemRequirements"] [class*="SkillActionDetail_inputCount"]'
                 );
+
                 if (countElements[index]) {
                     const text = countElements[index].textContent.trim();
-                    const cleaned = text.replace(/,/g, '');
-                    result.count = parseFloat(cleaned) || 1;
+                    // Extract number after the "/" character (format: "/ 2" or "/ 450")
+                    const match = text.match(/\/\s*([\d,]+)/);
+                    let parsedCount = 1;
+
+                    if (match) {
+                        const cleaned = match[1].replace(/,/g, '');
+                        parsedCount = parseFloat(cleaned);
+                    }
+
+                    result.count = parsedCount || 1;
+                } else {
+                    result.count = 1;
                 }
             } else if (!isRequirement) {
                 // Extract count and drop rate from drop by matching item HRID


### PR DESCRIPTION
#### Current Behavior
Material costs for alchemy actions (Transmute, Decompose, Coinify) were defaulting to 1 per action instead of the actual amounts. For example, decomposing an apple should consume 2 apples and 200 coins per action, but was being calculated as 1 apple and 1 coin.

Issue: N/A

#### Changes
- Add regex pattern `/\/\s*([\d,]+)/` to extract material counts from DOM text format ("/ 2", "/ 450")
- Fix `extractItemData()` method in `alchemy-profit.js` to properly parse count values
- Handle comma-separated numbers in material counts

#### Breaking Changes
None