### PR TITLE
fix: resolve CI failures and add Steam build to pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
             - name: Build (production libraries)
               run: npm run build
 
+            - name: Build (Steam bundle)
+              run: npm run build:steam
+
             - name: Verify bundle sizes
               run: |
                   limit=2097152
@@ -52,7 +55,7 @@ jobs:
                     exit 1
                   fi
                   echo "✅ dist/Toolasha.user.js is under 2MB ($entrypoint_size bytes)"
-                  for file in dist/libraries/*.user.js; do
+                  for file in dist/libraries/*.js; do
                     size=$(wc -c < "$file")
                     if [ "$size" -gt "$limit" ]; then
                       echo "❌ $file is over 2MB limit ($size bytes)"
@@ -60,3 +63,12 @@ jobs:
                     fi
                     echo "✅ $file is under 2MB ($size bytes)"
                   done
+
+                  # Verify Steam bundle size (should be ~3MB, max 5MB)
+                  steam_limit=5242880
+                  steam_size=$(wc -c < "dist/Toolasha.steam.user.js")
+                  if [ "$steam_size" -gt "$steam_limit" ]; then
+                    echo "❌ dist/Toolasha.steam.user.js is over 5MB limit ($steam_size bytes)"
+                    exit 1
+                  fi
+                  echo "✅ dist/Toolasha.steam.user.js is under 5MB ($steam_size bytes)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,19 +55,21 @@ jobs:
 
                   # Save the built files
                   cp dist/Toolasha.user.js /tmp/Toolasha.user.js
+                  cp dist/Toolasha.steam.user.js /tmp/Toolasha.steam.user.js
                   cp -R dist/libraries /tmp/libraries
 
                   # Fetch and checkout releases branch (create if doesn't exist)
                   git fetch origin releases:releases 2>/dev/null || git checkout --orphan releases
                   git checkout releases 2>/dev/null || git checkout --orphan releases
 
-                  # Clean the branch and add only the built file
+                  # Clean the branch and add only the built files
                   git rm -rf . 2>/dev/null || true
                   mkdir -p dist
                   mkdir -p dist/libraries
                   cp /tmp/Toolasha.user.js dist/Toolasha.user.js
+                  cp /tmp/Toolasha.steam.user.js dist/Toolasha.steam.user.js
                   cp -R /tmp/libraries/* dist/libraries/
-                  git add dist/Toolasha.user.js dist/libraries/*.js
+                  git add dist/Toolasha.user.js dist/Toolasha.steam.user.js dist/libraries/*.js
 
                   # Commit libraries
                   git commit -m "chore(main): release ${{ steps.release.outputs.version }}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -455,23 +455,27 @@ Rollup Bundler
       ▼
 dist/Toolasha.user.js (production entrypoint)
 dist/Toolasha-dev.user.js (dev standalone)
-dist/libraries/*.user.js (production libraries)
+dist/Toolasha.steam.user.js (Steam bundle)
+dist/libraries/*.js (production libraries)
 ```
 
 ### Build Configuration
 
 - **Dev standalone**: `src/dev-entrypoint.js` → `dist/Toolasha-dev.user.js` (bundles libraries + entrypoint)
-- **Production**: `src/entrypoint.js` → `dist/Toolasha.user.js` + `dist/libraries/*.user.js`
+- **Production**: `src/entrypoint.js` → `dist/Toolasha.user.js` + `dist/libraries/*.js` (libraries loaded via @require)
+- **Steam**: `src/dev-entrypoint.js` → `dist/Toolasha.steam.user.js` (single bundle with vendor libs inline)
 - **Format**: IIFE (Immediately Invoked Function Expression)
 - **Sourcemap**: Inline for debugging
 
 ### Build Commands
 
 ```bash
-npm run build:dev # One-time dev standalone build
-npm run build     # Production bundles (entrypoint + libraries)
-npm run watch     # Watch mode (auto-rebuild)
-npm run dev       # Alias for watch
+npm run build:dev   # One-time dev standalone build
+npm run build       # Production bundles (entrypoint + libraries)
+npm run build:steam # Steam bundle (single file with vendor libs)
+npm run build:all   # Build both production and Steam versions
+npm run watch       # Watch mode (auto-rebuild)
+npm run dev         # Alias for watch
 ```
 
 ## Deployment

--- a/package-lock.json
+++ b/package-lock.json
@@ -1799,6 +1799,7 @@
             "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -1944,6 +1945,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2206,7 +2208,8 @@
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.7.0.tgz",
             "integrity": "sha512-31gVuqqKp3lDIFmzpKIrBeum4OpZsQjSIAqlOpgjosHDJZlULtvwLEZKtEhIAZc7JMPaHlYMys40Qy9Mf+1AAg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/chartjs-plugin-datalabels": {
             "version": "2.0.0",
@@ -2507,6 +2510,7 @@
             "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
@@ -2965,6 +2969,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -3905,6 +3910,7 @@
             "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
@@ -5667,6 +5673,7 @@
             "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -6300,6 +6307,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,16 @@
             "prettier --write",
             "bash -c 'npm test'",
             "bash -c 'npm run build:dev'",
+            "bash -c 'npm run build'",
+            "bash -c 'npm run build:steam'"
+        ],
+        "rollup.config.js": [
+            "prettier --write",
             "bash -c 'npm run build'"
+        ],
+        "rollup.config.steam.js": [
+            "prettier --write",
+            "bash -c 'npm run build:steam'"
         ],
         "*.config.js": [
             "prettier --write"


### PR DESCRIPTION
#### Current Behavior
Commit 846c1b8 renamed library files from `*.user.js` to `.js` but didn't update all CI/CD workflows and scripts, causing CI failures. The Steam build was also not validated in the CI pipeline or pre-commit hooks, risking broken releases.

Issue: N/A

#### Changes
- Fix CI workflow to check `dist/libraries/*.js` instead of `*.user.js`
- Add Steam build step to CI pipeline with 5MB size limit validation
- Update `sync-version.js` to handle both userscript (`@version`) and JSDoc (`Version:`) formats
- Add Steam build to pre-commit hooks (lint-staged) for all relevant file changes
- Fix release workflow to commit Steam bundle to releases branch
- Update ARCHITECTURE.md documentation with new filenames and Steam build info
- Add rollup config validation to pre-commit hooks (`rollup.config.js` and `rollup.config.steam.js`)

#### Breaking Changes
None