### PR TITLE
fix: create corrrect commit messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,3 +205,7 @@ Key rules enforced (see `eslint.config.js` for full list):
 - `no-eval: error` - No eval()
 - `prefer-const: warn` - Use const when not reassigned
 - `no-duplicate-imports: error` - No duplicate imports
+
+## Commit message rules
+
+- For commits that will result in a new release the commit message should just be "release <version>"


### PR DESCRIPTION
The last commit claude did that should have created a release had an extra word in it, which caused aut-pushing to greasyfork to break. Hopefully this will keep claude from trying to add extra words again.