### PR TITLE
fix: correct release pinning SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,7 @@ jobs:
 
                   # Pin entrypoint @require URLs to the library commit SHA
                   lib_sha=$(git rev-parse HEAD)
-                  node -e "const fs=require('fs');const path='dist/Toolasha.user.js';const base='https://raw.githubusercontent.com/${{ github.repository }}/'+process.env.LIB_SHA+'/dist/libraries/';const content=fs.readFileSync(path,'utf8');const updated=content.split('https://UPDATE-THIS-URL/').join(base);fs.writeFileSync(path,updated);" \
-                    LIB_SHA="$lib_sha"
+                  LIB_SHA="$lib_sha" node -e "const fs=require('fs');const path='dist/Toolasha.user.js';const base='https://raw.githubusercontent.com/${{ github.repository }}/'+process.env.LIB_SHA+'/dist/libraries/';const content=fs.readFileSync(path,'utf8');const updated=content.split('https://UPDATE-THIS-URL/').join(base);fs.writeFileSync(path,updated);"
 
                   git add dist/Toolasha.user.js
                   git commit -m "chore(main): pin library requires ${{ steps.release.outputs.version }}"


### PR DESCRIPTION
## Summary
- fix release workflow to set LIB_SHA env before pinning @require URLs
- prevents undefined raw GitHub URLs in entrypoint

## Testing
- not run (workflow change only)