### PR TITLE
ci: conditionally skip release-please PR on merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
                   token: ${{ secrets.PAT }}
                   config-file: .release-please-config.json
                   manifest-file: .release-please-manifest.json
+                  skip-github-pull-request: ${{ startsWith(github.event.head_commit.message, 'Merge pull request') && contains(github.event.head_commit.message, 'release-please--') }}
 
             # Build and upload assets if a release was created
             - name: Checkout code


### PR DESCRIPTION
#### Current Behavior
Release-please opens a new release PR immediately after merging a release-please PR, which can re-trigger version calculations and create noise.

Issue: N/A

#### Changes
- Skip release-please PR creation when the push is a merge commit from a release-please branch

#### Breaking Changes
None