### PR TITLE
ci: add releases branch for Greasyfork webhook sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,30 @@ jobs:
               if: ${{ steps.release.outputs.release_created }}
               run: npm run build
 
+            - name: Commit built file to releases branch
+              if: ${{ steps.release.outputs.release_created }}
+              run: |
+                  # Configure git
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  # Save the built file
+                  cp dist/Toolasha.user.js /tmp/Toolasha.user.js
+
+                  # Fetch and checkout releases branch (create if doesn't exist)
+                  git fetch origin releases:releases 2>/dev/null || git checkout --orphan releases
+                  git checkout releases 2>/dev/null || git checkout --orphan releases
+
+                  # Clean the branch and add only the built file
+                  git rm -rf . 2>/dev/null || true
+                  mkdir -p dist
+                  cp /tmp/Toolasha.user.js dist/Toolasha.user.js
+                  git add dist/Toolasha.user.js
+
+                  # Commit and push
+                  git commit -m "chore(main): release ${{ steps.release.outputs.version }}"
+                  git push origin releases
+
             - name: Upload userscript and publish release
               if: ${{ steps.release.outputs.release_created }}
               uses: softprops/action-gh-release@v2


### PR DESCRIPTION
#### Current Behavior
Greasyfork's webhook for release assets doesn't actually download from release asset URLs - it fetches files from the git repository at the release tag. Since `dist/Toolasha.user.js` is a build artifact that only exists as a release asset (not committed to git), Greasyfork silently fails to update the script when a release is published.

Issue: N/A

#### Changes
- Add workflow step to commit the built `dist/Toolasha.user.js` to a dedicated `releases` branch on each release
- The `releases` branch is an orphan branch containing only the built userscript
- Commit message follows conventional format: `chore(main): release x.y.z`

#### Breaking Changes
None

#### Post-merge steps
After this is merged and a release is created:
1. Update Greasyfork sync URL to: `https://raw.githubusercontent.com/Celasha/Toolasha/releases/dist/Toolasha.user.js`
2. Webhook can remain configured for release events (or add push events for the `releases` branch)