### PR TITLE
fix: TLA-014 — restore queue-aware missing mats, House live-state alignment, custom inventory/crafting summaries

### DIFF
--- a/src/features/actions/required-materials.js
+++ b/src/features/actions/required-materials.js
@@ -10,6 +10,22 @@ import { calculateMaterialRequirements, isArtisanTeaOutOfStock } from '../../uti
 import { findActionInput, attachInputListeners, performInitialUpdate } from '../../utils/action-panel-helper.js';
 import { getActionHridFromName } from '../../utils/game-lookups.js';
 
+/**
+ * Build the compact requirement status shown below a material.
+ * Queue reservation is shown once beside Required because Missing already includes it.
+ * @param {Object} material
+ * @param {number} material.required
+ * @param {number} material.missing
+ * @param {number} [material.queued]
+ * @returns {string}
+ */
+export function formatRequiredMaterialStatus(material) {
+    const queuedText = material.queued > 0 ? ` (${numberFormatter(material.queued)} Q'd)` : '';
+    let text = `Required: ${numberFormatter(material.required)}${queuedText}`;
+    if (material.missing > 0) text += ` | Missing: ${numberFormatter(material.missing)}`;
+    return text;
+}
+
 class RequiredMaterials {
     constructor() {
         this.initialized = false;
@@ -145,13 +161,9 @@ class RequiredMaterials {
                     text = `Required: ${placeholderLabel}`;
                     displaySpan.style.color = '';
                 } else {
-                    const queuedText = material.queued > 0 ? ` (${numberFormatter(material.queued)} Q'd)` : '';
-                    text = `Required: ${numberFormatter(material.required)}${queuedText}`;
+                    text = formatRequiredMaterialStatus(material);
 
                     if (material.missing > 0) {
-                        const missingQueuedText =
-                            material.queued > 0 ? ` (${numberFormatter(material.queued)} Q'd)` : '';
-                        text += ` || Missing: ${numberFormatter(material.missing)}${missingQueuedText}`;
                         displaySpan.style.color = config.COLOR_LOSS; // Missing materials
                     } else {
                         displaySpan.style.color = config.COLOR_PROFIT; // Sufficient materials
@@ -199,12 +211,9 @@ class RequiredMaterials {
                 text = `Required: ${placeholderLabel}`;
                 displaySpan.style.color = '';
             } else {
-                const queuedText = material.queued > 0 ? ` (${numberFormatter(material.queued)} Q'd)` : '';
-                text = `Required: ${numberFormatter(material.required)}${queuedText}`;
+                text = formatRequiredMaterialStatus(material);
 
                 if (material.missing > 0) {
-                    const missingQueuedText = material.queued > 0 ? ` (${numberFormatter(material.queued)} Q'd)` : '';
-                    text += ` || Missing: ${numberFormatter(material.missing)}${missingQueuedText}`;
                     displaySpan.style.color = config.COLOR_LOSS; // Missing materials
                 } else {
                     displaySpan.style.color = config.COLOR_PROFIT; // Sufficient materials

--- a/src/features/actions/required-materials.test.js
+++ b/src/features/actions/required-materials.test.js
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('../../core/config.js', () => ({
+    default: {
+        COLOR_LOSS: '#f00',
+        COLOR_PROFIT: '#0f0',
+    },
+}));
+
+vi.mock('../../core/dom-observer.js', () => ({ default: {} }));
+vi.mock('../../utils/material-calculator.js', () => ({
+    calculateMaterialRequirements: vi.fn(),
+    isArtisanTeaOutOfStock: vi.fn(),
+}));
+vi.mock('../../utils/action-panel-helper.js', () => ({
+    findActionInput: vi.fn(),
+    attachInputListeners: vi.fn(),
+    performInitialUpdate: vi.fn(),
+}));
+vi.mock('../../utils/game-lookups.js', () => ({ getActionHridFromName: vi.fn() }));
+vi.mock('../../utils/formatters.js', () => ({
+    numberFormatter: vi.fn((value) => new Intl.NumberFormat('en-US').format(value)),
+}));
+
+import { formatRequiredMaterialStatus } from './required-materials.js';
+
+describe('formatRequiredMaterialStatus', () => {
+    test('shows the queued reservation once and keeps Missing compact', () => {
+        expect(
+            formatRequiredMaterialStatus({
+                required: 1800,
+                queued: 3496,
+                missing: 2,
+            })
+        ).toBe("Required: 1,800 (3,496 Q'd) | Missing: 2");
+    });
+
+    test('omits queue and Missing parts when they are not applicable', () => {
+        expect(formatRequiredMaterialStatus({ required: 900, queued: 0, missing: 0 })).toBe('Required: 900');
+    });
+});

--- a/src/features/crafting-plan/crafting-plan-display.js
+++ b/src/features/crafting-plan/crafting-plan-display.js
@@ -170,6 +170,77 @@ function createRow(leftText, rightText, options = {}) {
 }
 
 /**
+ * Calculate timing and XP metrics for every craft step in the plan.
+ * The returned total is the same value rendered as `Total craft time` in the
+ * expanded plan and reused in the collapsed summary.
+ * @param {Array} craftSteps
+ * @returns {{ steps: Array, totalCraftSeconds: number, totalXP: number }}
+ */
+export function calculateCraftingPlanMetrics(craftSteps) {
+    const gameData = dataManager.getInitClientData();
+    const skills = dataManager.getSkills();
+    const equipment = dataManager.getEquipment();
+    let totalCraftSeconds = 0;
+    let totalXP = 0;
+
+    const steps = craftSteps.map((step) => {
+        let totalSeconds = 0;
+        let expPerHour = 0;
+
+        if (step.actionHrid) {
+            const actionDetails = gameData?.actionDetailMap?.[step.actionHrid];
+            if (actionDetails) {
+                const stats = calculateActionStats(actionDetails, {
+                    skills,
+                    equipment,
+                    itemDetailMap: gameData.itemDetailMap,
+                });
+                const efficiencyMultiplier = calculateEfficiencyMultiplier(stats.totalEfficiency);
+                const calculatedSeconds = (stats.actionTime * step.actionsNeeded) / efficiencyMultiplier;
+                if (Number.isFinite(calculatedSeconds) && calculatedSeconds > 0) {
+                    totalSeconds = calculatedSeconds;
+                    totalCraftSeconds += calculatedSeconds;
+                }
+            }
+
+            const expData = calculateExpPerHour(step.actionHrid);
+            if (expData?.expPerHour > 0 && expData.actionsPerHour > 0) {
+                const xpPerAction = expData.expPerHour / expData.actionsPerHour;
+                totalXP += xpPerAction * step.actionsNeeded;
+                expPerHour = expData.expPerHour;
+            }
+        }
+
+        return { ...step, totalSeconds, expPerHour };
+    });
+
+    return { steps, totalCraftSeconds, totalXP };
+}
+
+/**
+ * Format a total plan duration without leading zero-hour padding.
+ * @param {number} totalCraftSeconds
+ * @returns {string|null}
+ */
+function formatTotalCraftTime(totalCraftSeconds) {
+    if (!Number.isFinite(totalCraftSeconds) || totalCraftSeconds <= 0) return null;
+    return timeReadable(totalCraftSeconds).replace(/^0h 0?/, '');
+}
+
+/**
+ * Format the collapsed Best Crafting Plan summary.
+ * Cost is per item (`ea` = each); time is the total for every craft step.
+ * @param {Object} plan
+ * @param {number} totalCraftSeconds
+ * @returns {string}
+ */
+export function formatCraftingPlanSummary(plan, totalCraftSeconds = 0) {
+    const cost = plan.unitCost === Infinity ? '?' : `${formatKMB(Math.round(plan.unitCost))}/ea`;
+    const totalTime = formatTotalCraftTime(totalCraftSeconds);
+    return totalTime ? `${cost} · ${totalTime}` : cost;
+}
+
+/**
  * Build the full crafting plan UI for an action.
  * @param {string} actionHrid
  * @param {Function} [onToggle] - Callback when buy-intermediates toggle changes
@@ -215,6 +286,13 @@ function buildPlanUI(actionHrid, onToggle, defaultOpen = false) {
 
     // Don't show if item has no production recipe (true raw material)
     if (plan.craftCost === null) return null;
+
+    const craftSteps = [];
+    collectCraftSteps(plan, craftSteps);
+    const craftMetrics =
+        plan.strategy === 'craft' && craftSteps.length > 0
+            ? calculateCraftingPlanMetrics(craftSteps)
+            : { steps: [], totalCraftSeconds: 0, totalXP: 0 };
 
     // Build content
     const content = document.createElement('div');
@@ -392,7 +470,7 @@ function buildPlanUI(actionHrid, onToggle, defaultOpen = false) {
 
     // Only show breakdown if crafting is the optimal strategy
     if (plan.strategy !== 'craft' || plan.children.length === 0) {
-        const costText = plan.unitCost === Infinity ? '?' : `${formatKMB(Math.round(plan.unitCost))}/ea`;
+        const costText = formatCraftingPlanSummary(plan, craftMetrics.totalCraftSeconds);
         const section = createCollapsibleSection('', 'Best Crafting Plan', costText, content, defaultOpen, 0);
         section.id = UI_ID;
         section.className = 'mwi-crafting-plan-section';
@@ -586,10 +664,7 @@ function buildPlanUI(actionHrid, onToggle, defaultOpen = false) {
     }
 
     // === Crafting Steps (what to craft, in order) ===
-    const craftSteps = [];
-    collectCraftSteps(plan, craftSteps);
-
-    if (craftSteps.length > 0) {
+    if (craftMetrics.steps.length > 0) {
         const divider2 = document.createElement('div');
         divider2.style.cssText = 'border-top: 1px solid var(--border-color, #333); margin: 6px 0;';
         content.appendChild(divider2);
@@ -603,47 +678,21 @@ function buildPlanUI(actionHrid, onToggle, defaultOpen = false) {
         stepsHeader.textContent = 'Crafting Steps';
         content.appendChild(stepsHeader);
 
-        const gameData = dataManager.getInitClientData();
-        const skills = dataManager.getSkills();
-        const equipment = dataManager.getEquipment();
-        let totalCraftSeconds = 0;
-        let totalXP = 0;
-
-        for (let i = 0; i < craftSteps.length; i++) {
-            const step = craftSteps[i];
+        for (let i = 0; i < craftMetrics.steps.length; i++) {
+            const step = craftMetrics.steps[i];
             const qty = formatWithSeparator(step.quantity);
-            let timeStr = '';
-            let xpStr = '';
-            if (step.actionHrid) {
-                const actionDetails = gameData?.actionDetailMap?.[step.actionHrid];
-                if (actionDetails) {
-                    const stats = calculateActionStats(actionDetails, {
-                        skills,
-                        equipment,
-                        itemDetailMap: gameData.itemDetailMap,
-                    });
-                    const effMultiplier = calculateEfficiencyMultiplier(stats.totalEfficiency);
-                    const totalSeconds = (stats.actionTime * step.actionsNeeded) / effMultiplier;
-                    totalCraftSeconds += totalSeconds;
-                    timeStr = ` (${timeReadable(totalSeconds)}`;
-                }
-                const expData = calculateExpPerHour(step.actionHrid);
-                if (expData?.expPerHour > 0 && expData.actionsPerHour > 0) {
-                    const xpPerAction = expData.expPerHour / expData.actionsPerHour;
-                    totalXP += xpPerAction * step.actionsNeeded;
-                    xpStr = ` · ${formatKMB(expData.expPerHour)} xp/hr`;
-                }
-                if (timeStr) {
-                    timeStr += `${xpStr})`;
-                } else if (xpStr) {
-                    timeStr = ` (${xpStr.slice(3)})`;
-                }
+            let timeStr = step.totalSeconds > 0 ? ` (${timeReadable(step.totalSeconds)}` : '';
+            const xpStr = step.expPerHour > 0 ? ` · ${formatKMB(step.expPerHour)} xp/hr` : '';
+            if (timeStr) {
+                timeStr += `${xpStr})`;
+            } else if (xpStr) {
+                timeStr = ` (${xpStr.slice(3)})`;
             }
             content.appendChild(createRow(`${i + 1}. ${step.itemName}`, `x${qty}${timeStr}`));
         }
 
-        if (totalCraftSeconds > 0) {
-            const totalTimeRow = createRow('Total craft time', timeReadable(totalCraftSeconds), {
+        if (craftMetrics.totalCraftSeconds > 0) {
+            const totalTimeRow = createRow('Total craft time', timeReadable(craftMetrics.totalCraftSeconds), {
                 leftColor: 'var(--text-color-primary, #fff)',
             });
             totalTimeRow.style.borderTop = '1px solid var(--border-color, #333)';
@@ -652,16 +701,16 @@ function buildPlanUI(actionHrid, onToggle, defaultOpen = false) {
             content.appendChild(totalTimeRow);
         }
 
-        if (totalXP > 0) {
+        if (craftMetrics.totalXP > 0) {
             content.appendChild(
-                createRow('Total XP', formatKMB(Math.round(totalXP)), {
+                createRow('Total XP', formatKMB(Math.round(craftMetrics.totalXP)), {
                     leftColor: 'var(--text-color-primary, #fff)',
                 })
             );
         }
     }
 
-    const costText = plan.unitCost === Infinity ? '?' : `${formatKMB(Math.round(plan.unitCost))}/ea`;
+    const costText = formatCraftingPlanSummary(plan, craftMetrics.totalCraftSeconds);
     const section = createCollapsibleSection('', 'Best Crafting Plan', costText, content, defaultOpen, 0);
     section.id = UI_ID;
     section.className = 'mwi-crafting-plan-section';

--- a/src/features/crafting-plan/crafting-plan-display.test.js
+++ b/src/features/crafting-plan/crafting-plan-display.test.js
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { mockCalculateActionStats, mockCalculateEfficiencyMultiplier, mockCalculateExpPerHour, mockDataManager } =
+    vi.hoisted(() => ({
+        mockCalculateActionStats: vi.fn(),
+        mockCalculateEfficiencyMultiplier: vi.fn(),
+        mockCalculateExpPerHour: vi.fn(),
+        mockDataManager: {
+            getInitClientData: vi.fn(),
+            getSkills: vi.fn(),
+            getEquipment: vi.fn(),
+        },
+    }));
+
+vi.mock('../../core/config.js', () => ({
+    default: {
+        getSetting: vi.fn(),
+        getSettingValue: vi.fn(),
+        setSetting: vi.fn(),
+        setSettingValue: vi.fn(),
+    },
+}));
+vi.mock('../../core/dom-observer.js', () => ({ default: { onClass: vi.fn() } }));
+vi.mock('../../core/data-manager.js', () => ({ default: mockDataManager }));
+vi.mock('../../core/marketplace-session.js', () => ({
+    MARKETPLACE_OWNER: { CRAFTING_PLAN: 'CRAFTING_PLAN' },
+    marketplaceSession: { isActive: vi.fn(), end: vi.fn(), start: vi.fn() },
+}));
+vi.mock('./crafting-plan-calculator.js', () => ({ computeBestCraftingPlan: vi.fn() }));
+vi.mock('../../utils/ui-components.js', () => ({ createCollapsibleSection: vi.fn() }));
+vi.mock('../../utils/formatters.js', () => ({
+    formatKMB: vi.fn((value) => (value === 1700 ? '1.7K' : String(value))),
+    formatWithSeparator: vi.fn((value) => String(value)),
+    timeReadable: vi.fn((value) => {
+        if (value === 133.4) return '0h 02m 13s';
+        if (value === 70) return '0h 01m 10s';
+        return `${value}s`;
+    }),
+}));
+vi.mock('../../utils/game-lookups.js', () => ({ getActionHridFromName: vi.fn() }));
+vi.mock('../../utils/action-panel-helper.js', () => ({ findActionInput: vi.fn() }));
+vi.mock('../../utils/marketplace-tabs.js', () => ({
+    createMaterialTab: vi.fn(),
+    removeMaterialTabsForOwner: vi.fn(),
+    getVisibleMarketplaceTabContainer: vi.fn(),
+    setupMarketplaceCleanupObserver: vi.fn(),
+    navigateToMarketplace: vi.fn(),
+    updateTabBadge: vi.fn(),
+    watchNativeTabExit: vi.fn(),
+    clickMarketplaceNavigationButton: vi.fn(),
+    MARKETPLACE_REMOUNT_GRACE_MS: 350,
+    isMarketplaceMarketListingsSelected: vi.fn(),
+}));
+vi.mock('../../utils/marketplace-autofill.js', () => ({
+    createAutofillManager: vi.fn(() => ({
+        initialize: vi.fn(),
+        startSession: vi.fn(),
+        arm: vi.fn(),
+        exitSession: vi.fn(),
+        cleanup: vi.fn(),
+    })),
+}));
+vi.mock('../../utils/action-calculator.js', () => ({ calculateActionStats: mockCalculateActionStats }));
+vi.mock('../../utils/efficiency.js', () => ({ calculateEfficiencyMultiplier: mockCalculateEfficiencyMultiplier }));
+vi.mock('../../utils/experience-calculator.js', () => ({ calculateExpPerHour: mockCalculateExpPerHour }));
+vi.mock('../actions/production-tools-layout.js', () => ({ compactActionPanelSection: vi.fn((section) => section) }));
+
+import { calculateCraftingPlanMetrics, formatCraftingPlanSummary } from './crafting-plan-display.js';
+
+const ACTION_HRID = '/actions/cooking/marsberry_cake';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockDataManager.getInitClientData.mockReturnValue({
+        actionDetailMap: { [ACTION_HRID]: { hrid: ACTION_HRID } },
+        itemDetailMap: {},
+    });
+    mockDataManager.getSkills.mockReturnValue(new Map());
+    mockDataManager.getEquipment.mockReturnValue(new Map());
+    mockCalculateActionStats.mockReturnValue({ actionTime: 5.53, totalEfficiency: 0 });
+    mockCalculateEfficiencyMultiplier.mockReturnValue(1);
+    mockCalculateExpPerHour.mockReturnValue(null);
+});
+
+describe('calculateCraftingPlanMetrics', () => {
+    test('sums every step into the same total used by the expanded plan', () => {
+        const secondActionHrid = '/actions/tailoring/umbral_chaps';
+        mockDataManager.getInitClientData.mockReturnValue({
+            actionDetailMap: {
+                [ACTION_HRID]: { hrid: ACTION_HRID },
+                [secondActionHrid]: { hrid: secondActionHrid },
+            },
+            itemDetailMap: {},
+        });
+        mockCalculateActionStats
+            .mockReturnValueOnce({ actionTime: 5, totalEfficiency: 0 })
+            .mockReturnValueOnce({ actionTime: 20, totalEfficiency: 0 });
+
+        const metrics = calculateCraftingPlanMetrics([
+            { itemName: 'Marsberry Cake', actionHrid: ACTION_HRID, actionsNeeded: 2, quantity: 2 },
+            { itemName: 'Umbral Chaps', actionHrid: secondActionHrid, actionsNeeded: 3, quantity: 3 },
+        ]);
+
+        expect(metrics.totalCraftSeconds).toBe(70);
+        expect(metrics.steps.map((step) => step.totalSeconds)).toEqual([10, 60]);
+    });
+});
+
+describe('formatCraftingPlanSummary', () => {
+    test('shows the formatted total time for the full multi-step plan', () => {
+        expect(formatCraftingPlanSummary({ strategy: 'craft', unitCost: 1700 }, 133.4)).toBe('1.7K/ea · 2m 13s');
+    });
+
+    test('shows cost only when the plan has no craft time', () => {
+        expect(formatCraftingPlanSummary({ strategy: 'buy', unitCost: 1700 }, 0)).toBe('1.7K/ea');
+    });
+});

--- a/src/features/house/house-cost-calculator.test.js
+++ b/src/features/house/house-cost-calculator.test.js
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { mockGetInitClientData, mockGetItemPrice } = vi.hoisted(() => ({
+    mockGetInitClientData: vi.fn(),
+    mockGetItemPrice: vi.fn(),
+}));
+
+vi.mock('../../core/data-manager.js', () => ({
+    default: {
+        getInitClientData: mockGetInitClientData,
+        getHouseRoomLevel: vi.fn(),
+        getInventory: vi.fn(),
+    },
+}));
+vi.mock('../../api/marketplace.js', () => ({
+    default: {
+        isLoaded: vi.fn(() => true),
+        fetch: vi.fn(),
+    },
+}));
+vi.mock('../../utils/market-data.js', () => ({ getItemPrice: mockGetItemPrice }));
+
+import houseCostCalculator from './house-cost-calculator.js';
+
+const ROOM = '/house_rooms/kitchen';
+const SUGAR = '/items/sugar';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetInitClientData.mockReturnValue({
+        houseRoomDetailMap: {
+            [ROOM]: {
+                upgradeCostsMap: {
+                    2: [
+                        { itemHrid: '/items/coin', count: 2_000_000 },
+                        { itemHrid: SUGAR, count: 8_000 },
+                    ],
+                    3: [
+                        { itemHrid: '/items/coin', count: 5_000_000 },
+                        { itemHrid: SUGAR, count: 20_000 },
+                    ],
+                },
+            },
+        },
+        itemDetailMap: {
+            [SUGAR]: { sellPrice: 2 },
+        },
+    });
+    mockGetItemPrice.mockReturnValue(13);
+});
+
+describe('HouseCostCalculator market pricing', () => {
+    test('uses ask prices for every purchased construction material', async () => {
+        const result = await houseCostCalculator.calculateCumulativeCost(ROOM, 1, 3);
+
+        expect(mockGetItemPrice).toHaveBeenCalledTimes(2);
+        expect(mockGetItemPrice).toHaveBeenNthCalledWith(1, SUGAR, { mode: 'ask' });
+        expect(mockGetItemPrice).toHaveBeenNthCalledWith(2, SUGAR, { mode: 'ask' });
+        expect(result).toMatchObject({
+            coins: 7_000_000,
+            materials: [
+                {
+                    itemHrid: SUGAR,
+                    count: 28_000,
+                    marketPrice: 13,
+                    totalValue: 364_000,
+                },
+            ],
+            totalValue: 7_364_000,
+        });
+    });
+});

--- a/src/features/house/house-cost-display.js
+++ b/src/features/house/house-cost-display.js
@@ -103,6 +103,20 @@ class HouseCostDisplay {
     }
 
     /**
+     * Resolve the room level from the same live House component that renders the modal.
+     * The DataManager cache remains a fallback for startup/test states, but must not
+     * override newer React props after an upgrade message or panel remount.
+     * @param {string} houseRoomHrid
+     * @returns {number}
+     */
+    _getLiveHouseRoomLevel(houseRoomHrid) {
+        const houseComponent = this._getHouseComponent(houseRoomHrid);
+        const liveLevel = houseComponent?.props?.characterHouseRoomDict?.[houseRoomHrid]?.level;
+        if (Number.isInteger(liveLevel) && liveLevel >= 0) return liveLevel;
+        return houseCostCalculator.getCurrentRoomLevel(houseRoomHrid);
+    }
+
+    /**
      * Augment native costs section with market pricing
      * @param {Element} costsSection - The native HousePanel_costs element
      * @param {string} houseRoomHrid - House room HRID
@@ -110,8 +124,9 @@ class HouseCostDisplay {
      */
     async addCostColumn(costsSection, houseRoomHrid, modalContent) {
         this.removeExistingColumn(modalContent);
+        this.currentModalContent = modalContent;
 
-        const currentLevel = houseCostCalculator.getCurrentRoomLevel(houseRoomHrid);
+        const currentLevel = this._getLiveHouseRoomLevel(houseRoomHrid);
 
         if (currentLevel >= 8) {
             return;
@@ -119,7 +134,6 @@ class HouseCostDisplay {
 
         try {
             await this.addCompactToLevel(costsSection, houseRoomHrid, currentLevel);
-            this.currentModalContent = modalContent;
         } catch {
             // Silently fail - augmentation is optional
         }
@@ -1175,16 +1189,30 @@ class HouseCostDisplay {
             return;
         }
 
-        // Reopen the saved House room through its visible native tile. A bounded
-        // component fallback supports modal-based retained clients without scanning the root.
-        if (!this._openHouseRoomByHrid(houseRoomHrid)) {
-            fallbackHouseComponent = fallbackHouseComponent || this._getHouseComponent();
-            if (!fallbackHouseComponent || typeof fallbackHouseComponent.handleHouseRoomClicked !== 'function') {
-                console.error('[HouseCostDisplay] Return: could not open the saved House room');
-                this.exitHouseMarketplaceSession(capturedSessionId);
-                return;
-            }
+        // Restore through the freshly mounted visible House React owner. Restoring a
+        // previous main-nav target can remount the House panel (notably while combat is
+        // active), so a stale pre-Marketplace tile/component must never receive the click.
+        fallbackHouseComponent = this._getHouseComponent();
+        if (!fallbackHouseComponent) {
+            await this._pollUntil(
+                () => {
+                    fallbackHouseComponent = this._getHouseComponent();
+                    return Boolean(fallbackHouseComponent);
+                },
+                2000,
+                50
+            );
+        }
+
+        if (this._houseReturnGeneration !== generation) return;
+        if (capturedSessionId !== this._houseSessionId || !marketplaceSession.isActive(capturedSessionId)) return;
+
+        if (fallbackHouseComponent && typeof fallbackHouseComponent.handleHouseRoomClicked === 'function') {
             fallbackHouseComponent.handleHouseRoomClicked(houseRoomHrid);
+        } else if (!this._openHouseRoomByHrid(houseRoomHrid)) {
+            console.error('[HouseCostDisplay] Return: could not open the saved House room');
+            this.exitHouseMarketplaceSession(capturedSessionId);
+            return;
         }
 
         // Bounded wait: freshly connected exact-room Toolasha target control
@@ -1333,7 +1361,7 @@ class HouseCostDisplay {
             return;
         }
 
-        const newLevel = houseCostCalculator.getCurrentRoomLevel(houseRoomHrid);
+        const newLevel = this._getLiveHouseRoomLevel(houseRoomHrid);
         if (newLevel >= 8) {
             costContainer.innerHTML = '';
             this._cumulativeState = null;

--- a/src/features/house/house-cost-display.test.js
+++ b/src/features/house/house-cost-display.test.js
@@ -222,6 +222,7 @@ function makeMarketplaceComponent() {
 }
 
 function resetInstanceState() {
+    houseCostDisplay.currentModalContent = null;
     houseCostDisplay._houseSessionId = null;
     houseCostDisplay._nativeTabExitCleanup = null;
     houseCostDisplay._houseReturnGeneration = 0;
@@ -455,6 +456,51 @@ describe('HouseCostDisplay — Section 3 Rev2 correction', () => {
             p['__reactFiber$abc'] = chain;
 
             expect(houseCostDisplay._getMarketplaceComponent()).toBeNull();
+        });
+    });
+
+    // =========================================================================
+    // _getLiveHouseRoomLevel
+    // =========================================================================
+
+    describe('_getLiveHouseRoomLevel', () => {
+        it('prefers the live House component level over a stale DataManager cache', () => {
+            const component = makeHouseComponent({
+                props: {
+                    characterHouseRoomDict: {
+                        '/house_rooms/library': { houseRoomHrid: '/house_rooms/library', level: 4 },
+                    },
+                },
+            });
+            const getHouseSpy = vi.spyOn(houseCostDisplay, '_getHouseComponent').mockReturnValue(component);
+
+            expect(houseCostDisplay._getLiveHouseRoomLevel('/house_rooms/library')).toBe(4);
+            getHouseSpy.mockRestore();
+        });
+
+        it('falls back to the calculator cache when the live owner is unavailable', () => {
+            const getHouseSpy = vi.spyOn(houseCostDisplay, '_getHouseComponent').mockReturnValue(null);
+
+            expect(houseCostDisplay._getLiveHouseRoomLevel('/house_rooms/library')).toBe(3);
+            getHouseSpy.mockRestore();
+        });
+
+        it('anchors the live modal before resolving its room level', async () => {
+            const modalContent = document.createElement('div');
+            const costsSection = document.createElement('div');
+            modalContent.appendChild(costsSection);
+            document.body.appendChild(modalContent);
+
+            const levelSpy = vi.spyOn(houseCostDisplay, '_getLiveHouseRoomLevel').mockImplementation(() => {
+                expect(houseCostDisplay.currentModalContent).toBe(modalContent);
+                return 2;
+            });
+            const compactSpy = vi.spyOn(houseCostDisplay, 'addCompactToLevel').mockResolvedValue();
+
+            await houseCostDisplay.addCostColumn(costsSection, '/house_rooms/library', modalContent);
+
+            expect(levelSpy).toHaveBeenCalledWith('/house_rooms/library');
+            expect(compactSpy).toHaveBeenCalledWith(costsSection, '/house_rooms/library', 2);
         });
     });
 
@@ -1117,6 +1163,36 @@ describe('HouseCostDisplay — Section 3 Rev2 correction', () => {
 
             expect(callOrder.indexOf('closeMarket')).toBeLessThan(callOrder.indexOf('roomClick'));
             vi.useRealTimers();
+        });
+
+        it('waits for a freshly remounted House owner before reopening the room', async () => {
+            houseCostDisplay._houseSessionId = 9;
+            mockIsActive.mockReturnValue(true);
+
+            vi.spyOn(houseCostDisplay, '_getMarketplaceComponent').mockReturnValue(makeMarketplaceComponent());
+            const freshHouse = makeHouseComponent({ state: { selectedHouseRoomHrid: null } });
+            const getHouseSpy = vi
+                .spyOn(houseCostDisplay, '_getHouseComponent')
+                .mockReturnValueOnce(null)
+                .mockReturnValue(freshHouse);
+
+            const dropdown = makeConnectedDropdown(['5']);
+            houseCostDisplay._cumulativeState = {
+                houseRoomHrid: '/house_rooms/library',
+                dropdown,
+                costContainer: makeConnectedCostContainer(),
+            };
+            freshHouse.handleHouseRoomClicked.mockImplementation((hrid) => {
+                freshHouse.state.selectedHouseRoomHrid = hrid;
+            });
+            houseCostDisplay._pollUntil = vi.fn(async (predicate) => Boolean(predicate()));
+
+            await houseCostDisplay._handleHouseReturn(makeReturnContext());
+
+            expect(getHouseSpy).toHaveBeenCalledTimes(2);
+            expect(freshHouse.handleHouseRoomClicked).toHaveBeenCalledWith('/house_rooms/library');
+            expect(dropdown.value).toBe('5');
+            expect(mockEnd).toHaveBeenCalledWith(9);
         });
 
         it('a stale rejected Return does not advance generation or cancel current work', async () => {

--- a/src/features/inventory/custom-tabs/custom-tabs-layout-guards.js
+++ b/src/features/inventory/custom-tabs/custom-tabs-layout-guards.js
@@ -1,0 +1,36 @@
+/**
+ * Return true only when every Toolasha-owned layout node is still attached to
+ * the current Inventory container.
+ * @param {Element[]} injectedElements
+ * @param {Element|null} inventoryContainer
+ * @returns {boolean}
+ */
+export function areInjectedLayoutElementsAttached(injectedElements, inventoryContainer) {
+    return (
+        Boolean(inventoryContainer) &&
+        injectedElements.length > 0 &&
+        injectedElements.every((element) => element?.parentElement === inventoryContainer)
+    );
+}
+
+const RELEVANT_LAYOUT_SELECTOR = [
+    '[class*="Item_itemContainer"]',
+    '.toolasha-ct-topbar',
+    '.toolasha-ct-section-header',
+    '.toolasha-ct-unorg-header',
+    '.toolasha-ct-empty',
+    '.toolasha-ct-linebreak',
+].join(', ');
+
+/**
+ * Return true when a mutation added or removed an inventory tile or one of the
+ * Toolasha-owned layout nodes whose loss requires a layout integrity pass.
+ * @param {MutationRecord} mutation
+ * @returns {boolean}
+ */
+export function mutationTouchesCustomTabsLayout(mutation) {
+    return [...mutation.addedNodes, ...mutation.removedNodes].some((node) => {
+        if (node?.nodeType !== 1) return false;
+        return Boolean(node.matches?.(RELEVANT_LAYOUT_SELECTOR) || node.querySelector?.(RELEVANT_LAYOUT_SELECTOR));
+    });
+}

--- a/src/features/inventory/custom-tabs/custom-tabs-layout-guards.test.js
+++ b/src/features/inventory/custom-tabs/custom-tabs-layout-guards.test.js
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { describe, expect, test } from 'vitest';
+import { areInjectedLayoutElementsAttached, mutationTouchesCustomTabsLayout } from './custom-tabs-layout-guards.js';
+
+describe('custom tabs layout guards', () => {
+    test('detects when only the trailing Unorganized header was removed', () => {
+        const container = document.createElement('div');
+        const topbar = document.createElement('div');
+        const unorganized = document.createElement('div');
+        unorganized.className = 'toolasha-ct-unorg-header';
+        container.append(topbar, unorganized);
+
+        expect(areInjectedLayoutElementsAttached([topbar, unorganized], container)).toBe(true);
+
+        unorganized.remove();
+
+        expect(areInjectedLayoutElementsAttached([topbar, unorganized], container)).toBe(false);
+    });
+
+    test('treats removal of an injected header as a relevant layout mutation', () => {
+        const unorganized = document.createElement('div');
+        unorganized.className = 'toolasha-ct-unorg-header';
+
+        expect(
+            mutationTouchesCustomTabsLayout({
+                addedNodes: [],
+                removedNodes: [unorganized],
+            })
+        ).toBe(true);
+    });
+
+    test('ignores unrelated text and elements', () => {
+        expect(
+            mutationTouchesCustomTabsLayout({
+                addedNodes: [document.createTextNode('unrelated')],
+                removedNodes: [document.createElement('span')],
+            })
+        ).toBe(false);
+    });
+});

--- a/src/features/inventory/custom-tabs/custom-tabs-ui.js
+++ b/src/features/inventory/custom-tabs/custom-tabs-ui.js
@@ -23,6 +23,7 @@ function getLoadoutSnapshot() {
     return window.Toolasha?.Combat?.loadoutSnapshot || loadoutSnapshotLocal;
 }
 import { formatKMB } from '../../../utils/formatters.js';
+import { areInjectedLayoutElementsAttached, mutationTouchesCustomTabsLayout } from './custom-tabs-layout-guards.js';
 import {
     loadConfig,
     saveConfig,
@@ -833,8 +834,7 @@ export default class CustomTabsUI {
     _applyLayoutSync(invContainer) {
         // Compare BEFORE assignment — otherwise isSameNode is always true
         const isSameNode = invContainer === this._invContainer;
-        const injectedStillPresent =
-            this._injectedEls.length > 0 && this._injectedEls[0].parentElement === invContainer;
+        const injectedStillPresent = areInjectedLayoutElementsAttached(this._injectedEls, invContainer);
         let needsFullRebuild = !isSameNode || !injectedStillPresent;
 
         this._invContainer = invContainer;
@@ -919,15 +919,8 @@ export default class CustomTabsUI {
             this._observedContainer = invContainer;
             this._tileObserver = new MutationObserver((mutations) => {
                 if (!this._isActive) return;
-                const hasTileChange = mutations.some((m) =>
-                    [...m.addedNodes, ...m.removedNodes].some(
-                        (n) =>
-                            n.nodeType === Node.ELEMENT_NODE &&
-                            (n.className?.includes?.('Item_itemContainer') ||
-                                n.querySelector?.('[class*="Item_itemContainer"]'))
-                    )
-                );
-                if (hasTileChange) this._applyLayoutSync(invContainer);
+                const hasRelevantChange = mutations.some(mutationTouchesCustomTabsLayout);
+                if (hasRelevantChange) this._applyLayoutSync(invContainer);
             });
             this._tileObserver.observe(invContainer, { childList: true, subtree: true });
         }

--- a/src/utils/marketplace-autofill.js
+++ b/src/utils/marketplace-autofill.js
@@ -392,13 +392,18 @@ export function createAutofillManager(observerId) {
 
     function targetMatchesInput(target, quantityInput) {
         const state = readMarketplaceRuntimeStateFromElement(quantityInput);
+        // MWI uses two exact buy forms: an instant order from an existing ask and
+        // a patient New Buy Listing. Reject mixed flag states rather than widening
+        // the verified write path to every post-listing modal.
+        const isInstantBuy = state?.isPostNewListing === false && state?.isInstantOrder === true;
+        const isNewBuyListing = state?.isPostNewListing === true && state?.isInstantOrder === false;
+
         return (
             state?.marketTabKey === 'MarketListings' &&
             state?.marketListingsView === 'OrderBook' &&
             state?.showPostListing === true &&
-            state?.isPostNewListing === false &&
             state?.isSell === false &&
-            state?.isInstantOrder === true &&
+            (isInstantBuy || isNewBuyListing) &&
             state?.itemHrid === target.itemHrid &&
             state?.enhancementLevel === target.enhancementLevel &&
             state?.enhancementLevelInput === target.enhancementLevel

--- a/src/utils/marketplace-autofill.test.js
+++ b/src/utils/marketplace-autofill.test.js
@@ -178,6 +178,24 @@ describe('marketplace-autofill', () => {
         manager.cleanup();
     });
 
+    test('fills the exact matching New Buy Listing modal', () => {
+        const { manager, sessionId } = startManager({ quantityProvider: () => 900 });
+        const component = makeMarketplaceComponent({
+            isPostNewListing: true,
+            isInstantOrder: false,
+        });
+        const { modal, input } = makeBuyModal(component, { title: 'Buy Listing' });
+        const inputEvents = vi.fn();
+        input.addEventListener('input', inputEvents);
+
+        emitModal(modal);
+
+        expect(input.value).toBe('900');
+        expect(inputEvents).toHaveBeenCalledTimes(1);
+        expect(marketplaceSession.isActive(sessionId)).toBe(true);
+        manager.cleanup();
+    });
+
     test('does not fill a modal for a different item and keeps the exact target armed', () => {
         const { manager } = startManager({ quantityProvider: () => 865 });
         const component = makeMarketplaceComponent({ itemHrid: '/items/verdant_milk' });
@@ -200,8 +218,8 @@ describe('marketplace-autofill', () => {
         ['wrong selected enhancement level', { enhancementLevel: 1 }],
         ['wrong modal enhancement level', { enhancementLevelInput: 1 }],
         ['closed post-listing modal state', { showPostListing: false }],
-        ['new listing state', { isPostNewListing: true }],
-        ['non-instant order state', { isInstantOrder: false }],
+        ['inconsistent instant new-listing state', { isPostNewListing: true, isInstantOrder: true }],
+        ['inconsistent non-instant existing-order state', { isPostNewListing: false, isInstantOrder: false }],
         ['wrong Marketplace view', { marketListingsView: 'ItemGrid' }],
     ])('rejects %s', (_label, stateOverride) => {
         const { manager } = startManager();

--- a/src/utils/material-calculator.test.js
+++ b/src/utils/material-calculator.test.js
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { mockGetActionDetails, mockGetCurrentActions, mockGetInventory, mockGetInitClientData } = vi.hoisted(() => ({
+    mockGetActionDetails: vi.fn(),
+    mockGetCurrentActions: vi.fn(),
+    mockGetInventory: vi.fn(),
+    mockGetInitClientData: vi.fn(),
+}));
+
+vi.mock('../core/config.js', () => ({
+    default: {
+        getSettingValue: vi.fn(() => 'expected'),
+    },
+}));
+
+vi.mock('../core/data-manager.js', () => ({
+    default: {
+        getActionDetails: mockGetActionDetails,
+        getCurrentActions: mockGetCurrentActions,
+        getInventory: mockGetInventory,
+        getInitClientData: mockGetInitClientData,
+    },
+}));
+
+vi.mock('./tea-parser.js', () => ({
+    parseArtisanBonus: vi.fn(() => 0.1),
+    getDrinkConcentration: vi.fn(() => 1),
+}));
+
+vi.mock('./action-context.js', () => ({
+    resolveActionContext: vi.fn(() => ({ equipment: new Map(), drinks: [] })),
+}));
+
+vi.mock('./enhancement-config.js', () => ({ getEnhancingParams: vi.fn() }));
+vi.mock('./enhancement-calculator.js', () => ({ calculateEnhancement: vi.fn() }));
+
+import { calculateMaterialRequirements, calculateQueuedMaterialsForAction } from './material-calculator.js';
+
+const SUGAR = '/items/sugar';
+const CAKE = '/actions/cooking/marsberry_cake';
+const DONUT = '/actions/cooking/marsberry_donut';
+
+describe('material-calculator queue reservations', () => {
+    beforeEach(() => {
+        mockGetActionDetails.mockImplementation((actionHrid) => {
+            if (actionHrid === CAKE) {
+                return {
+                    hrid: CAKE,
+                    type: '/action_types/cooking',
+                    inputItems: [{ itemHrid: SUGAR, count: 2 }],
+                };
+            }
+            if (actionHrid === DONUT) {
+                return {
+                    hrid: DONUT,
+                    type: '/action_types/cooking',
+                    inputItems: [{ itemHrid: SUGAR, count: 4 }],
+                };
+            }
+            return null;
+        });
+        mockGetCurrentActions.mockReturnValue([
+            {
+                actionHrid: DONUT,
+                hasMaxCount: true,
+                maxCount: 1000,
+                currentCount: 176,
+            },
+        ]);
+        mockGetInventory.mockReturnValue([
+            {
+                itemHrid: SUGAR,
+                itemLocationHrid: '/item_locations/inventory',
+                enhancementLevel: 0,
+                count: 4758,
+            },
+        ]);
+        mockGetInitClientData.mockReturnValue({
+            itemDetailMap: {
+                [SUGAR]: { name: 'Sugar', isTradable: true },
+            },
+        });
+    });
+
+    test('matches the reported Marsberry queue math exactly', () => {
+        const queued = calculateQueuedMaterialsForAction();
+        expect(queued.get(SUGAR)).toBe(2967); // ceil(824 remaining × 4 × 0.9)
+
+        const [sugar] = calculateMaterialRequirements(CAKE, 1000, true);
+        expect(sugar).toMatchObject({
+            required: 1800,
+            have: 4758,
+            queued: 2967,
+            available: 1791,
+            missing: 9,
+        });
+    });
+
+    test('ignoring the queue leaves the same inventory fully available', () => {
+        const [sugar] = calculateMaterialRequirements(CAKE, 1000, false);
+        expect(sugar).toMatchObject({
+            required: 1800,
+            have: 4758,
+            queued: 0,
+            available: 4758,
+            missing: 0,
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Three independently reviewable fixes (TLA-014), each verified against current source and the MWI client reference before applying:

1. **Restore queue-aware missing mats buying** — compacts the duplicated `Required`/`Missing` queue text, adds a regression test locking in the existing (already-correct) queue-reservation arithmetic, and extends Missing Mats autofill to accept `New Buy Listing` (`isPostNewListing=true, isInstantOrder=false`) in addition to the existing instant `Buy Now` path (`isPostNewListing=false, isInstantOrder=true`) — both states verified directly against the MWI client bundle's `handleShowPrefilledPostListing`/`handleShowNewPostListing` call sites.
2. **Align House costs and Return with live state** — resolves House's current room level from the live React component (`characterHouseRoomDict[houseRoomHrid].level`) instead of a cache that can go stale relative to the native modal; fixes House Return reopening the wrong/no room after a navigation-restore remount (notably while combat is active) by resolving a fresh House owner after restoration instead of reusing a pre-wait stale reference. Ask pricing was already correct and is unchanged (locked in with a new test).
3. **Restore custom inventory and crafting summaries** — fixes Custom Inventory Tabs' `Unorganized` header intermittently disappearing (integrity check only looked at the first injected node, and the tile observer ignored removal of Toolasha's own header nodes) with a bounded, non-looping self-repair. Best Crafting Plan's collapsed summary now shows the full multi-step plan's total craft time (matching the expanded section's canonical `Total craft time`) instead of a single root action's duration — this was corrected once during runtime acceptance (see below).

## Runtime acceptance

Full runtime acceptance matrix (`RUNTIME_ACCEPTANCE.md`) run by Vladimir against the first dev build (`SHA-256 c78290050eb4e38a8e697d2d6949845e5de6b25fd97d25b81f5532f3155b7ad1`):

| Case | Result |
|---|---|
| 1. Custom Inventory Tabs `Unorganized` self-repair | PASS |
| 2. House live level and ask-valued cumulative total | PASS |
| 3. Dairy Barn Return and Garden control flow | PASS |
| 4. Compact Required/Missing queue text | PASS |
| 5. Queue-aware missing-material quantity | PASS |
| 6. Best Crafting Plan collapsed time | FAIL — isolated root-action-time semantic defect |
| 7. New Buy Listing and instant Buy autofill | PASS |

Case 6 was corrected (collapsed summary now reuses the exact same `totalCraftSeconds` as the expanded plan's `Total craft time`, computed once via a new `calculateCraftingPlanMetrics` helper) and independently re-reviewed against current source. No second manual runtime pass was required for this correction per Vladimir's authorization.

**Accepted and unchanged by this PR:** the one-item difference between `Direct recipe cost` and `Best crafting plan` under fractional Artisan consumption (direct acquisition rounds to whole market items for the actual batch; the plan's expected-cost calculation may be fractional — these converge for larger batches). Direct Recipe Cost, Artisan rounding, Missing Mats quantities, shopping-list math, and plan selection are all unchanged.

## Test plan

- [x] `npm test` — 607/607 passing (0 failures)
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run format:check` — clean
- [x] `npm run build:dev` — succeeded
- [x] `npm run build` — succeeded
- [x] Bundle-size gate (exact `ci.yml` logic) — all 14 dist files under the 2MB limit
- [x] `src/utils/panel-z-index.js` / `src/utils/performance-monitor.js` — confirmed untouched
- [x] No retention/cap/prune/archive/aggregate/compaction logic introduced
- [x] All six intended source changes confirmed present in the compiled dev bundle