### PR TITLE
Render gathering indicators after initial update

### DIFF
--- a/src/features/actions/gathering-stats.js
+++ b/src/features/actions/gathering-stats.js
@@ -26,6 +26,7 @@ class GatheringStats {
         this.itemsUpdatedDebounceTimer = null; // Debounce timer for items_updated events
         this.actionCompletedDebounceTimer = null; // Debounce timer for action_completed events
         this.consumablesUpdatedDebounceTimer = null; // Debounce timer for consumables_updated events
+        this.indicatorUpdateDebounceTimer = null; // Debounce timer for indicator rendering
         this.DEBOUNCE_DELAY = 300; // 300ms debounce for event handlers
     }
 
@@ -126,7 +127,7 @@ class GatheringStats {
             });
             // Update with fresh data (skip render; indicators handle output)
             this.updateStats(actionPanel, { skipRender: true }).then(() => {
-                this.addBestActionIndicators();
+                this.scheduleIndicatorUpdate();
             });
             // Register with shared sort manager
             actionPanelSort.registerPanel(actionPanel, actionHrid);
@@ -173,7 +174,7 @@ class GatheringStats {
 
         // Initial update (skip render; indicators handle output)
         this.updateStats(actionPanel, { skipRender: true }).then(() => {
-            this.addBestActionIndicators();
+            this.scheduleIndicatorUpdate();
         });
 
         // Trigger sort
@@ -289,10 +290,20 @@ class GatheringStats {
         await Promise.all(updatePromises);
 
         // Find best actions and add indicators
-        this.addBestActionIndicators();
+        this.scheduleIndicatorUpdate();
 
         // Trigger sort via shared manager
         actionPanelSort.triggerSort();
+    }
+
+    /**
+     * Debounce indicator rendering to batch panel updates
+     */
+    scheduleIndicatorUpdate() {
+        clearTimeout(this.indicatorUpdateDebounceTimer);
+        this.indicatorUpdateDebounceTimer = setTimeout(() => {
+            this.addBestActionIndicators();
+        }, this.DEBOUNCE_DELAY);
     }
 
     /**
@@ -455,6 +466,8 @@ class GatheringStats {
      * Clear all DOM references to prevent memory leaks during character switch
      */
     clearAllReferences() {
+        clearTimeout(this.indicatorUpdateDebounceTimer);
+        this.indicatorUpdateDebounceTimer = null;
         // CRITICAL: Remove injected DOM elements BEFORE clearing Maps
         // This prevents detached SVG elements from accumulating
         // Note: .remove() is safe to call even if element is already detached
@@ -481,9 +494,11 @@ class GatheringStats {
         clearTimeout(this.itemsUpdatedDebounceTimer);
         clearTimeout(this.actionCompletedDebounceTimer);
         clearTimeout(this.consumablesUpdatedDebounceTimer);
+        clearTimeout(this.indicatorUpdateDebounceTimer);
         this.itemsUpdatedDebounceTimer = null;
         this.actionCompletedDebounceTimer = null;
         this.consumablesUpdatedDebounceTimer = null;
+        this.indicatorUpdateDebounceTimer = null;
 
         if (this.itemsUpdatedHandler) {
             dataManager.off('items_updated', this.itemsUpdatedHandler);


### PR DESCRIPTION
#### Current Behavior
Gathering indicators can fail to render until a later data event triggers a refresh, causing the emoji indicators to appear briefly and then disappear.

Issue: N/A

#### Changes
- Trigger a best-indicator render after the initial gathering stats update
- Ensure gathering stat panels render with indicators immediately after injection

#### Breaking Changes
None