### PR TITLE
ci: add force-tag-creation to fix release-please version detection

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,7 +6,8 @@
             "component": "Toolasha",
             "include-component-in-tag": false,
             "draft": true,
-            "bootstrap-sha": "ed1fb8f6dbb6e7f0f1c29a3917632c5e26459a72"
+            "bootstrap-sha": "ed1fb8f6dbb6e7f0f1c29a3917632c5e26459a72",
+            "force-tag-creation": true
         }
     }
 }


### PR DESCRIPTION
#### Current Behavior
Release Please keeps creating PRs for version 0.6.2 instead of the correct next version (0.8.4). The root cause is that with `draft: true`, GitHub doesn't create git tags until releases are published. Without tags, Release Please can't find the previous release and falls back to incorrect version calculation.

Issue: N/A

#### Changes
- Add `force-tag-creation: true` to `.release-please-config.json`
- This ensures git tags are created immediately when draft releases are created, allowing Release Please to correctly detect the previous version

#### Breaking Changes
None