### PR TITLE
fix: resolve all 7 pre-existing lint warnings

### DIFF
--- a/src/core/dom-observer.test.js
+++ b/src/core/dom-observer.test.js
@@ -24,7 +24,6 @@ describe('DOMObserver debounce', () => {
     });
 
     test('retains O(1) state under 100,000 continuous events', () => {
-        const callback = vi.fn();
         const nodes = [];
         for (let i = 0; i < 100000; i++) {
             nodes.push({ id: i });

--- a/src/core/feature-registry.js
+++ b/src/core/feature-registry.js
@@ -249,21 +249,6 @@ function setupCharacterSwitchHandler() {
 }
 
 /**
- * Get feature instance from imported module
- * @param {string} key - Feature key
- * @returns {Object|null} Feature instance or null
- * @private
- */
-function getFeatureInstance(key) {
-    const feature = getFeature(key);
-    if (!feature) {
-        return null;
-    }
-
-    return feature.module || feature;
-}
-
-/**
  * Retry initialization for specific features
  * @param {Array<Object>} failedFeatures - Array of failed feature objects
  * @returns {Promise<void>}

--- a/src/core/settings-storage.test.js
+++ b/src/core/settings-storage.test.js
@@ -16,38 +16,9 @@ vi.mock('./storage.js', () => ({
     },
 }));
 
-async function makeStorage(currentCharId, knownIds) {
-    vi.resetModules();
-    Object.keys(storageData).forEach((k) => delete storageData[k]);
-    storageData['known_character_ids'] = knownIds;
-
-    const { default: storage } = await import('./storage.js');
-    storage.getJSON.mockImplementation(async (key, _area, defaultValue) => storageData[key] ?? defaultValue);
-    storage.setJSON.mockImplementation(async (key, value) => {
-        storageData[key] = value;
-    });
-
-    const { SettingsStorage } = await import('./settings-storage.js');
-    const s = new SettingsStorage();
-    if (currentCharId !== null) s.setCharacterId(currentCharId);
-    return { s, storage };
-}
-
-// settings-storage.js exports the singleton by default; we need the class for isolated instances
-// so we re-export it as a named export in a compatible way via dynamic import with a class wrapper test.
-// Instead, instantiate through the module's default export factory pattern by reaching the class directly.
-// Since the file exports a singleton, we test via importSettings on the singleton after patching its state.
-
-async function makeInstance(currentCharId, knownCharacterObjects) {
-    vi.resetModules();
-    Object.keys(storageData).forEach((k) => delete storageData[k]);
-    storageData['known_character_ids'] = knownCharacterObjects;
-
-    const mod = await import('./settings-storage.js');
-    const instance = mod.default;
-    instance.currentCharacterId = currentCharId !== null ? String(currentCharId) : null;
-    return instance;
-}
+// settings-storage.js exports a singleton. We test via importSettings on that singleton
+// after patching its state directly (currentCharacterId, storageData), rather than
+// instantiating the class in isolation.
 
 describe('SettingsStorage.importSettings — character isolation', () => {
     beforeEach(() => {

--- a/src/core/storage.test.js
+++ b/src/core/storage.test.js
@@ -86,8 +86,9 @@ describe('Storage write durability (TLA-007)', () => {
         expect(goodDb._store['myKey']).toBe('hello');
 
         const result = await writePromise;
-        // Original promise resolves false (first attempt failed); flush resolves pending resolvers
-        // The important invariant is that the value made it to disk.
+        // The failed first attempt requeues without resolving; the original resolver is
+        // carried over and only settled once flushAll's retry actually succeeds.
+        expect(result).toBe(true);
         expect(goodDb._store['myKey']).toBe('hello');
     });
 

--- a/src/features/crafting-plan/crafting-plan-display.js
+++ b/src/features/crafting-plan/crafting-plan-display.js
@@ -794,6 +794,10 @@ function createCraftingPlanTabs(missingMaterials, tabsContainer = null, sessionI
 
     for (const material of missingMaterials) {
         const tabRef = { tab: null };
+        // activeWorkflowModel (read inside quantityProvider below) is module-level state,
+        // not a per-iteration loop variable — this intentionally reads its live value when
+        // the quantity provider is invoked later, not a stale snapshot from loop creation.
+        // eslint-disable-next-line no-loop-func
         const handler = () => {
             if (!marketplaceSession.isActive(sessionId)) return;
             const liveMissing = Number.parseInt(tabRef.tab?.getAttribute('data-missing-quantity') || '0', 10);

--- a/src/features/settings/settings-ui.js
+++ b/src/features/settings/settings-ui.js
@@ -570,7 +570,7 @@ class SettingsUI {
                                 .map((item) => (item.type === 'variable' ? item.key : (item.value ?? '')))
                                 .join('');
                         }
-                    } catch (e) {
+                    } catch {
                         /* leave as-is */
                     }
                 }


### PR DESCRIPTION
## Summary

Resolves all 7 lint warnings that have been showing up on every CI run. Each addressed on its
own merits rather than blanket-suppressed with `_` prefixes.

## Changes

- **`settings-ui.js`**: switched to optional catch binding (`catch {}`) for a swallowed
  `JSON.parse` failure — removes the unused var entirely, no suppression needed.
- **`crafting-plan-display.js`**: `no-loop-func` false positive — `activeWorkflowModel` is
  module-level state intentionally read live when the closure fires later, not a per-iteration
  loop variable. Added a scoped disable with a comment explaining why, on the actual flagged
  declaration.
- **`storage.test.js`**: the unused `result` capture had a stale comment claiming the promise
  resolves `false`. Traced `_debouncedSave`/`flushAll` and confirmed empirically (temporary
  `console.log` under the real test, since reverted) that the failed first attempt requeues
  without resolving, and the original resolver only settles `true` once `flushAll`'s retry
  actually succeeds. Added the correct assertion and fixed the comment.
- **`settings-storage.test.js`**: deleted `makeStorage`/`makeInstance` — grepped the file, every
  real test inlines the same setup directly, these were fully dead.
- **`feature-registry.js`**: deleted `getFeatureInstance` — grepped `src/`, not called or
  exported anywhere.
- **`dom-observer.test.js`**: removed an unused `callback = vi.fn()` in the first test; that
  test's handler object never wires up a callback and nothing asserts on it (leftover from the
  next test down, which does use it correctly).

`npm run lint` now reports zero warnings.

## Test plan

- [x] `npm test` — 529/529 passed (no regressions from the two dead-code deletions)
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run build:dev` — succeeded
- [x] `npm run build` — succeeded