### PR TITLE
✨ feat: apply achievement buffs and breakdowns

### DIFF
--- a/src/features/actions/action-time-display.js
+++ b/src/features/actions/action-time-display.js
@@ -441,8 +441,10 @@ class ActionTimeDisplay {
             const communityGathering = communityBuffLevel ? 0.2 + (communityBuffLevel - 1) * 0.005 : 0;
 
             // Achievement buffs
-            const achievementBuffs = dataManager.getAchievementBuffs(actionDetails.type);
-            const achievementGathering = achievementBuffs.gatheringQuantity || 0;
+            const achievementGathering = dataManager.getAchievementBuffFlatBoost(
+                actionDetails.type,
+                '/buff_types/gathering'
+            );
 
             // Total gathering bonus (all additive)
             const totalGathering = gatheringTea + communityGathering + achievementGathering;

--- a/src/features/actions/enhancement-display.js
+++ b/src/features/actions/enhancement-display.js
@@ -587,9 +587,13 @@ function formatEnhancementDisplay(
             `<div style="color: #ffaa55;"><span style="color: #888;">Rare Find:</span> +${params.rareFindBonus.toFixed(1)}%</div>`
         );
 
-        // Show house room breakdown if available
-        if (params.houseRareFindBonus > 0) {
-            const equipmentRareFind = params.rareFindBonus - params.houseRareFindBonus;
+        // Show breakdown if available
+        const achievementRareFind = params.achievementRareFindBonus || 0;
+        if (params.houseRareFindBonus > 0 || achievementRareFind > 0) {
+            const equipmentRareFind = Math.max(
+                0,
+                params.rareFindBonus - params.houseRareFindBonus - achievementRareFind
+            );
             if (equipmentRareFind > 0) {
                 lines.push(
                     `<div style="color: #ffaa55; font-size: 0.8em; padding-left: 10px;"><span style="color: #666;">Equipment:</span> +${equipmentRareFind.toFixed(1)}%</div>`
@@ -598,6 +602,11 @@ function formatEnhancementDisplay(
             lines.push(
                 `<div style="color: #ffaa55; font-size: 0.8em; padding-left: 10px;"><span style="color: #666;">House Rooms:</span> +${params.houseRareFindBonus.toFixed(1)}%</div>`
             );
+            if (achievementRareFind > 0) {
+                lines.push(
+                    `<div style="color: #ffaa55; font-size: 0.8em; padding-left: 10px;"><span style="color: #666;">Achievement:</span> +${achievementRareFind.toFixed(1)}%</div>`
+                );
+            }
         }
     }
     if (params.experienceBonus > 0) {
@@ -605,11 +614,15 @@ function formatEnhancementDisplay(
             `<div style="color: #ffdd88;"><span style="color: #888;">Experience:</span> +${params.experienceBonus.toFixed(1)}%</div>`
         );
 
-        // Show breakdown: equipment + house wisdom + tea wisdom + community wisdom
+        // Show breakdown: equipment + house wisdom + tea wisdom + community wisdom + achievement wisdom
         const teaWisdom = params.teaWisdomBonus || 0;
         const houseWisdom = params.houseWisdomBonus || 0;
         const communityWisdom = params.communityWisdomBonus || 0;
-        const equipmentExperience = params.experienceBonus - houseWisdom - teaWisdom - communityWisdom;
+        const achievementWisdom = params.achievementWisdomBonus || 0;
+        const equipmentExperience = Math.max(
+            0,
+            params.experienceBonus - houseWisdom - teaWisdom - communityWisdom - achievementWisdom
+        );
 
         if (equipmentExperience > 0) {
             lines.push(
@@ -630,6 +643,11 @@ function formatEnhancementDisplay(
         if (teaWisdom > 0) {
             lines.push(
                 `<div style="color: #ffdd88; font-size: 0.8em; padding-left: 10px;"><span style="color: #666;">Wisdom Tea:</span> +${teaWisdom.toFixed(1)}%</div>`
+            );
+        }
+        if (achievementWisdom > 0) {
+            lines.push(
+                `<div style="color: #ffdd88; font-size: 0.8em; padding-left: 10px;"><span style="color: #666;">Achievement:</span> +${achievementWisdom.toFixed(1)}%</div>`
             );
         }
     }

--- a/src/features/actions/profit-display.js
+++ b/src/features/actions/profit-display.js
@@ -36,6 +36,27 @@ export const getBonusDropTotalsForActions = (drop, actionsCount, actionsPerHour)
         totalRevenue: revenuePerAction * actionsCount,
     };
 };
+const formatRareFindBonusSummary = (bonusRevenue) => {
+    const rareFindBonus = bonusRevenue?.rareFindBonus || 0;
+    return `${rareFindBonus.toFixed(1)}% rare find`;
+};
+
+const getRareFindBreakdownParts = (bonusRevenue) => {
+    const breakdown = bonusRevenue?.rareFindBreakdown || {};
+    const parts = [];
+
+    if (breakdown.equipment > 0) {
+        parts.push(`${breakdown.equipment.toFixed(1)}% equip`);
+    }
+    if (breakdown.house > 0) {
+        parts.push(`${breakdown.house.toFixed(1)}% house`);
+    }
+    if (breakdown.achievement > 0) {
+        parts.push(`${breakdown.achievement.toFixed(1)}% achievement`);
+    }
+
+    return parts;
+};
 
 /**
  * Display gathering profit calculation in panel
@@ -218,10 +239,10 @@ export async function displayGatheringProfit(panel, actionHrid, dropTableSelecto
             0
         );
         const rareFindRevenueLabel = formatMissingLabel(bonusMissing, formatLargeNumber(Math.round(rareFindRevenue)));
-        const rareFindBonus = profitData.bonusRevenue?.rareFindBonus || 0;
+        const rareFindSummary = formatRareFindBonusSummary(profitData.bonusRevenue);
         rareFindSection = createCollapsibleSection(
             '',
-            `Rare Finds: ${rareFindRevenueLabel}/hr (${rareFinds.length} item${rareFinds.length !== 1 ? 's' : ''}, ${rareFindBonus.toFixed(1)}% rare find)`,
+            `Rare Finds: ${rareFindRevenueLabel}/hr (${rareFinds.length} item${rareFinds.length !== 1 ? 's' : ''}, ${rareFindSummary})`,
             null,
             rareFindContent,
             false,
@@ -310,6 +331,9 @@ export async function displayGatheringProfit(panel, actionHrid, dropTableSelecto
     if (profitData.details.equipmentEfficiency > 0) {
         effParts.push(`${profitData.details.equipmentEfficiency.toFixed(1)}% equip`);
     }
+    if (profitData.details.achievementEfficiency > 0) {
+        effParts.push(`${profitData.details.achievementEfficiency.toFixed(1)}% achievement`);
+    }
 
     if (effParts.length > 0) {
         modifierLines.push(
@@ -334,6 +358,18 @@ export async function displayGatheringProfit(panel, actionHrid, dropTableSelecto
         }
         modifierLines.push(
             `<div style="margin-left: 8px;">• Gathering Quantity: +${(profitData.gatheringQuantity * 100).toFixed(1)}% (${gatheringParts.join(', ')})</div>`
+        );
+    }
+
+    const gatheringRareFindParts = getRareFindBreakdownParts(profitData.bonusRevenue);
+    if (gatheringRareFindParts.length > 0) {
+        if (modifierLines.length === 0) {
+            modifierLines.push(
+                `<div style="font-weight: 500; color: var(--text-color-primary, ${config.COLOR_TEXT_PRIMARY});">Modifiers:</div>`
+            );
+        }
+        modifierLines.push(
+            `<div style="margin-left: 8px;">• Rare Find: +${(profitData.bonusRevenue?.rareFindBonus || 0).toFixed(1)}% (${gatheringRareFindParts.join(', ')})</div>`
         );
     }
 
@@ -638,10 +674,10 @@ export async function displayProductionProfit(panel, actionHrid, dropTableSelect
             0
         );
         const rareFindRevenueLabel = bonusMissing ? '-- ⚠' : formatLargeNumber(Math.round(rareFindRevenue));
-        const rareFindBonus = profitData.bonusRevenue?.rareFindBonus || 0;
+        const rareFindSummary = formatRareFindBonusSummary(profitData.bonusRevenue);
         rareFindSection = createCollapsibleSection(
             '',
-            `Rare Finds: ${rareFindRevenueLabel}/hr (${rareFinds.length} item${rareFinds.length !== 1 ? 's' : ''}, ${rareFindBonus.toFixed(1)}% rare find)`,
+            `Rare Finds: ${rareFindRevenueLabel}/hr (${rareFinds.length} item${rareFinds.length !== 1 ? 's' : ''}, ${rareFindSummary})`,
             null,
             rareFindContent,
             false,
@@ -775,6 +811,9 @@ export async function displayProductionProfit(panel, actionHrid, dropTableSelect
     if (profitData.communityEfficiency > 0) {
         effParts.push(`${profitData.communityEfficiency.toFixed(1)}% community`);
     }
+    if (profitData.achievementEfficiency > 0) {
+        effParts.push(`${profitData.achievementEfficiency.toFixed(1)}% achievement`);
+    }
 
     if (effParts.length > 0) {
         modifierLines.push(
@@ -782,6 +821,18 @@ export async function displayProductionProfit(panel, actionHrid, dropTableSelect
         );
         modifierLines.push(
             `<div style="margin-left: 8px;">• Efficiency: +${profitData.totalEfficiency.toFixed(1)}% (${effParts.join(', ')})</div>`
+        );
+    }
+
+    const productionRareFindParts = getRareFindBreakdownParts(profitData.bonusRevenue);
+    if (productionRareFindParts.length > 0) {
+        if (modifierLines.length === 0) {
+            modifierLines.push(
+                `<div style="font-weight: 500; color: var(--text-color-primary, ${config.COLOR_TEXT_PRIMARY});">Modifiers:</div>`
+            );
+        }
+        modifierLines.push(
+            `<div style="margin-left: 8px;">• Rare Find: +${(profitData.bonusRevenue?.rareFindBonus || 0).toFixed(1)}% (${productionRareFindParts.join(', ')})</div>`
         );
     }
 
@@ -1138,10 +1189,10 @@ function buildGatheringActionsBreakdown(profitData, actionsCount) {
             return sum + getBonusDropTotalsForActions(drop, actionsCount, profitData.actionsPerHour).totalRevenue;
         }, 0);
         const rareFindRevenueLabel = formatMissingLabel(bonusMissing, formatLargeNumber(Math.round(rareFindRevenue)));
-        const rareFindBonus = profitData.bonusRevenue?.rareFindBonus || 0;
+        const rareFindSummary = formatRareFindBonusSummary(profitData.bonusRevenue);
         rareFindSection = createCollapsibleSection(
             '',
-            `Rare Finds: ${rareFindRevenueLabel} (${rareFinds.length} item${rareFinds.length !== 1 ? 's' : ''}, ${rareFindBonus.toFixed(1)}% rare find)`,
+            `Rare Finds: ${rareFindRevenueLabel} (${rareFinds.length} item${rareFinds.length !== 1 ? 's' : ''}, ${rareFindSummary})`,
             null,
             rareFindContent,
             false,
@@ -1382,10 +1433,10 @@ function buildProductionActionsBreakdown(profitData, actionsCount) {
             return sum + revenuePerAction * actionsCount;
         }, 0);
         const rareFindRevenueLabel = formatMissingLabel(bonusMissing, formatLargeNumber(Math.round(rareFindRevenue)));
-        const rareFindBonus = profitData.bonusRevenue?.rareFindBonus || 0;
+        const rareFindSummary = formatRareFindBonusSummary(profitData.bonusRevenue);
         rareFindSection = createCollapsibleSection(
             '',
-            `Rare Finds: ${rareFindRevenueLabel} (${rareFinds.length} item${rareFinds.length !== 1 ? 's' : ''}, ${rareFindBonus.toFixed(1)}% rare find)`,
+            `Rare Finds: ${rareFindRevenueLabel} (${rareFinds.length} item${rareFinds.length !== 1 ? 's' : ''}, ${rareFindSummary})`,
             null,
             rareFindContent,
             false,

--- a/src/features/actions/quick-input-buttons.js
+++ b/src/features/actions/quick-input-buttons.js
@@ -295,6 +295,9 @@ class QuickInputButtons {
                 if (efficiencyBreakdown.equipmentEfficiency > 0) {
                     speedLines.push(`  - Equipment: +${efficiencyBreakdown.equipmentEfficiency.toFixed(1)}%`);
                 }
+                if (efficiencyBreakdown.achievementEfficiency > 0) {
+                    speedLines.push(`  - Achievement: +${efficiencyBreakdown.achievementEfficiency.toFixed(1)}%`);
+                }
                 // Break out individual teas - show BASE efficiency on main line, DC as sub-line
                 if (efficiencyBreakdown.teaBreakdown && efficiencyBreakdown.teaBreakdown.length > 0) {
                     for (const tea of efficiencyBreakdown.teaBreakdown) {
@@ -582,6 +585,7 @@ class QuickInputButtons {
                     teaEfficiency: 0,
                     teaBreakdown: [],
                     communityEfficiency: 0,
+                    achievementEfficiency: 0,
                     skillLevel: 1,
                     baseRequirement: 1,
                     actionLevelBonus: 0,
@@ -1098,6 +1102,11 @@ class QuickInputButtons {
                 // Tea/Coffee
                 if (xpData.breakdown.consumableWisdom > 0) {
                     lines.push(`    • Wisdom Tea: +${xpData.breakdown.consumableWisdom.toFixed(1)}%`);
+                }
+
+                // Achievement wisdom
+                if (xpData.breakdown.achievementWisdom > 0) {
+                    lines.push(`    • Achievement: +${xpData.breakdown.achievementWisdom.toFixed(1)}%`);
                 }
             }
 

--- a/src/features/alchemy/alchemy-profit.js
+++ b/src/features/alchemy/alchemy-profit.js
@@ -278,8 +278,8 @@ class AlchemyProfit {
             }
 
             // Get achievement buffs (Adept tier: +2% efficiency per tier)
-            const achievementBuffs = dataManager.getAchievementBuffs(actionTypeHrid);
-            const achievementEfficiency = (achievementBuffs.efficiency || 0) * 100; // Convert to percentage
+            const achievementEfficiency =
+                dataManager.getAchievementBuffFlatBoost(actionTypeHrid, '/buff_types/efficiency') * 100;
 
             // Stack all efficiency bonuses additively
             const totalEfficiency = stackAdditive(
@@ -336,8 +336,8 @@ class AlchemyProfit {
             }
 
             // Get achievement rare find bonus (Veteran tier: +2%)
-            const achievementBuffs = dataManager.getAchievementBuffs(actionTypeHrid);
-            const achievementRareFind = (achievementBuffs.rareFind || 0) * 100; // Convert to percentage
+            const achievementRareFind =
+                dataManager.getAchievementBuffFlatBoost(actionTypeHrid, '/buff_types/rare_find') * 100;
 
             const total = equipmentRareFind + achievementRareFind;
 

--- a/src/features/enhancement/enhancement-xp.js
+++ b/src/features/enhancement/enhancement-xp.js
@@ -86,6 +86,9 @@ function getWisdomBuff() {
             });
         }
 
+        // 5. Achievement Buffs
+        totalFlatBoost += dataManager.getAchievementBuffFlatBoost('/action_types/enhancing', '/buff_types/wisdom');
+
         // Return as decimal (flatBoost is already in decimal form, e.g., 0.2 for 20%)
         return totalFlatBoost;
     } catch {
@@ -218,6 +221,10 @@ export function calculateEnhancementPredictions(itemHrid, startLevel, targetLeve
                 }
             });
         }
+
+        // Add achievement buffs
+        toolBonus +=
+            dataManager.getAchievementBuffFlatBoost('/action_types/enhancing', '/buff_types/enhancing_success') * 100;
 
         // Check for blessed tea
         let hasBlessed = false;

--- a/src/features/market/profit-calculator.js
+++ b/src/features/market/profit-calculator.js
@@ -155,6 +155,9 @@ class ProfitCalculator {
         // Calculate tea efficiency bonus
         const teaEfficiency = parseTeaEfficiency(actionDetails.type, activeDrinks, itemDetailMap, drinkConcentration);
 
+        const achievementEfficiency =
+            dataManager.getAchievementBuffFlatBoost(actionDetails.type, '/buff_types/efficiency') * 100;
+
         // Calculate artisan material cost reduction
         const artisanBonus = parseArtisanBonus(activeDrinks, itemDetailMap, drinkConcentration);
 
@@ -170,7 +173,12 @@ class ProfitCalculator {
 
         // Total efficiency bonus (all sources additive)
         const totalEfficiency =
-            levelEfficiency + houseEfficiency + equipmentEfficiency + teaEfficiency + communityEfficiency;
+            levelEfficiency +
+            houseEfficiency +
+            equipmentEfficiency +
+            teaEfficiency +
+            communityEfficiency +
+            achievementEfficiency;
 
         // Calculate equipment speed bonus
         const equipmentSpeedBonus = parseEquipmentSpeedBonuses(characterEquipment, actionDetails.type, itemDetailMap);
@@ -295,6 +303,7 @@ class ProfitCalculator {
             equipmentEfficiency, // Equipment efficiency
             teaEfficiency, // Tea buff efficiency
             communityEfficiency, // Community buff efficiency
+            achievementEfficiency, // Achievement buff efficiency
             actionLevelBonus, // Action Level bonus from teas (e.g., Artisan Tea)
             artisanBonus, // Artisan material cost reduction
             gourmetBonus, // Gourmet bonus item chance

--- a/src/utils/action-calculator.js
+++ b/src/utils/action-calculator.js
@@ -97,6 +97,8 @@ export function calculateActionStats(actionDetails, options = {}) {
         const levelEfficiency = Math.max(0, effectiveLevel - effectiveRequirement);
         const houseEfficiency = calculateHouseEfficiency(actionDetails.type);
         const equipmentEfficiency = parseEquipmentEfficiencyBonuses(equipment, actionDetails.type, itemDetailMap);
+        const achievementEfficiency =
+            dataManager.getAchievementBuffFlatBoost(actionDetails.type, '/buff_types/efficiency') * 100;
 
         // Calculate tea efficiency
         let teaEfficiency;
@@ -141,7 +143,8 @@ export function calculateActionStats(actionDetails, options = {}) {
             houseEfficiency,
             equipmentEfficiency,
             teaEfficiency,
-            communityEfficiency
+            communityEfficiency,
+            achievementEfficiency
         );
 
         // Build result object
@@ -159,6 +162,7 @@ export function calculateActionStats(actionDetails, options = {}) {
                 teaEfficiency,
                 teaBreakdown,
                 communityEfficiency,
+                achievementEfficiency,
                 skillLevel,
                 baseRequirement,
                 actionLevelBonus,

--- a/src/utils/bonus-revenue-calculator.js
+++ b/src/utils/bonus-revenue-calculator.js
@@ -6,6 +6,7 @@
 
 import marketAPI from '../api/marketplace.js';
 import expectedValueCalculator from '../features/market/expected-value-calculator.js';
+import dataManager from '../core/data-manager.js';
 import { parseEssenceFindBonus, parseRareFindBonus } from './equipment-parser.js';
 import { calculateHouseRareFind } from './house-efficiency.js';
 
@@ -24,7 +25,14 @@ export function calculateBonusRevenue(actionDetails, actionsPerHour, characterEq
     // Get Rare Find bonus from BOTH equipment and house rooms
     const equipmentRareFindBonus = parseRareFindBonus(characterEquipment, actionDetails.type, itemDetailMap);
     const houseRareFindBonus = calculateHouseRareFind();
-    const rareFindBonus = equipmentRareFindBonus + houseRareFindBonus;
+    const achievementRareFindBonus =
+        dataManager.getAchievementBuffFlatBoost(actionDetails.type, '/buff_types/rare_find') * 100;
+    const rareFindBonus = equipmentRareFindBonus + houseRareFindBonus + achievementRareFindBonus;
+    const rareFindBreakdown = {
+        equipment: equipmentRareFindBonus,
+        house: houseRareFindBonus,
+        achievement: achievementRareFindBonus,
+    };
 
     const bonusDrops = [];
     let totalBonusRevenue = 0;
@@ -138,7 +146,8 @@ export function calculateBonusRevenue(actionDetails, actionsPerHour, characterEq
 
     return {
         essenceFindBonus, // Essence Find % from equipment
-        rareFindBonus, // Rare Find % from equipment + house rooms (combined)
+        rareFindBonus, // Rare Find % from equipment + house rooms + achievements (combined)
+        rareFindBreakdown,
         bonusDrops, // Array of all bonus drops with details
         totalBonusRevenue, // Total revenue/hour from all bonus drops
         hasMissingPrices,

--- a/src/utils/enhancement-config.js
+++ b/src/utils/enhancement-config.js
@@ -128,6 +128,11 @@ function getAutoDetectedParams() {
     // Formula: 20% base + 0.5% per level (same as other community buffs)
     const communityWisdomBonus = communityWisdomLevel > 0 ? 20 + (communityWisdomLevel - 1) * 0.5 : 0;
 
+    const achievementWisdomBonus =
+        dataManager.getAchievementBuffFlatBoost('/action_types/enhancing', '/buff_types/wisdom') * 100;
+    const achievementRareFindBonus =
+        dataManager.getAchievementBuffFlatBoost('/action_types/enhancing', '/buff_types/rare_find') * 100;
+
     // Calculate total success rate bonus
     // Equipment + house + (check for other sources)
     const houseSuccessBonus = houseLevel * 0.05; // 0.05% per level for success
@@ -140,8 +145,9 @@ function getAutoDetectedParams() {
     const totalSpeedBonus = gear.speedBonus + houseSpeedBonus + communitySpeedBonus + teaSpeedBonus;
 
     // Calculate total experience bonus
-    // Equipment + house wisdom + tea wisdom + community wisdom
-    const totalExperienceBonus = gear.experienceBonus + houseWisdomBonus + teaWisdomBonus + communityWisdomBonus;
+    // Equipment + house wisdom + tea wisdom + community wisdom + achievement wisdom
+    const totalExperienceBonus =
+        gear.experienceBonus + houseWisdomBonus + teaWisdomBonus + communityWisdomBonus + achievementWisdomBonus;
 
     // Calculate guzzling bonus multiplier (1.0 at level 0, scales with drink concentration)
     const guzzlingBonus = 1 + drinkConcentration / 100;
@@ -152,7 +158,7 @@ function getAutoDetectedParams() {
         houseLevel: houseLevel,
         toolBonus: totalSuccessBonus, // Tool + house combined
         speedBonus: totalSpeedBonus, // Speed + house + community + tea combined
-        rareFindBonus: gear.rareFindBonus + houseRareFindBonus, // Rare find (equipment + all house rooms)
+        rareFindBonus: gear.rareFindBonus + houseRareFindBonus + achievementRareFindBonus, // Rare find (equipment + house rooms + achievements)
         experienceBonus: totalExperienceBonus, // Experience (equipment + house + tea + community wisdom)
         guzzlingBonus: guzzlingBonus, // Drink concentration multiplier for blessed tea
         teas: teas,
@@ -167,10 +173,12 @@ function getAutoDetectedParams() {
         communitySpeedBonus: communitySpeedBonus, // For display
         communityWisdomLevel: communityWisdomLevel, // For display
         communityWisdomBonus: communityWisdomBonus, // For display
+        achievementWisdomBonus: achievementWisdomBonus, // For display
         teaSpeedBonus: teaSpeedBonus, // For display
         teaWisdomBonus: teaWisdomBonus, // For display
         drinkConcentration: drinkConcentration, // For display
         houseRareFindBonus: houseRareFindBonus, // For display
+        achievementRareFindBonus: achievementRareFindBonus, // For display
         houseWisdomBonus: houseWisdomBonus, // For display
         equipmentRareFind: gear.rareFindBonus, // For display
         equipmentExperience: gear.experienceBonus, // For display

--- a/src/utils/experience-parser.js
+++ b/src/utils/experience-parser.js
@@ -221,8 +221,9 @@ export function calculateExperienceMultiplier(skillHrid, actionTypeHrid) {
     const houseWisdom = parseHouseRoomWisdom();
     const communityWisdom = parseCommunityBuffWisdom();
     const consumableWisdom = parseConsumableWisdom(activeDrinks, itemDetailMap, drinkConcentration);
+    const achievementWisdom = dataManager.getAchievementBuffFlatBoost(actionTypeHrid, '/buff_types/wisdom') * 100;
 
-    const totalWisdom = equipmentWisdom + houseWisdom + communityWisdom + consumableWisdom;
+    const totalWisdom = equipmentWisdom + houseWisdom + communityWisdom + consumableWisdom + achievementWisdom;
 
     // Parse charm experience (skill-specific) - now returns object with total and breakdown
     const charmData = parseCharmExperience(equipment, skillHrid, itemDetailMap);
@@ -242,6 +243,7 @@ export function calculateExperienceMultiplier(skillHrid, actionTypeHrid) {
             houseWisdom,
             communityWisdom,
             consumableWisdom,
+            achievementWisdom,
             charmExperience,
         },
     };


### PR DESCRIPTION
#### Current Behavior
Achievement buffs from completed achievements are not reflected in profit calculations, efficiency displays, or rare find bonuses. Users cannot see how their achievements contribute to their action performance.

Issue: N/A

#### Changes
- Add `getAchievementBuffFlatBoost()` method to DataManager with caching for achievement buff lookups
- Apply achievement efficiency buffs to gathering and production profit calculations
- Include achievement rare find bonuses in bonus revenue calculations
- Display achievement contributions in efficiency breakdowns (e.g., "5.0% achievement")
- Display achievement contributions in rare find breakdowns
- Update action time displays, enhancement displays, and XP calculations to include achievement buffs
- Propagate achievement buff data through action calculator, bonus revenue calculator, and enhancement config utilities

#### Breaking Changes
None