### PR TITLE
chore: add bootstrap-sha to fix release-please version tracking

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,7 +5,8 @@
             "package-name": "toolasha",
             "component": "Toolasha",
             "include-component-in-tag": false,
-            "draft": true
+            "draft": true,
+            "bootstrap-sha": "ed1fb8f6dbb6e7f0f1c29a3917632c5e26459a72"
         }
     }
 }


### PR DESCRIPTION
#### Current Behavior
Release Please keeps creating PRs for version 0.6.2 instead of the correct next version after 0.8.1. This happens because old release commits used a different component name format (`release toolasha X.Y.Z` vs `release X.Y.Z`), causing Release Please to get confused about version history.

Issue: N/A

#### Changes
- Add `bootstrap-sha` to `.release-please-config.json` pointing to v0.8.1 release commit
- This tells Release Please to ignore all commit history before v0.8.1, preventing version calculation errors from the old component name format

#### Breaking Changes
None