### PR TITLE
docs: organize investigation files and add root file validation

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 node scripts/check-version-bump.js
+node scripts/check-root-files.js
 npx lint-staged

--- a/scripts/check-root-files.js
+++ b/scripts/check-root-files.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * Pre-commit hook to prevent unauthorized .txt and .md files at project root.
+ * Helps maintain clean project structure by ensuring documentation and data files
+ * are organized in appropriate directories.
+ */
+
+import { execSync } from 'child_process';
+import { readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+// Allowed files at project root
+const ALLOWED_FILES = new Set([
+    'README.md',
+    'CHANGELOG.md',
+    'CONTRIBUTING.md',
+    'LICENSE.md',
+    'AGENTS.md',
+    'CLAUDE.md',
+    'DOCUMENTATION.md',
+    'FEATURES.md',
+    'MWI-TOOLS-CHANGELOG.md',
+    'userscript-header.txt',
+]);
+
+// Get all staged files
+const stagedFiles = execSync('git diff --cached --name-only', { encoding: 'utf-8' }).split('\n').filter(Boolean);
+
+// Check for root-level .txt and .md files in staged changes
+const unauthorizedFiles = stagedFiles.filter((file) => {
+    // Only check files at root (no directory separator)
+    if (file.includes('/')) {
+        return false;
+    }
+
+    // Check if it's a .txt or .md file
+    if (!file.endsWith('.txt') && !file.endsWith('.md')) {
+        return false;
+    }
+
+    // Check if it's in the allowed list
+    return !ALLOWED_FILES.has(file);
+});
+
+if (unauthorizedFiles.length > 0) {
+    console.error('\x1b[31m%s\x1b[0m', '❌ Error: Unauthorized files at project root detected');
+    console.error('');
+    console.error('The following files should not be at the project root:');
+    unauthorizedFiles.forEach((file) => {
+        console.error(`  - ${file}`);
+    });
+    console.error('');
+    console.error('Please move these files to appropriate directories:');
+    console.error('  • Documentation: docs/');
+    console.error('  • Investigations: docs/archive/investigations/');
+    console.error('  • Planning: docs/planning/');
+    console.error('  • Proposals: docs/archive/proposals/');
+    console.error('');
+    console.error('To unstage these files:');
+    unauthorizedFiles.forEach((file) => {
+        console.error(`  git reset HEAD ${file}`);
+    });
+    process.exit(1);
+}
+
+process.exit(0);


### PR DESCRIPTION
#### Current Behavior
The project root was accumulating loose `.txt` and `.md` files (investigation notes, data dumps, analysis documents) with no enforcement to keep them organized. This made it difficult to maintain a clean project structure.

Issue: N/A

#### Changes
- Move investigation files to `docs/archive/investigations/` directory
- Rename data files with `.json` extension for clarity (edible-data-1-31-26.json, edible-data-downloads-v2.json)
- Remove generic `optimize.md` template that wasn't project-specific
- Add pre-commit hook (`scripts/check-root-files.js`) to prevent unauthorized `.txt`/`.md` files at project root
- Update `.husky/pre-commit` to run the new validation check
- Maintain allowlist for essential root files (README.md, CHANGELOG.md, AGENTS.md, etc.)

#### Breaking Changes
None