### PR TITLE
ci: simplify workflow triggers and prevent duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,32 +5,19 @@ on:
         branches: [main]
     pull_request:
         branches: [main]
-    workflow_run:
-        workflows: ['Format Release Please']
-        types: [completed]
 
 jobs:
     lint-and-build:
         # Run CI when:
-        # - push: normal commits (not release-please's unformatted commits)
-        # - pull_request: normal PRs (not release-please branches)
-        # - workflow_run: after Format Release Please completes (for release-please PRs)
+        # - push: normal commits (not release-please's release commits)
+        # - pull_request: normal PRs immediately, release-please PRs only after formatting
         if: >
             (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(main): release')) ||
-            (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--')) ||
-            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+            (github.event_name == 'pull_request' && (!startsWith(github.head_ref, 'release-please--') || contains(github.event.head_commit.message, 'chore: sync version and format')))
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              if: github.event_name != 'workflow_run'
               uses: actions/checkout@v6
-
-            - name: Checkout code (workflow_run)
-              if: github.event_name == 'workflow_run'
-              uses: actions/checkout@v6
-              with:
-                  # Use head_branch to get latest commit including formatting changes
-                  ref: ${{ github.event.workflow_run.head_branch }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v6

--- a/.github/workflows/format-release-please.yml
+++ b/.github/workflows/format-release-please.yml
@@ -9,9 +9,10 @@ permissions:
 
 jobs:
     format-release-notes:
-        if: startsWith(github.head_ref, 'release-please--')
+        if: |
+            startsWith(github.head_ref, 'release-please--') &&
+            github.actor != 'github-actions[bot]'
         runs-on: ubuntu-latest
-
         steps:
             - name: Checkout code
               uses: actions/checkout@v6


### PR DESCRIPTION
#### Current Behavior
The CI workflow uses complex `workflow_run` triggers and conditional logic to handle release-please branches. The format-release-please workflow runs twice - once on the initial PR commit and again on its own formatting commit, wasting CI resources.

Issue: N/A

#### Changes
- Remove `workflow_run` trigger from CI workflow
- Simplify CI conditions to run on release-please PRs only after formatting completes
- Add `github.actor != 'github-actions[bot]'` check to format-release-please workflow to prevent running on its own commits
- Remove conditional checkout logic for workflow_run events

#### Breaking Changes
None