### PR TITLE
feat(tasks): rank task efficiency colors by relative profit

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -244,7 +244,7 @@ class Config {
                 enabled: true,
                 name: 'Task Efficiency Rating',
                 category: 'Tasks',
-                description: 'Shows tokens or gold value per hour on task cards',
+                description: 'Shows tokens or profit per hour on task cards',
                 settingKey: 'taskEfficiencyRating',
             },
             taskRerollTracker: {

--- a/src/features/settings/settings-config.js
+++ b/src/features/settings/settings-config.js
@@ -547,7 +547,7 @@ export const settingsGroups = {
             },
             taskEfficiencyRating: {
                 id: 'taskEfficiencyRating',
-                label: 'Show task efficiency rating (tokens/gold per hour)',
+                label: 'Show task efficiency rating (tokens/profit per hour)',
                 type: 'checkbox',
                 default: true,
                 help: 'Displays a color-graded efficiency score based on expected completion time.',
@@ -556,13 +556,21 @@ export const settingsGroups = {
                 id: 'taskEfficiencyRatingMode',
                 label: '  └─ Efficiency algorithm',
                 type: 'select',
-                default: 'tokens',
+                default: 'gold',
                 options: [
                     { value: 'tokens', label: 'Task tokens per hour' },
-                    { value: 'gold', label: 'Task reward gold value per hour' },
+                    { value: 'gold', label: 'Task profit per hour' },
                 ],
                 dependencies: ['taskEfficiencyRating'],
-                help: 'Choose whether to rate by task token payout or expected gold value.',
+                help: 'Choose whether to rate by task token payout or total profit.',
+            },
+            taskEfficiencyGradient: {
+                id: 'taskEfficiencyGradient',
+                label: '  └─ Use relative gradient colors',
+                type: 'checkbox',
+                default: false,
+                dependencies: ['taskEfficiencyRating'],
+                help: 'Colors efficiency ratings relative to visible tasks.',
             },
             taskRerollTracker: {
                 id: 'taskRerollTracker',


### PR DESCRIPTION
#### Current Behavior
Task efficiency ratings use fixed thresholds, so most values appear at the extremes and do not reflect relative performance.

Issue: N/A

#### Changes
- Use total task profit for gold/hr efficiency
- Rank visible task ratings per mode to drive relative gradient colors
- Add a toggle for relative gradient colors and default profit/hr rating

#### Breaking Changes
None