### PR TITLE
fix: correct feature registry key for skillRemainingXP toggle

### DIFF
--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -280,7 +280,7 @@ function registerFeatures() {
         },
         { key: 'taskSorter', name: 'Task Sorter', category: 'Tasks', module: UI.taskSorter, async: false },
         { key: 'taskIcons', name: 'Task Icons', category: 'Tasks', module: UI.taskIcons, async: false },
-        { key: 'remainingXP', name: 'Remaining XP', category: 'Skills', module: UI.remainingXP, async: false },
+        { key: 'skillRemainingXP', name: 'Remaining XP', category: 'Skills', module: UI.remainingXP, async: false },
         {
             key: 'housePanelObserver',
             name: 'House Panel Observer',


### PR DESCRIPTION
#### Current Behavior
The "Left sidebar: Show remaining XP to next level" toggle in settings does not work. The feature is always enabled regardless of the toggle state due to a key mismatch between the feature registry and config/settings.

Issue: N/A

#### Changes
- Change feature registry key from `'remainingXP'` to `'skillRemainingXP'` in `src/entrypoint.js` to match the config and settings schema

#### Breaking Changes
None