### PR TITLE
Prevent action_completed double-processing and stat bar emoji clipping

### DIFF
--- a/src/core/websocket.js
+++ b/src/core/websocket.js
@@ -28,6 +28,7 @@ class WebSocketHook {
          * Uses message content (first 100 chars) as key since same message can have different event objects
          */
         this.processedMessages = new Map(); // message hash -> timestamp
+        this.recentActionCompleted = new Map(); // message content -> timestamp (50ms TTL dedup)
         this.messageCleanupInterval = null;
         this.isSocketWrapped = false;
         this.originalWebSocket = null;
@@ -349,6 +350,25 @@ class WebSocketHook {
             // Cleanup old entries every 100 messages to prevent memory leak
             if (this.processedMessages.size > 100) {
                 this.cleanupProcessedMessages();
+            }
+        } else if (messageType === 'action_completed') {
+            // action_completed bypasses the content-hash dedup (Gabriel's fix, commit 1007215)
+            // but the WebSocket prototype wrapper can fire two listeners for the same physical
+            // message object. The WeakSet guard catches same-object duplicates, but if two
+            // independent listeners each receive a distinct MessageEvent wrapping the same
+            // payload, both pass the WeakSet check and processMessage is called twice.
+            // Use a short 50ms TTL keyed on full message content to collapse these duplicates.
+            // Two genuine consecutive action_completed messages are always seconds apart.
+            const now = Date.now();
+            if (this.recentActionCompleted.has(message)) {
+                return; // Duplicate from second listener — skip
+            }
+            this.recentActionCompleted.set(message, now);
+            // Prune entries older than 50ms to keep memory bounded
+            for (const [key, ts] of this.recentActionCompleted) {
+                if (now - ts > 50) {
+                    this.recentActionCompleted.delete(key);
+                }
             }
         }
 

--- a/src/features/actions/gathering-stats.js
+++ b/src/features/actions/gathering-stats.js
@@ -24,7 +24,6 @@ class GatheringStats {
         this.characterSwitchingHandler = null; // Handler for character switch cleanup
         this.isInitialized = false;
         this.itemsUpdatedDebounceTimer = null; // Debounce timer for items_updated events
-        this.actionCompletedDebounceTimer = null; // Debounce timer for action_completed events
         this.consumablesUpdatedDebounceTimer = null; // Debounce timer for consumables_updated events
         this.indicatorUpdateDebounceTimer = null; // Debounce timer for indicator rendering
         this.DEBOUNCE_DELAY = 300; // 300ms debounce for event handlers
@@ -56,13 +55,6 @@ class GatheringStats {
                 this.updateAllStats();
             }, this.DEBOUNCE_DELAY);
         };
