### PR TITLE
fix: collection filter setting inconsistently read

### DIFF
--- a/src/features/collection/collection-filters.js
+++ b/src/features/collection/collection-filters.js
@@ -474,7 +474,7 @@ class CollectionFilters {
 
     async initialize() {
         if (this.isInitialized) return;
-        if (!config.isFeatureEnabled('collectionFilters')) return;
+        if (!config.getSetting('collectionFilters')) return;
 
         this.isInitialized = true;
 


### PR DESCRIPTION
'collectionFilters' is a setting, not a feature, so this doesn't read the correct setting value until after the setting is toggled in the current session.