### PR TITLE
💚 fix: resolve detached HEAD issue in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v6
               with:
-                  ref: ${{ github.event.workflow_run.head_sha }}
+                  ref: main
                   fetch-depth: 2 # Need previous commit to detect version changes
                   token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
#### Current Behavior
The release workflow fails when attempting to push version bump commits with the error "fatal: You are not currently on a branch." This occurs because the workflow checks out a specific commit SHA (`github.event.workflow_run.head_sha`), which puts Git in a detached HEAD state.

Issue: N/A

#### Changes
- Change checkout reference from `github.event.workflow_run.head_sha` to `main` branch
- Ensures Git is on a proper branch when committing and pushing version bumps

#### Breaking Changes
None