### PR TITLE
fix: serialize character switch reinitialization

### DIFF
--- a/src/core/feature-registry-lifecycle.test.js
+++ b/src/core/feature-registry-lifecycle.test.js
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
     applyColorSettings: vi.fn(),
     endAll: vi.fn(),
     clearAllMarketplaceUI: vi.fn(),
+    currentCharacterId: 'a',
 }));
 
 vi.mock('./config.js', () => ({
@@ -23,6 +24,7 @@ vi.mock('./config.js', () => ({
 vi.mock('./data-manager.js', () => ({
     default: {
         getIsCharacterSwitching: vi.fn(() => false),
+        getCurrentCharacterId: vi.fn(() => mocks.currentCharacterId),
         on: vi.fn((event, handler) => mocks.handlers.set(event, handler)),
     },
 }));
@@ -38,11 +40,21 @@ vi.mock('./marketplace-session.js', () => ({
     },
 }));
 
+function createDeferred() {
+    let resolve;
+    const promise = new Promise((resolver) => {
+        resolve = resolver;
+    });
+    return { promise, resolve };
+}
+
 beforeEach(() => {
     vi.useFakeTimers();
     vi.resetModules();
     vi.clearAllMocks();
     mocks.handlers.clear();
+    mocks.currentCharacterId = 'a';
+    mocks.loadSettings.mockImplementation(async () => {});
 });
 
 afterEach(() => {
@@ -68,6 +80,7 @@ describe('FeatureRegistry character-switch lifecycle ownership', () => {
         await registry.initializeFeatures();
         registry.setupCharacterSwitchHandler();
 
+        mocks.currentCharacterId = 'b';
         await mocks.handlers.get('character_switching')({ oldId: 'a', newId: 'b' });
         const switched = mocks.handlers.get('character_switched')({ oldId: 'a', newId: 'b' });
         await vi.advanceTimersByTimeAsync(50);
@@ -76,6 +89,120 @@ describe('FeatureRegistry character-switch lifecycle ownership', () => {
         expect(featureModule.cleanup).toHaveBeenCalledTimes(1);
         expect(featureModule.initialize).toHaveBeenCalledTimes(2);
         expect(mocks.loadSettings).toHaveBeenCalledWith({ notifyChanges: false });
+    });
+
+    test('coalesces rapid A → B → A switches to the latest character', async () => {
+        const registry = (await import('./feature-registry.js')).default;
+        const cleanupGate = createDeferred();
+        const initializedFor = [];
+        const featureModule = {
+            initialize: vi.fn(() => initializedFor.push(mocks.currentCharacterId)),
+            cleanup: vi.fn(() => cleanupGate.promise),
+        };
+
+        registry.replaceFeatures([
+            {
+                key: 'itemCountDisplay',
+                name: 'Item Count Display',
+                module: featureModule,
+                initialize: featureModule.initialize,
+            },
+        ]);
+        await registry.initializeFeatures();
+        registry.setupCharacterSwitchHandler();
+
+        mocks.currentCharacterId = 'b';
+        mocks.handlers.get('character_switching')({ oldId: 'a', newId: 'b' });
+        mocks.handlers.get('character_switched')({ oldId: 'a', newId: 'b' });
+
+        mocks.currentCharacterId = 'a';
+        mocks.handlers.get('character_switching')({ oldId: 'b', newId: 'a' });
+        const finalSwitch = mocks.handlers.get('character_switched')({ oldId: 'b', newId: 'a' });
+
+        cleanupGate.resolve();
+        await vi.advanceTimersByTimeAsync(50);
+        await finalSwitch;
+
+        expect(featureModule.cleanup).toHaveBeenCalledTimes(1);
+        expect(featureModule.initialize).toHaveBeenCalledTimes(2);
+        expect(initializedFor).toEqual(['a', 'a']);
+        expect(mocks.loadSettings).toHaveBeenCalledTimes(1);
+        expect(mocks.applyColorSettings).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not initialize new-character features before slow cleanup completes', async () => {
+        const registry = (await import('./feature-registry.js')).default;
+        const cleanupGate = createDeferred();
+        const featureModule = {
+            initialize: vi.fn(),
+            cleanup: vi.fn(() => cleanupGate.promise),
+        };
+
+        registry.replaceFeatures([
+            {
+                key: 'itemCountDisplay',
+                name: 'Item Count Display',
+                module: featureModule,
+                initialize: featureModule.initialize,
+            },
+        ]);
+        await registry.initializeFeatures();
+        registry.setupCharacterSwitchHandler();
+
+        mocks.currentCharacterId = 'b';
+        mocks.handlers.get('character_switching')({ oldId: 'a', newId: 'b' });
+        const switched = mocks.handlers.get('character_switched')({ oldId: 'a', newId: 'b' });
+
+        await vi.advanceTimersByTimeAsync(550);
+        expect(mocks.loadSettings).not.toHaveBeenCalled();
+        expect(featureModule.initialize).toHaveBeenCalledTimes(1);
+
+        cleanupGate.resolve();
+        await vi.advanceTimersByTimeAsync(50);
+        await switched;
+
+        expect(mocks.loadSettings).toHaveBeenCalledTimes(1);
+        expect(featureModule.initialize).toHaveBeenCalledTimes(2);
+    });
+
+    test('abandons settings loaded for a character that becomes stale mid-load', async () => {
+        const registry = (await import('./feature-registry.js')).default;
+        const firstLoadGate = createDeferred();
+        const initializedFor = [];
+        const featureModule = {
+            initialize: vi.fn(() => initializedFor.push(mocks.currentCharacterId)),
+            cleanup: vi.fn(),
+        };
+        mocks.loadSettings.mockImplementationOnce(() => firstLoadGate.promise).mockImplementationOnce(async () => {});
+
+        registry.replaceFeatures([
+            {
+                key: 'itemCountDisplay',
+                name: 'Item Count Display',
+                module: featureModule,
+                initialize: featureModule.initialize,
+            },
+        ]);
+        await registry.initializeFeatures();
+        registry.setupCharacterSwitchHandler();
+
+        mocks.currentCharacterId = 'b';
+        mocks.handlers.get('character_switching')({ oldId: 'a', newId: 'b' });
+        mocks.handlers.get('character_switched')({ oldId: 'a', newId: 'b' });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(mocks.loadSettings).toHaveBeenCalledTimes(1);
+
+        mocks.currentCharacterId = 'a';
+        mocks.handlers.get('character_switching')({ oldId: 'b', newId: 'a' });
+        const finalSwitch = mocks.handlers.get('character_switched')({ oldId: 'b', newId: 'a' });
+
+        firstLoadGate.resolve();
+        await vi.advanceTimersByTimeAsync(50);
+        await finalSwitch;
+
+        expect(mocks.loadSettings).toHaveBeenCalledTimes(2);
+        expect(mocks.applyColorSettings).toHaveBeenCalledTimes(1);
+        expect(initializedFor).toEqual(['a', 'a']);
     });
 
     test('dungeon modules do not own additional character_switching cleanup listeners', () => {

--- a/src/core/feature-registry.js
+++ b/src/core/feature-registry.js
@@ -22,17 +22,23 @@ const featureInstances = new Map();
 
 /**
  * Initialize all enabled features
+ * @param {Object} [options] - Optional lifecycle guard
+ * @param {Function} [options.shouldContinue] - Returns false when initialization has become stale
  * @returns {Promise<void>}
  */
-async function initializeFeatures() {
+async function initializeFeatures({ shouldContinue = () => true } = {}) {
     // Block feature initialization during character switch
-    if (dataManager.getIsCharacterSwitching()) {
+    if (dataManager.getIsCharacterSwitching() || !shouldContinue()) {
         return;
     }
 
     const errors = [];
 
     for (const feature of featureRegistry) {
+        if (!shouldContinue()) {
+            break;
+        }
+
         try {
             const isEnabled = feature.customCheck ? feature.customCheck() : config.isFeatureEnabled(feature.key);
 
@@ -184,62 +190,91 @@ function checkFeatureHealth() {
  * Re-initializes all features when character switches
  */
 function setupCharacterSwitchHandler() {
-    // Promise that resolves when cleanup is complete
-    let cleanupPromise = null;
-    let reinitScheduled = false;
+    // Character switch lifecycle work is serialized through one queue. A monotonic
+    // generation lets stale reinits stop when a newer switch arrives (A → B → A).
+    // This prevents both dropped switch events and late cleanup from touching the
+    // newest character's freshly initialized features.
+    let lifecycleGeneration = 0;
+    let lifecycleQueue = Promise.resolve();
+
+    const enqueueLifecycleTask = (label, task) => {
+        lifecycleQueue = lifecycleQueue
+            .catch((error) => {
+                console.error('[FeatureRegistry] Previous lifecycle task failed:', error);
+            })
+            .then(task)
+            .catch((error) => {
+                console.error(`[FeatureRegistry] ${label} lifecycle task failed:`, error);
+            });
+
+        return lifecycleQueue;
+    };
 
     // Handle character_switching event (cleanup phase)
-    dataManager.on('character_switching', async (_data) => {
-        cleanupPromise = (async () => {
-            try {
-                // Clear config cache IMMEDIATELY to prevent stale settings
-                if (config && typeof config.clearSettingsCache === 'function') {
-                    config.clearSettingsCache();
-                }
+    dataManager.on('character_switching', (_data) => {
+        lifecycleGeneration += 1;
 
-                // End any active marketplace session before features clean up
-                marketplaceSession.endAll();
-                marketplaceSession.clearAllMarketplaceUI();
+        // Clear config cache immediately, before any asynchronous cleanup starts,
+        // so code still running from the departing character cannot read its settings.
+        if (config && typeof config.clearSettingsCache === 'function') {
+            config.clearSettingsCache();
+        }
 
-                await cleanupFeatures();
-            } catch (error) {
-                console.error('[FeatureRegistry] Error during character switch cleanup:', error);
-            }
-        })();
+        return enqueueLifecycleTask('character cleanup', async () => {
+            // End any active marketplace session before features clean up.
+            marketplaceSession.endAll();
+            marketplaceSession.clearAllMarketplaceUI();
 
-        await cleanupPromise;
+            await cleanupFeatures();
+        });
     });
 
     // Handle character_switched event (re-initialization phase)
-    dataManager.on('character_switched', async (_data) => {
-        // Prevent multiple overlapping reinits
-        if (reinitScheduled) {
-            return;
-        }
+    dataManager.on('character_switched', (data) => {
+        const generation = lifecycleGeneration;
+        const targetCharacterId = data?.newId ? String(data.newId) : null;
 
-        reinitScheduled = true;
+        const isCurrentGeneration = () => {
+            if (generation !== lifecycleGeneration) {
+                return false;
+            }
 
-        try {
-            // Wait for cleanup to complete (with safety timeout)
-            if (cleanupPromise) {
-                await Promise.race([cleanupPromise, new Promise((resolve) => setTimeout(resolve, 500))]);
+            const currentCharacterId = dataManager.getCurrentCharacterId?.();
+            if (targetCharacterId && currentCharacterId != null) {
+                return String(currentCharacterId) === targetCharacterId;
+            }
+
+            return true;
+        };
+
+        return enqueueLifecycleTask('character reinitialization', async () => {
+            // A newer switch may have arrived while this task waited in the queue.
+            if (!isCurrentGeneration()) {
+                return;
             }
 
             // CRITICAL: Load settings BEFORE any feature initialization
             // This ensures all features see the new character's settings
             await config.loadSettings({ notifyChanges: false });
+
+            // Loading IndexedDB can take long enough for another character switch.
+            // Never apply or initialize settings that no longer belong to the active character.
+            if (!isCurrentGeneration()) {
+                return;
+            }
+
             config.applyColorSettings();
 
             // Small delay to ensure game state is stable
             await new Promise((resolve) => setTimeout(resolve, 50));
 
+            if (!isCurrentGeneration()) {
+                return;
+            }
+
             // Now re-initialize all features with fresh settings
-            await initializeFeatures();
-        } catch (error) {
-            console.error('[FeatureRegistry] Error during feature reinitialization:', error);
-        } finally {
-            reinitScheduled = false;
-        }
+            await initializeFeatures({ shouldContinue: isCurrentGeneration });
+        });
     });
 }
 


### PR DESCRIPTION
## Summary

Fixes an intermittent per-character settings/runtime mismatch after rapid character switching
(e.g. `market character -> Iron Cow character -> market character`), where a market character's
opacity/feature settings could temporarily show another character's state until a hard refresh.

Two unsafe coordination paths in `src/core/feature-registry.js` caused this:

- A boolean `reinitScheduled` guard could **drop** a later `character_switched` event during a
  rapid A -> B -> A sequence, leaving B's live feature/settings state applied while A is active.
- A fixed `Promise.race([cleanupPromise, setTimeout(500)])` allowed reinitialization to start
  before slow old-character cleanup had actually finished, letting the two overlap.

## Fix

Replaced both with:

- one serialized lifecycle promise queue (no switch event is ever dropped or run out of order);
- one monotonic switch generation, with stale-generation checks before/after settings loading,
  after stabilization, and during feature iteration;
- target-character identity checks against `dataManager.getCurrentCharacterId()`;
- immediate config-cache clearing on every `character_switching` event.

Invariant: latest-character-wins, with no cleanup/initialization from different generations
ever allowed to overlap.

## Explicitly out of scope (unchanged)

- per-character settings storage/migration, Iron Cow snapshots, opacity calculations, item-count
  display DOM behavior, `notifyChanges: false` during reinit;
- retention/cap/prune/archive/aggregation logic;
- `panel-z-index.js`, `performance-monitor.js`;
- userscript metadata, update URLs, versioning, release workflows, Greasy Fork publication.

## Test plan

- [x] Targeted: `npx vitest run src/core/feature-registry-lifecycle.test.js` — 5/5 pass (2 existing + 3 new)
- [x] Full suite: `npm test` — 610/610 pass
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build:dev`, `npm run build`, `npm run build:enhancement` — all succeed
- [x] Exact CI bundle-size gate — all 14 dist files under 2MB
- [x] Built artifacts verified directly: no `reinitScheduled`-style guard, no fixed 500ms cleanup race, serialized generation/queue logic present
- [x] Protected files (`panel-z-index.js`, `performance-monitor.js`) untouched; no retention logic introduced
- [x] No userscript metadata/update URL/release/versioning files changed