### PR TITLE
fix: skip CI on unformatted release-please commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,14 @@ on:
 
 jobs:
     lint-and-build:
+        # Run CI when:
+        # - push: normal commits (not release-please's unformatted commits)
+        # - pull_request: normal PRs (not release-please branches)
+        # - workflow_run: after Format Release Please completes (for release-please PRs)
         if: >
-            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-            (github.event_name != 'workflow_run' && !startsWith(github.head_ref, 'release-please--'))
+            (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(main): release')) ||
+            (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--')) ||
+            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
@@ -24,7 +29,8 @@ jobs:
               if: github.event_name == 'workflow_run'
               uses: actions/checkout@v6
               with:
-                  ref: ${{ github.event.workflow_run.head_sha }}
+                  # Use head_branch to get latest commit including formatting changes
+                  ref: ${{ github.event.workflow_run.head_branch }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v6


### PR DESCRIPTION
#### Current Behavior
When release-please PRs are merged to main, CI runs on both commits (the original release commit and the formatting commit). The CI fails on the unformatted release-please commit before the formatting workflow has a chance to run.

Issue: N/A

#### Changes
- Skip CI on push events when commit message starts with `chore(main): release` (unformatted release-please commits)
- Skip CI on pull_request events from `release-please--*` branches (wait for formatting workflow)
- Add workflow_run trigger to run CI after Format Release Please workflow completes
- Update checkout ref to use `head_branch` instead of `head_sha` to get latest formatted commit

#### Breaking Changes
None