### PR TITLE
fix: prevent CI from double-triggering on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ on:
 jobs:
     lint-and-build:
         if: >
-            github.event_name == 'workflow_run' ||
-            !startsWith(github.head_ref, 'release-please--')
+            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+            (github.event_name != 'workflow_run' && !startsWith(github.head_ref, 'release-please--'))
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code


### PR DESCRIPTION
#### Current Behavior
CI workflow runs twice on regular PRs. The "Format Release Please" workflow triggers on all PRs but skips its job for non-release-please branches. However, the workflow still "completes" with a skipped status, which fires the `workflow_run` trigger in CI, causing a second run.

Issue: N/A

#### Changes
- Add `conclusion == 'success'` check to the CI workflow_run condition
- Restructure job condition to only run via workflow_run when Format Release Please actually succeeded (not just skipped)

#### Breaking Changes
None