### PR TITLE
fix: skip websocket dedup for action_completed and items_updated events

### DIFF
--- a/src/core/data-manager.js
+++ b/src/core/data-manager.js
@@ -291,11 +291,13 @@ class DataManager {
                     }
 
                     // Find and update the item in inventory
-                    for (const invItem of this.characterItems) {
-                        if (invItem.id === endItem.id) {
-                            invItem.count = endItem.count;
-                            break;
-                        }
+                    const index = this.characterItems.findIndex((invItem) => invItem.id === endItem.id);
+                    if (index !== -1) {
+                        // Update existing item
+                        this.characterItems[index].count = endItem.count;
+                    } else {
+                        // Add new item to inventory
+                        this.characterItems.push(endItem);
                     }
                 }
             }

--- a/src/core/websocket.js
+++ b/src/core/websocket.js
@@ -319,9 +319,10 @@ class WebSocketHook {
             messageType = null;
         }
 
-        // Skip deduplication for quest updates (quest content changes are beyond 100 chars)
-        // The quest slot ID stays the same, causing false duplicate detection
-        const skipDedup = messageType === 'quests_updated';
+        // Skip deduplication for events where consecutive messages have similar first 100 chars
+        // but contain different data (counts, timestamps, etc. beyond the 100-char hash window)
+        const skipDedup =
+            messageType === 'quests_updated' || messageType === 'action_completed' || messageType === 'items_updated';
 
         if (!skipDedup) {
             // Deduplicate by message content to prevent 4x JSON.parse on same message


### PR DESCRIPTION
#### Current Behavior
The WebSocket message deduplication uses the first 100 characters of a message as a hash to prevent duplicate processing. However, consecutive `action_completed` and `items_updated` messages have nearly identical first 100 characters (same type, same item IDs), causing the 2nd+ messages to be silently dropped. This prevents inventory from updating after the first event, breaking "Can produce" counts, the Max queue button, and real-time inventory tracking on action panels.

Issue: N/A

#### Changes
- Skip message deduplication for `action_completed` and `items_updated` event types (same approach already used for `quests_updated`)
- Add missing inventory item handling in `action_completed`: new items are now pushed to the inventory array instead of being silently ignored

#### Breaking Changes
None