### PR TITLE
feat: add disconnect-aware runtime behavior

### DIFF
--- a/src/api/marketplace.test.js
+++ b/src/api/marketplace.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+
+const createMocks = (isConnected) => {
+    vi.doMock('../core/connection-state.js', () => ({
+        default: {
+            isConnected: vi.fn(() => isConnected),
+        },
+    }));
+
+    const getJSON = vi.fn();
+    vi.doMock('../core/storage.js', () => ({
+        default: {
+            getJSON,
+            setJSON: vi.fn(),
+        },
+    }));
+
+    vi.doMock('../features/market/network-alert.js', () => ({
+        default: {
+            hide: vi.fn(),
+            show: vi.fn(),
+        },
+    }));
+
+    return { getJSON };
+};
+
+describe('MarketAPI fetch', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    test('returns cached data when disconnected', async () => {
+        // Arrange
+        const cachedPayload = {
+            marketData: { items: [] },
+            timestamp: 123,
+        };
+        const { getJSON } = createMocks(false);
+        getJSON.mockResolvedValue(cachedPayload);
+
+        const { default: marketAPI } = await import('./marketplace.js');
+
+        // Act
+        const result = await marketAPI.fetch(true);
+
+        // Assert
+        expect(result).toEqual(cachedPayload.marketData);
+        expect(getJSON).toHaveBeenCalled();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    test('returns null when disconnected without cache', async () => {
+        // Arrange
+        const { getJSON } = createMocks(false);
+        getJSON.mockResolvedValue(null);
+
+        const { default: marketAPI } = await import('./marketplace.js');
+
+        // Act
+        const result = await marketAPI.fetch(true);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/connection-state.js
+++ b/src/core/connection-state.js
@@ -1,0 +1,166 @@
+import webSocketHook from './websocket.js';
+
+const CONNECTION_STATES = {
+    CONNECTED: 'connected',
+    DISCONNECTED: 'disconnected',
+    RECONNECTING: 'reconnecting',
+};
+
+class ConnectionState {
+    constructor() {
+        this.state = CONNECTION_STATES.RECONNECTING;
+        this.eventListeners = new Map();
+        this.lastDisconnectedAt = null;
+        this.lastConnectedAt = null;
+
+        this.setupListeners();
+    }
+
+    /**
+     * Get current connection state
+     * @returns {string} Connection state (connected, disconnected, reconnecting)
+     */
+    getState() {
+        return this.state;
+    }
+
+    /**
+     * Check if currently connected
+     * @returns {boolean} True if connected
+     */
+    isConnected() {
+        return this.state === CONNECTION_STATES.CONNECTED;
+    }
+
+    /**
+     * Register a listener for connection events
+     * @param {string} event - Event name (disconnected, reconnected)
+     * @param {Function} callback - Handler function
+     */
+    on(event, callback) {
+        if (!this.eventListeners.has(event)) {
+            this.eventListeners.set(event, []);
+        }
+        this.eventListeners.get(event).push(callback);
+    }
+
+    /**
+     * Unregister a connection event listener
+     * @param {string} event - Event name
+     * @param {Function} callback - Handler function to remove
+     */
+    off(event, callback) {
+        const listeners = this.eventListeners.get(event);
+        if (listeners) {
+            const index = listeners.indexOf(callback);
+            if (index > -1) {
+                listeners.splice(index, 1);
+            }
+        }
+    }
+
+    /**
+     * Notify connection state from character initialization
+     * @param {Object} data - Character initialization payload
+     */
+    handleCharacterInitialized(data) {
+        if (!data) {
+            return;
+        }
+
+        this.setConnected('character_initialized');
+    }
+
+    setupListeners() {
+        webSocketHook.onSocketEvent('open', () => {
+            this.setReconnecting('socket_open', { allowConnected: true });
+        });
+
+        webSocketHook.onSocketEvent('close', (event) => {
+            this.setDisconnected('socket_close', event);
+        });
+
+        webSocketHook.onSocketEvent('error', (event) => {
+            this.setDisconnected('socket_error', event);
+        });
+
+        webSocketHook.on('init_character_data', () => {
+            this.setConnected('init_character_data');
+        });
+    }
+
+    setReconnecting(reason, options = {}) {
+        if (this.state === CONNECTION_STATES.CONNECTED && !options.allowConnected) {
+            return;
+        }
+
+        this.updateState(CONNECTION_STATES.RECONNECTING, {
+            reason,
+        });
+    }
+
+    setDisconnected(reason, event) {
+        if (this.state === CONNECTION_STATES.DISCONNECTED) {
+            return;
+        }
+
+        this.lastDisconnectedAt = Date.now();
+        this.updateState(CONNECTION_STATES.DISCONNECTED, {
+            reason,
+            event,
+            disconnectedAt: this.lastDisconnectedAt,
+        });
+    }
+
+    setConnected(reason) {
+        if (this.state === CONNECTION_STATES.CONNECTED) {
+            return;
+        }
+
+        this.lastConnectedAt = Date.now();
+        this.updateState(CONNECTION_STATES.CONNECTED, {
+            reason,
+            disconnectedAt: this.lastDisconnectedAt,
+            connectedAt: this.lastConnectedAt,
+        });
+    }
+
+    updateState(nextState, details) {
+        if (this.state === nextState) {
+            return;
+        }
+
+        const previousState = this.state;
+        this.state = nextState;
+
+        if (nextState === CONNECTION_STATES.DISCONNECTED) {
+            this.emit('disconnected', {
+                previousState,
+                ...details,
+            });
+            return;
+        }
+
+        if (nextState === CONNECTION_STATES.CONNECTED) {
+            this.emit('reconnected', {
+                previousState,
+                ...details,
+            });
+        }
+    }
+
+    emit(event, data) {
+        const listeners = this.eventListeners.get(event) || [];
+        for (const listener of listeners) {
+            try {
+                listener(data);
+            } catch (error) {
+                console.error('[ConnectionState] Listener error:', error);
+            }
+        }
+    }
+}
+
+const connectionState = new ConnectionState();
+
+export default connectionState;

--- a/src/core/connection-state.test.js
+++ b/src/core/connection-state.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+let messageHandlers;
+let socketHandlers;
+
+vi.mock('./websocket.js', () => {
+    messageHandlers = new Map();
+    socketHandlers = new Map();
+
+    return {
+        default: {
+            on: vi.fn((event, handler) => {
+                messageHandlers.set(event, handler);
+            }),
+            onSocketEvent: vi.fn((event, handler) => {
+                socketHandlers.set(event, handler);
+            }),
+        },
+    };
+});
+
+beforeEach(() => {
+    vi.resetModules();
+});
+
+describe('ConnectionState', () => {
+    test('transitions to connected on init_character_data', async () => {
+        // Arrange
+        const { default: connectionState } = await import('./connection-state.js');
+        const onReconnected = vi.fn();
+        connectionState.on('reconnected', onReconnected);
+
+        // Act
+        const handler = messageHandlers.get('init_character_data');
+        handler({});
+
+        // Assert
+        expect(connectionState.isConnected()).toBe(true);
+        expect(onReconnected).toHaveBeenCalledTimes(1);
+    });
+
+    test('moves to reconnecting on socket open after connected', async () => {
+        // Arrange
+        const { default: connectionState } = await import('./connection-state.js');
+        const initHandler = messageHandlers.get('init_character_data');
+        const openHandler = socketHandlers.get('open');
+
+        // Act
+        initHandler({});
+        openHandler({});
+
+        // Assert
+        expect(connectionState.isConnected()).toBe(false);
+        expect(connectionState.getState()).toBe('reconnecting');
+    });
+
+    test('emits disconnected on socket close', async () => {
+        // Arrange
+        const { default: connectionState } = await import('./connection-state.js');
+        const onDisconnected = vi.fn();
+        connectionState.on('disconnected', onDisconnected);
+
+        // Act
+        const closeHandler = socketHandlers.get('close');
+        closeHandler({ code: 1006 });
+
+        // Assert
+        expect(connectionState.getState()).toBe('disconnected');
+        expect(onDisconnected).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/core/data-manager.js
+++ b/src/core/data-manager.js
@@ -7,6 +7,7 @@
  */
 
 import webSocketHook from './websocket.js';
+import connectionState from './connection-state.js';
 import storage from './storage.js';
 import { mergeMarketListings } from '../utils/market-listings.js';
 
@@ -130,6 +131,7 @@ class DataManager {
 
                             // Fire character_initialized event
                             this.emit('character_initialized', characterData);
+                            connectionState.handleCharacterInitialized(characterData);
 
                             // Stop polling
                             stopFallbackInterval();
@@ -283,6 +285,7 @@ class DataManager {
 
             // Emit character_initialized event (trigger feature initialization)
             this.emit('character_initialized', data);
+            connectionState.handleCharacterInitialized(data);
         });
 
         // Handle actions_updated (action queue changes)

--- a/src/core/data-manager.test.js
+++ b/src/core/data-manager.test.js
@@ -19,6 +19,8 @@ vi.mock('./websocket.js', () => {
                     webSocketHandlers.delete(event);
                 }
             }),
+            onSocketEvent: vi.fn(),
+            offSocketEvent: vi.fn(),
         },
     };
 });

--- a/src/utils/pause-registry.js
+++ b/src/utils/pause-registry.js
@@ -1,0 +1,137 @@
+import connectionState from '../core/connection-state.js';
+
+/**
+ * Create a pause registry for deterministic pause/resume handling.
+ * @param {{ connectionState?: { on: Function, off: Function } }} [options] - Optional dependency overrides.
+ * @returns {{
+ *   register: (id: string, pauseFn: Function, resumeFn: Function) => void,
+ *   unregister: (id: string) => void,
+ *   pauseAll: () => void,
+ *   resumeAll: () => void,
+ *   cleanup: () => void
+ * }} Pause registry API
+ */
+export function createPauseRegistry(options = {}) {
+    const registry = new Map();
+    const connectionStateRef = options.connectionState || connectionState;
+    let isPaused = false;
+
+    const normalizeId = (id) => (typeof id === 'string' ? id.trim() : id);
+    const isValidId = (id) => typeof id === 'string' && id.trim().length > 0;
+
+    /**
+     * Register pausable work by unique id.
+     * @param {string} id - Unique identifier for the pausable work.
+     * @param {Function} pauseFn - Callback invoked on pause.
+     * @param {Function} resumeFn - Callback invoked on resume.
+     */
+    const register = (id, pauseFn, resumeFn) => {
+        if (!isValidId(id) || typeof pauseFn !== 'function' || typeof resumeFn !== 'function') {
+            console.warn('[PauseRegistry] register called with invalid arguments');
+            return;
+        }
+
+        const normalizedId = normalizeId(id);
+        if (registry.has(normalizedId)) {
+            console.warn(`[PauseRegistry] register called with duplicate id: ${normalizedId}`);
+        }
+
+        registry.set(normalizedId, { pauseFn, resumeFn });
+
+        if (isPaused) {
+            try {
+                pauseFn();
+            } catch (error) {
+                console.error(`[PauseRegistry] Failed to pause '${normalizedId}' during register:`, error);
+            }
+        }
+    };
+
+    /**
+     * Unregister pausable work by id.
+     * Note: Unregister does not auto-resume if currently paused.
+     * @param {string} id - Identifier to remove.
+     */
+    const unregister = (id) => {
+        if (!isValidId(id)) {
+            console.warn('[PauseRegistry] unregister called with invalid id');
+            return;
+        }
+
+        registry.delete(normalizeId(id));
+    };
+
+    const callAll = (actionLabel, handlerKey) => {
+        for (const [entryId, entry] of registry.entries()) {
+            const handler = entry[handlerKey];
+            if (typeof handler !== 'function') {
+                continue;
+            }
+
+            try {
+                handler();
+            } catch (error) {
+                console.error(`[PauseRegistry] Failed to ${actionLabel} '${entryId}':`, error);
+            }
+        }
+    };
+
+    /**
+     * Pause all registered work.
+     */
+    const pauseAll = () => {
+        if (isPaused) {
+            return;
+        }
+
+        isPaused = true;
+        callAll('pause', 'pauseFn');
+    };
+
+    /**
+     * Resume all registered work.
+     */
+    const resumeAll = () => {
+        if (!isPaused) {
+            return;
+        }
+
+        isPaused = false;
+        callAll('resume', 'resumeFn');
+    };
+
+    const handleDisconnected = () => {
+        pauseAll();
+    };
+
+    const handleReconnected = () => {
+        resumeAll();
+    };
+
+    if (connectionStateRef && typeof connectionStateRef.on === 'function') {
+        connectionStateRef.on('disconnected', handleDisconnected);
+        connectionStateRef.on('reconnected', handleReconnected);
+    } else {
+        console.warn('[PauseRegistry] connectionState unavailable; pause/resume events not wired');
+    }
+
+    /**
+     * Cleanup registry subscriptions.
+     */
+    const cleanup = () => {
+        if (!connectionStateRef || typeof connectionStateRef.off !== 'function') {
+            return;
+        }
+
+        connectionStateRef.off('disconnected', handleDisconnected);
+        connectionStateRef.off('reconnected', handleReconnected);
+    };
+
+    return {
+        register,
+        unregister,
+        pauseAll,
+        resumeAll,
+        cleanup,
+    };
+}

--- a/src/utils/pause-registry.test.js
+++ b/src/utils/pause-registry.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { createPauseRegistry } from './pause-registry.js';
+
+const createConnectionStateStub = () => {
+    const handlers = {};
+
+    return {
+        handlers,
+        connectionState: {
+            on: vi.fn((event, handler) => {
+                handlers[event] = handler;
+            }),
+            off: vi.fn((event) => {
+                delete handlers[event];
+            }),
+        },
+    };
+};
+
+describe('pause registry', () => {
+    test('pauses and resumes registered work on connection events', () => {
+        // Arrange
+        const { handlers, connectionState } = createConnectionStateStub();
+        const pauseFn = vi.fn();
+        const resumeFn = vi.fn();
+        const registry = createPauseRegistry({ connectionState });
+
+        registry.register('work', pauseFn, resumeFn);
+
+        // Act
+        handlers.disconnected();
+        handlers.reconnected();
+
+        // Assert
+        expect(pauseFn).toHaveBeenCalledTimes(1);
+        expect(resumeFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('registers new work in paused state by invoking pause', () => {
+        // Arrange
+        const { handlers, connectionState } = createConnectionStateStub();
+        const pauseFn = vi.fn();
+        const resumeFn = vi.fn();
+        const registry = createPauseRegistry({ connectionState });
+
+        handlers.disconnected();
+
+        // Act
+        registry.register('late-work', pauseFn, resumeFn);
+
+        // Assert
+        expect(pauseFn).toHaveBeenCalledTimes(1);
+        expect(resumeFn).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
#### Current Behavior
Toolasha fails to intercept game WebSocket messages when the page context differs from the userscript context, and continues periodic work during disconnects, causing offline instability.

Issue: N/A

#### Changes
- Add connection state tracking with disconnect/reconnect events
- Pause and resume periodic networth updates using a pause registry
- Guard marketplace fetches during disconnects with cached fallback
- Intercept WebSocket messages via page-context constructor and prototype hooks
- Add tests for connection state, pause registry, and offline market fallback

#### Breaking Changes
None