### PR TITLE
ci: add version sync script and integrate with release workflow

### DIFF
--- a/.github/workflows/format-release-please.yml
+++ b/.github/workflows/format-release-please.yml
@@ -28,6 +28,9 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
+            - name: Sync version across files
+              run: npm run version:sync
+
             - name: Run formatting
               run: npm run format
 
@@ -41,5 +44,5 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
                   git add -A
-                  git commit -m "chore: format release notes"
+                  git commit -m "chore: sync version and format release notes"
                   git push

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -2,33 +2,7 @@
     "packages": {
         ".": {
             "release-type": "node",
-            "package-name": "toolasha",
-            "extra-files": [
-                {
-                    "path": "userscript-header.txt",
-                    "type": "regex",
-                    "regex": "^// @version\\s+\\d+\\.\\d+\\.\\d+$",
-                    "replacement": "// @version      {{version}}"
-                },
-                {
-                    "path": "README.md",
-                    "type": "regex",
-                    "regex": "^!\\[Version\\]\\(https://img\\.shields\\.io/badge/version-\\d+\\.\\d+\\.\\d+-orange\\?style=flat-square\\)",
-                    "replacement": "![Version](https://img.shields.io/badge/version-{{version}}-orange?style=flat-square)"
-                },
-                {
-                    "path": "README.md",
-                    "type": "regex",
-                    "regex": "^\\*\\*Version\\*\\*: \\d+\\.\\d+\\.\\d+ \\(Pre-release\\)$",
-                    "replacement": "**Version**: {{version}} (Pre-release)"
-                },
-                {
-                    "path": "src/main.js",
-                    "type": "regex",
-                    "regex": "version: '\\d+\\.\\d+\\.\\d+',",
-                    "replacement": "version: '{{version}}',"
-                }
-            ]
+            "package-name": "toolasha"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "lint:md": "markdownlint \"**/*.md\" --ignore node_modules",
         "lint:md:fix": "markdownlint \"**/*.md\" --ignore node_modules --fix",
         "lint:md:links": "find . -name '*.md' ! -path './node_modules/*' -exec markdown-link-check --quiet {} \\;",
+        "version:sync": "node scripts/sync-version.js",
         "prepare": "husky"
     },
     "keywords": [

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * Version Sync Script
+ *
+ * Syncs version from package.json to all files that need version updates:
+ * - userscript-header.txt (userscript @version tag)
+ * - README.md (badge and footer version)
+ * - src/main.js (Toolasha.version property)
+ *
+ * This ensures all version references stay in sync automatically.
+ *
+ * Usage:
+ *   node scripts/sync-version.js
+ *   npm run version:sync
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, '..');
+
+function syncVersion() {
+    try {
+        // Read version from package.json (source of truth)
+        const packageJsonPath = join(rootDir, 'package.json');
+        const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+        const version = packageJson.version;
+
+        if (!version) {
+            console.error('❌ Error: No version found in package.json');
+            process.exit(1);
+        }
+
+        let filesUpdated = [];
+
+        // 1. Update userscript-header.txt
+        const headerPath = join(rootDir, 'userscript-header.txt');
+        let headerContent = readFileSync(headerPath, 'utf8');
+        const headerRegex = /^(\/\/ @version\s+)[\d.]+$/m;
+
+        if (!headerRegex.test(headerContent)) {
+            console.error('❌ Error: Could not find @version line in userscript-header.txt');
+            process.exit(1);
+        }
+
+        const updatedHeader = headerContent.replace(headerRegex, `$1${version}`);
+        if (updatedHeader !== headerContent) {
+            writeFileSync(headerPath, updatedHeader, 'utf8');
+            filesUpdated.push('userscript-header.txt');
+        }
+
+        // 2. Update README.md (badge and footer)
+        const readmePath = join(rootDir, 'README.md');
+        let readmeContent = readFileSync(readmePath, 'utf8');
+
+        // Update badge: ![Version](https://img.shields.io/badge/version-X.X.X-orange?style=flat-square)
+        const badgeRegex = /(!\[Version\]\(https:\/\/img\.shields\.io\/badge\/version-)[\d.]+(-.+?\))/;
+        // Update footer: **Version:** X.X.X (Pre-release)
+        const footerRegex = /(\*\*Version:\*\* )[\d.]+( \(Pre-release\))/;
+
+        let updatedReadme = readmeContent;
+        updatedReadme = updatedReadme.replace(badgeRegex, `$1${version}$2`);
+        updatedReadme = updatedReadme.replace(footerRegex, `$1${version}$2`);
+
+        if (updatedReadme !== readmeContent) {
+            writeFileSync(readmePath, updatedReadme, 'utf8');
+            filesUpdated.push('README.md');
+        }
+
+        // 3. Update src/main.js (Toolasha.version property)
+        const mainJsPath = join(rootDir, 'src', 'main.js');
+        let mainJsContent = readFileSync(mainJsPath, 'utf8');
+
+        // Match: version: 'X.X.X',
+        const mainJsRegex = /(version:\s+['"])[\d.]+(['"],)/;
+
+        if (!mainJsRegex.test(mainJsContent)) {
+            console.error('❌ Error: Could not find version property in src/main.js');
+            process.exit(1);
+        }
+
+        const updatedMainJs = mainJsContent.replace(mainJsRegex, `$1${version}$2`);
+        if (updatedMainJs !== mainJsContent) {
+            writeFileSync(mainJsPath, updatedMainJs, 'utf8');
+            filesUpdated.push('src/main.js');
+        }
+
+        // Report results
+        if (filesUpdated.length === 0) {
+            console.log(`✅ All files already at version ${version}`);
+        } else {
+            console.log(`✅ Version synced to ${version}`);
+            console.log(`   Updated files:`);
+            filesUpdated.forEach((file) => console.log(`   - ${file}`));
+            console.log(`   (dist/Toolasha.user.js will be updated on next build)`);
+        }
+    } catch (error) {
+        console.error('❌ Error syncing version:', error.message);
+        process.exit(1);
+    }
+}
+
+syncVersion();


### PR DESCRIPTION
#### Current Behavior
Release-please updates package.json version, but other files (userscript-header.txt, README.md, src/main.js) remain out of sync, requiring manual updates after each release.

Issue: N/A

#### Changes
- Add `scripts/sync-version.js` to automatically sync version from package.json to all version-dependent files
- Add `version:sync` npm script for manual version synchronization
- Integrate version sync into `format-release-please.yml` workflow to run automatically on release PRs
- Update workflow commit message to reflect both version sync and formatting

#### Breaking Changes
None