### PR TITLE
fix: correct version sync regex for README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ npm test -- --coverage # Coverage report
 **Original Author**: bot7420 (MWITools)  
 **Rewrite & Maintenance**: Celasha and Claude
 
-**Version**: 0.6.2 (Pre-release)
+**Version**: 0.9.2 (Pre-release)
 
 ---
 

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -59,8 +59,8 @@ function syncVersion() {
 
         // Update badge: ![Version](https://img.shields.io/badge/version-X.X.X-orange?style=flat-square)
         const badgeRegex = /(!\[Version\]\(https:\/\/img\.shields\.io\/badge\/version-)[\d.]+(-.+?\))/;
-        // Update footer: **Version:** X.X.X (Pre-release)
-        const footerRegex = /(\*\*Version:\*\* )[\d.]+( \(Pre-release\))/;
+        // Update footer: **Version**: X.X.X (Pre-release)
+        const footerRegex = /(\*\*Version\*\*: )[\d.]+( \(Pre-release\))/;
 
         let updatedReadme = readmeContent;
         updatedReadme = updatedReadme.replace(badgeRegex, `$1${version}$2`);


### PR DESCRIPTION
#### Current Behavior
The version sync script fails to update the README footer version because the regex pattern expects `**Version:** ` (colon inside bold markers) but the README actually uses `**Version**: ` (colon outside bold markers).

Issue: N/A

#### Changes
- Fix regex pattern in `scripts/sync-version.js` to match actual README footer format (`**Version**:` instead of `**Version:**`)
- Update README.md footer version from 0.6.2 to 0.9.2 using the corrected sync script

#### Breaking Changes
None