-        this.actionCompletedHandler = () => {
-            clearTimeout(this.actionCompletedDebounceTimer);
-            this.actionCompletedDebounceTimer = setTimeout(() => {
-                this.updateAllStats();
-            }, this.DEBOUNCE_DELAY);
-        };
-
         this.consumablesUpdatedHandler = () => {
             clearTimeout(this.consumablesUpdatedDebounceTimer);
             this.consumablesUpdatedDebounceTimer = setTimeout(() => {
@@ -76,7 +68,6 @@ class GatheringStats {
 
         // Event-driven updates (no polling needed)
         dataManager.on('items_updated', this.itemsUpdatedHandler);
-        dataManager.on('action_completed', this.actionCompletedHandler);
         dataManager.on('consumables_updated', this.consumablesUpdatedHandler);
         dataManager.on('character_switching', this.characterSwitchingHandler);
     }
@@ -550,10 +541,7 @@ class GatheringStats {
             dataManager.off('items_updated', this.itemsUpdatedHandler);
             this.itemsUpdatedHandler = null;
         }
-        if (this.actionCompletedHandler) {
-            dataManager.off('action_completed', this.actionCompletedHandler);
-            this.actionCompletedHandler = null;
-        }
+
         if (this.consumablesUpdatedHandler) {
             dataManager.off('consumables_updated', this.consumablesUpdatedHandler);
             this.consumablesUpdatedHandler = null;

--- a/src/features/actions/inventory-count-display.js
+++ b/src/features/actions/inventory-count-display.js
@@ -73,7 +73,6 @@ class InventoryCountDisplay {
         this.detailPanels = new Set();
         this.unregisterObservers = [];
         this.itemsUpdatedHandler = null;
-        this.actionCompletedHandler = null;
         this.isInitialized = false;
         this.DEBOUNCE_DELAY = 300;
         this.debounceTimer = null;
@@ -93,17 +92,10 @@ class InventoryCountDisplay {
             this.debounceTimer = setTimeout(() => this._refreshAll(), this.DEBOUNCE_DELAY);
         };
 
-        this.actionCompletedHandler = () => {
-            clearTimeout(this.debounceTimer);
-            this.debounceTimer = setTimeout(() => this._refreshAll(), this.DEBOUNCE_DELAY);
-        };
-
         dataManager.on('items_updated', this.itemsUpdatedHandler);
-        dataManager.on('action_completed', this.actionCompletedHandler);
 
         this.unregisterObservers.push(() => {
             dataManager.off('items_updated', this.itemsUpdatedHandler);
-            dataManager.off('action_completed', this.actionCompletedHandler);
         });
     }
 

--- a/src/features/actions/max-produceable.js
+++ b/src/features/actions/max-produceable.js
@@ -61,7 +61,6 @@ class MaxProduceable {
         this.actionNameToHridCache = null; // Cached reverse lookup map (name → hrid)
         this.isInitialized = false;
         this.itemsUpdatedDebounceTimer = null; // Debounce timer for items_updated events
-        this.actionCompletedDebounceTimer = null; // Debounce timer for action_completed events
         this.DEBOUNCE_DELAY = 300; // 300ms debounce for event handlers
         this.timerRegistry = createTimerRegistry();
     }
@@ -92,19 +91,12 @@ class MaxProduceable {
                 this.updateAllCounts();
             }, this.DEBOUNCE_DELAY);
         };
-        this.actionCompletedHandler = () => {
-            clearTimeout(this.actionCompletedDebounceTimer);
-            this.actionCompletedDebounceTimer = setTimeout(() => {
-                this.updateAllCounts();
-            }, this.DEBOUNCE_DELAY);
-        };
         this.characterSwitchingHandler = () => {
             this.clearAllReferences();
         };
 
         // Event-driven updates (no polling needed)
         dataManager.on('items_updated', this.itemsUpdatedHandler);
-        dataManager.on('action_completed', this.actionCompletedHandler);
         dataManager.on('character_switching', this.characterSwitchingHandler);
     }
 
@@ -786,10 +778,7 @@ class MaxProduceable {
             dataManager.off('items_updated', this.itemsUpdatedHandler);
             this.itemsUpdatedHandler = null;
         }
-        if (this.actionCompletedHandler) {
-            dataManager.off('action_completed', this.actionCompletedHandler);
-            this.actionCompletedHandler = null;
-        }
+
         if (this.characterSwitchingHandler) {
             dataManager.off('character_switching', this.characterSwitchingHandler);
             this.characterSwitchingHandler = null;


### PR DESCRIPTION
#### Current Behavior
Toolasha can process action_completed twice for the same message because multiple WebSocket message listeners fire, which causes action-based features to run twice per tick. Also, best‑action emoji indicators can increase line width without re-fitting font sizes, causing clipping.

Issue: N/A

#### Changes
- Add a 50ms TTL dedup for action_completed messages to collapse duplicate listener invocations
- Remove redundant action_completed listeners from inventory/material-related features (items_updated is sufficient)
- Re-run stat line font sizing after emoji updates to prevent clipping

#### Breaking Changes
None