### PR TITLE
fix: run lint-and-build on every pull_request, not just after format sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ jobs:
     lint-and-build:
         # Run CI when:
         # - push: normal commits (not release-please's release commits)
-        # - pull_request: normal PRs immediately, release-please PRs only after formatting
+        # - pull_request: always. head_commit is a push-event-only field and is
+        #   undefined on pull_request payloads, so it must not gate this trigger.
         if: >
-            (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(main): release')) ||
-            (github.event_name == 'pull_request' && (!startsWith(github.head_ref, 'release-please--') || contains(github.event.head_commit.message, 'chore: sync version and format')))
+            github.event_name == 'pull_request' ||
+            (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(main): release'))
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code


### PR DESCRIPTION
## Summary

While investigating why PR #610's `lint-and-build` check never ran, found that
`ci.yml`'s `if:` condition checks `contains(github.event.head_commit.message, 'chore: sync
version and format')` to decide whether a release-please `pull_request` event should run the
job. `head_commit` is a field that only exists on `push` event payloads — it is always undefined
on `pull_request` payloads. That makes the release-please branch of the condition permanently
false, so `lint-and-build` has never actually run on any release-please PR's `pull_request`
event, regardless of what commits land on the branch. This is separate from (and predates) the
`npm.apple.com` lockfile issue fixed in #611.

## Changes

Simplified the trigger: run on every `pull_request` event unconditionally, and only use
`head_commit.message` for `push` events, where that field is actually valid.

## Test plan

- [x] `npm test` — 529/529 passed
- [x] `npm run lint` — 0 errors
- [x] `npm run build:dev` — succeeded
- [x] `npm run build` — succeeded
- [x] Workflow YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- [ ] Confirm `lint-and-build` actually runs (not skips) on this PR itself