### PR TITLE
chore: show all commit types in changelog and bump refactor/perf/build/revert as patch

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,7 +7,21 @@
             "include-component-in-tag": false,
             "draft": true,
             "bootstrap-sha": "bfcf9634a2a8af61dd3f8e9467c41268dfa32b44",
-            "force-tag-creation": true
+            "force-tag-creation": true,
+            "changelog-sections": [
+                { "type": "feat", "section": "Features", "hidden": false },
+                { "type": "fix", "section": "Bug Fixes", "hidden": false },
+                { "type": "refactor", "section": "Code Refactoring", "hidden": false, "bump": "patch" },
+                { "type": "perf", "section": "Performance Improvements", "hidden": false, "bump": "patch" },
+                { "type": "docs", "section": "Documentation", "hidden": false },
+                { "type": "style", "section": "Styles", "hidden": false },
+                { "type": "test", "section": "Tests", "hidden": false },
+                { "type": "build", "section": "Build System", "hidden": false, "bump": "patch" },
+                { "type": "ci", "section": "Continuous Integration", "hidden": false },
+                { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
+                { "type": "revert", "section": "Reverts", "hidden": false, "bump": "patch" }
+            ],
+            "exclude-commits": ["^chore\\(main\\): release", "^chore: sync version and format release notes"]
         }
     }
 }


### PR DESCRIPTION
#### Current Behavior
Release-please only shows `feat` and `fix` commits in changelogs, hiding all other commit types. Additionally, `refactor`, `perf`, `build`, and `revert` commits don't trigger any version bump.

Issue: N/A

#### Changes
- Add `changelog-sections` config to show all conventional commit types (feat, fix, refactor, perf, docs, style, test, build, ci, chore, revert) in release notes
- Set `refactor`, `perf`, `build`, and `revert` to trigger patch version bumps
- Add `exclude-commits` patterns to filter out `chore(main): release` and `chore: sync version and format release notes` from changelogs

#### Breaking Changes
None