### PR TITLE
fix: restructure release-please config for monorepo format

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,30 +1,34 @@
 {
-    "release-type": "node",
-    "package-name": "toolasha",
-    "extra-files": [
-        {
-            "path": "userscript-header.txt",
-            "type": "regex",
-            "regex": "^// @version\\s+\\d+\\.\\d+\\.\\d+$",
-            "replacement": "// @version      {{version}}"
-        },
-        {
-            "path": "README.md",
-            "type": "regex",
-            "regex": "^!\\[Version\\]\\(https://img\\.shields\\.io/badge/version-\\d+\\.\\d+\\.\\d+-orange\\?style=flat-square\\)",
-            "replacement": "![Version](https://img.shields.io/badge/version-{{version}}-orange?style=flat-square)"
-        },
-        {
-            "path": "README.md",
-            "type": "regex",
-            "regex": "^\\*\\*Version\\*\\*: \\d+\\.\\d+\\.\\d+ \\(Pre-release\\)$",
-            "replacement": "**Version**: {{version}} (Pre-release)"
-        },
-        {
-            "path": "src/main.js",
-            "type": "regex",
-            "regex": "version: '\\d+\\.\\d+\\.\\d+',",
-            "replacement": "version: '{{version}}',"
+    "packages": {
+        ".": {
+            "release-type": "node",
+            "package-name": "toolasha",
+            "extra-files": [
+                {
+                    "path": "userscript-header.txt",
+                    "type": "regex",
+                    "regex": "^// @version\\s+\\d+\\.\\d+\\.\\d+$",
+                    "replacement": "// @version      {{version}}"
+                },
+                {
+                    "path": "README.md",
+                    "type": "regex",
+                    "regex": "^!\\[Version\\]\\(https://img\\.shields\\.io/badge/version-\\d+\\.\\d+\\.\\d+-orange\\?style=flat-square\\)",
+                    "replacement": "![Version](https://img.shields.io/badge/version-{{version}}-orange?style=flat-square)"
+                },
+                {
+                    "path": "README.md",
+                    "type": "regex",
+                    "regex": "^\\*\\*Version\\*\\*: \\d+\\.\\d+\\.\\d+ \\(Pre-release\\)$",
+                    "replacement": "**Version**: {{version}} (Pre-release)"
+                },
+                {
+                    "path": "src/main.js",
+                    "type": "regex",
+                    "regex": "version: '\\d+\\.\\d+\\.\\d+',",
+                    "replacement": "version: '{{version}}',"
+                }
+            ]
         }
-    ]
+    }
 }


### PR DESCRIPTION
#### Current Behavior
Release-please was showing warnings "Found release tag with component '', but not configured in manifest" and failing to detect commits for release PR creation. The configuration was using a flat structure instead of the required monorepo `packages` format.

Issue: N/A

#### Changes
- Restructure `.release-please-config.json` to use `packages` object with `"."` path
- Move `release-type`, `package-name`, and `extra-files` under `packages["."]"
- Maintains all existing configuration values, only changes structure

#### Breaking Changes
None