### PR TITLE
fix: use jsdelivr for pinned library URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
 
                   # Pin entrypoint @require URLs to the library commit SHA
                   lib_sha=$(git rev-parse HEAD)
-                  LIB_SHA="$lib_sha" node -e "const fs=require('fs');const path='dist/Toolasha.user.js';const base='https://raw.githubusercontent.com/${{ github.repository }}/'+process.env.LIB_SHA+'/dist/libraries/';const content=fs.readFileSync(path,'utf8');const updated=content.split('https://UPDATE-THIS-URL/').join(base);fs.writeFileSync(path,updated);"
+                  LIB_SHA="$lib_sha" node -e "const fs=require('fs');const path='dist/Toolasha.user.js';const base='https://cdn.jsdelivr.net/gh/${{ github.repository }}@'+process.env.LIB_SHA+'/dist/libraries/';const content=fs.readFileSync(path,'utf8');const updated=content.split('https://UPDATE-THIS-URL/').join(base);fs.writeFileSync(path,updated);"
 
                   git add dist/Toolasha.user.js
                   git commit -m "chore(main): pin library requires ${{ steps.release.outputs.version }}"


### PR DESCRIPTION
## Summary
- switch pinned @require URL base to jsDelivr commit-specific URLs (GF-approved CDN)

## Testing
- not run (workflow change only)