### PR TITLE
Add artisan material requirement mode for missing/required materials

### DIFF
--- a/src/features/actions/missing-materials-button.js
+++ b/src/features/actions/missing-materials-button.js
@@ -8,7 +8,7 @@ import config from '../../core/config.js';
 import domObserver from '../../core/dom-observer.js';
 import webSocketHook from '../../core/websocket.js';
 import { findActionInput, attachInputListeners, performInitialUpdate } from '../../utils/action-panel-helper.js';
-import { ARTISAN_MATERIAL_MODE, calculateMaterialRequirements } from '../../utils/material-calculator.js';
+import { calculateMaterialRequirements } from '../../utils/material-calculator.js';
 import { formatWithSeparator } from '../../utils/formatters.js';
 import { createTimerRegistry } from '../../utils/timer-registry.js';
 import { createAutofillManager } from '../../utils/marketplace-autofill.js';
@@ -168,14 +168,7 @@ function updateButtonForPanel(panel, value) {
     // Check if user wants to ignore queue (default: false, meaning we DO account for queue)
     const ignoreQueue = config.getSetting('actions_missingMaterialsButton_ignoreQueue') || false;
     const accountForQueue = !ignoreQueue; // Invert: ignoreQueue=false means accountForQueue=true
-    const artisanModeSetting = config.getSettingValue('actions_artisanMaterialMode', ARTISAN_MATERIAL_MODE.EXPECTED);
-    const artisanMode =
-        artisanModeSetting === ARTISAN_MATERIAL_MODE.WORST_CASE
-            ? ARTISAN_MATERIAL_MODE.WORST_CASE
-            : ARTISAN_MATERIAL_MODE.EXPECTED;
-    const missingMaterials = calculateMaterialRequirements(actionHrid, numActions, accountForQueue, {
-        artisanMode,
-    });
+    const missingMaterials = calculateMaterialRequirements(actionHrid, numActions, accountForQueue);
     if (missingMaterials.length === 0) {
         return;
     }


### PR DESCRIPTION
#### Current Behavior
Artisan Tea material reductions are always applied using the expected-value formula, which can underestimate the worst‑case materials needed and cause missing‑materials to suggest too few items.

Issue: N/A

#### Changes
- Add a setting to choose expected vs worst‑case (ceil per craft) Artisan material requirements
- Apply the selected mode to required and missing material calculations
- Place the setting in the Economy & Inventory section

#### Breaking Changes
None