### PR TITLE
fix: guard against infinite sort loop when Pinned Actions is disabled

### DIFF
--- a/src/features/actions/max-produceable.js
+++ b/src/features/actions/max-produceable.js
@@ -206,6 +206,21 @@ class MaxProduceable {
             return;
         }
 
+        // Pin feature is off (no pin element ever created), but the display already
+        // exists — this is a sort-triggered re-insertion, not a fresh panel. Re-register
+        // and return without calling triggerSort() again, or every re-insertion would
+        // append a duplicate display and re-trigger the sort, looping forever.
+        if (existingDisplay) {
+            this.actionElements.set(actionPanel, {
+                actionHrid,
+                displayElement: existingDisplay,
+                pinElement: null,
+            });
+            this.scheduleStatsLayoutSync(actionPanel, existingDisplay);
+            this.getResizeObserver().observe(existingDisplay);
+            return;
+        }
+
         // Make sure the action panel has relative positioning
         if (actionPanel.style.position !== 'relative' && actionPanel.style.position !== 'absolute') {
             actionPanel.style.position = 'relative';


### PR DESCRIPTION
## Summary

On skilling/production pages with Pinned Actions disabled and a non-default sort mode active
(or a stored pinned action), the MutationObserver call rate spikes to ~2,000/s and the page
becomes unresponsive until navigating away. Reported by a user on Firefox/Mac after an update
about a week prior.

**Root cause**: a sort-triggered panel re-insertion falls through `injectMaxProduceable`'s
pin-disabled branch as if it were a fresh panel — appends a duplicate `.mwi-max-produceable` div
and calls `triggerSort()` again, which re-triggers the next re-insertion. Infinite loop, growing
DOM, MutationObserver storm.

Documented and root-caused previously in a local working note; deferred until TLA-001 was
finalized (now shipped in v2.86.0).

## Changes

Added a guard mirroring the pattern `gathering-stats.js` already uses correctly: when
`existingDisplay` is found and there's no pin element (pin feature off), re-register the existing
display and return without calling `triggerSort()` again.

## Test plan

- [x] `npm test` — 529/529 passed
- [x] `npm run lint` — 0 errors
- [x] `npm run build:dev` — succeeded
- [x] `npm run build` — succeeded
- [ ] Manual repro: disable Pinned Actions, set sort to Profit, navigate to a production skill
      page, confirm MutationObserver call rate stays low and no duplicate
      `.mwi-max-produceable` elements appear