### PR TITLE
fix: Custom Tabs Unorganized self-heal + House cumulative render race

### DIFF
--- a/src/features/house/house-cost-display.js
+++ b/src/features/house/house-cost-display.js
@@ -60,6 +60,8 @@ class HouseCostDisplay {
         this._houseSessionId = null;
         this._nativeTabExitCleanup = null;
         this._houseReturnGeneration = 0;
+        this._cumulativeRenderGeneration = 0;
+        this._cumulativeRenderGenerations = new WeakMap();
         this.activeWorkflowModel = null;
     }
 
@@ -373,9 +375,15 @@ class HouseCostDisplay {
      * @param {number} targetLevel - Target level
      */
     async updateCompactCumulativeDisplay(container, houseRoomHrid, currentLevel, targetLevel) {
-        container.innerHTML = '';
+        const renderGeneration = ++this._cumulativeRenderGeneration;
+        this._cumulativeRenderGenerations.set(container, renderGeneration);
+        container.replaceChildren();
 
         const costData = await houseCostCalculator.calculateCumulativeCost(houseRoomHrid, currentLevel, targetLevel);
+
+        if (this._cumulativeRenderGenerations.get(container) !== renderGeneration) {
+            return;
+        }
 
         const materialsList = document.createElement('div');
         materialsList.style.cssText = `
@@ -396,7 +404,7 @@ class HouseCostDisplay {
             this.appendMaterialRow(materialsList, material);
         }
 
-        container.appendChild(materialsList);
+        const renderNodes = [materialsList];
 
         const totalDiv = document.createElement('div');
         totalDiv.style.cssText = `
@@ -409,13 +417,18 @@ class HouseCostDisplay {
         text-align: center;
     `;
         totalDiv.textContent = `Total Market Value: ${coinFormatter(costData.totalValue)}`;
-        container.appendChild(totalDiv);
+        renderNodes.push(totalDiv);
 
         const missingMaterials = this.getMissingMaterials(costData);
         if (missingMaterials.length > 0) {
-            const button = this.createMissingMaterialsButton(missingMaterials);
-            container.appendChild(button);
+            renderNodes.push(this.createMissingMaterialsButton(missingMaterials));
         }
+
+        // Commit the completed render atomically. Concurrent refreshes may overlap while
+        // market prices are awaited, but only the latest request for this container may
+        // replace its contents. This prevents duplicate material/total/button blocks and
+        // prevents an older calculation from overwriting a newer one.
+        container.replaceChildren(...renderNodes);
     }
 
     /**
@@ -1363,6 +1376,7 @@ class HouseCostDisplay {
 
         const newLevel = this._getLiveHouseRoomLevel(houseRoomHrid);
         if (newLevel >= 8) {
+            this._cumulativeRenderGenerations.set(costContainer, ++this._cumulativeRenderGeneration);
             costContainer.innerHTML = '';
             this._cumulativeState = null;
             this._costContext = null;
@@ -1374,6 +1388,7 @@ class HouseCostDisplay {
         }
 
         if (dropdown.options.length === 0) {
+            this._cumulativeRenderGenerations.set(costContainer, ++this._cumulativeRenderGeneration);
             costContainer.innerHTML = '';
             this._cumulativeState = null;
             this._costContext = null;
@@ -1462,6 +1477,8 @@ class HouseCostDisplay {
 
         this._cumulativeState = null;
         this._costContext = null;
+        this._cumulativeRenderGeneration++;
+        this._cumulativeRenderGenerations = new WeakMap();
 
         this.autofillManager.cleanup();
         this.timerRegistry.clearAll();

--- a/src/features/house/house-cost-display.test.js
+++ b/src/features/house/house-cost-display.test.js
@@ -176,6 +176,7 @@ vi.mock('../../utils/formatters.js', () => ({
 }));
 
 import dataManager from '../../core/data-manager.js';
+import houseCostCalculator from './house-cost-calculator.js';
 import houseCostDisplay from './house-cost-display.js';
 
 // ---------------------------------------------------------------------------
@@ -231,6 +232,8 @@ function resetInstanceState() {
     houseCostDisplay.cleanupObserver = null;
     houseCostDisplay._cumulativeState = null;
     houseCostDisplay._costContext = null;
+    houseCostDisplay._cumulativeRenderGeneration = 0;
+    houseCostDisplay._cumulativeRenderGenerations = new WeakMap();
 }
 
 function makeConnectedDropdown(values = ['4', '5', '6']) {
@@ -268,6 +271,107 @@ describe('HouseCostDisplay — Section 3 Rev2 correction', () => {
 
     afterEach(() => {
         document.body.innerHTML = '';
+    });
+
+    // =========================================================================
+    // updateCompactCumulativeDisplay — overlapping async refreshes
+    // =========================================================================
+
+    describe('updateCompactCumulativeDisplay — overlapping async refreshes', () => {
+        function deferred() {
+            let resolve;
+            const promise = new Promise((res) => {
+                resolve = res;
+            });
+            return { promise, resolve };
+        }
+
+        function costData(totalValue) {
+            return { coins: 500000, materials: [], totalValue };
+        }
+
+        afterEach(() => {
+            houseCostDisplay.getMissingMaterials.mockRestore?.();
+            houseCostDisplay._getLiveHouseRoomLevel.mockRestore?.();
+        });
+
+        it('collapses an eight-request refresh burst into one rendered block', async () => {
+            const container = makeConnectedCostContainer();
+            const requests = Array.from({ length: 8 }, () => deferred());
+            for (const request of requests) {
+                houseCostCalculator.calculateCumulativeCost.mockImplementationOnce(() => request.promise);
+            }
+            vi.spyOn(houseCostDisplay, 'getMissingMaterials').mockReturnValue([makeMaterial()]);
+
+            const renders = requests.map(() =>
+                houseCostDisplay.updateCompactCumulativeDisplay(container, '/house_rooms/garden', 0, 1)
+            );
+
+            for (const request of requests) {
+                request.resolve(costData(734000));
+            }
+            await Promise.all(renders);
+
+            expect(container.children).toHaveLength(3);
+            expect(container.textContent.match(/Total Market Value:/g)).toHaveLength(1);
+            expect(container.querySelectorAll('button')).toHaveLength(1);
+            expect(container.textContent).toContain('Total Market Value: 734000');
+        });
+
+        it('keeps the latest requested render when an older calculation resolves last', async () => {
+            const container = makeConnectedCostContainer();
+            const older = deferred();
+            const newer = deferred();
+            houseCostCalculator.calculateCumulativeCost
+                .mockImplementationOnce(() => older.promise)
+                .mockImplementationOnce(() => newer.promise);
+            vi.spyOn(houseCostDisplay, 'getMissingMaterials').mockReturnValue([]);
+
+            const olderRender = houseCostDisplay.updateCompactCumulativeDisplay(container, '/house_rooms/garden', 0, 1);
+            const newerRender = houseCostDisplay.updateCompactCumulativeDisplay(container, '/house_rooms/garden', 0, 2);
+
+            newer.resolve(costData(222000));
+            await newerRender;
+            expect(container.textContent).toContain('Total Market Value: 222000');
+
+            older.resolve(costData(111000));
+            await olderRender;
+
+            expect(container.textContent).toContain('Total Market Value: 222000');
+            expect(container.textContent).not.toContain('Total Market Value: 111000');
+            expect(container.textContent.match(/Total Market Value:/g)).toHaveLength(1);
+        });
+
+        it('does not let a stale pending render resurrect a display cleared by a room-completed refresh', async () => {
+            // _onHouseRoomUpdated's max-level branch clears the container directly (the room
+            // reached its cap, so there is nothing left to show) and must invalidate any
+            // updateCompactCumulativeDisplay call already in flight for that same container —
+            // otherwise the older calculation resolving afterward would repopulate a display
+            // that the user has already been told is complete.
+            const container = makeConnectedCostContainer();
+            const dropdown = makeConnectedDropdown(['4', '5']);
+            houseCostDisplay._cumulativeState = {
+                costContainer: container,
+                houseRoomHrid: '/house_rooms/garden',
+                currentLevel: 3,
+                dropdown,
+            };
+            const pending = deferred();
+            houseCostCalculator.calculateCumulativeCost.mockImplementationOnce(() => pending.promise);
+            vi.spyOn(houseCostDisplay, 'getMissingMaterials').mockReturnValue([]);
+
+            const staleRender = houseCostDisplay.updateCompactCumulativeDisplay(container, '/house_rooms/garden', 3, 4);
+
+            vi.spyOn(houseCostDisplay, '_getLiveHouseRoomLevel').mockReturnValue(8);
+            await houseCostDisplay._onHouseRoomUpdated();
+            expect(container.children).toHaveLength(0);
+
+            pending.resolve(costData(999000));
+            await staleRender;
+
+            expect(container.children).toHaveLength(0);
+            expect(container.textContent).not.toContain('Total Market Value: 999000');
+        });
     });
 
     describe('getMissingMaterials', () => {

--- a/src/features/inventory/custom-tabs/custom-tabs-ui.js
+++ b/src/features/inventory/custom-tabs/custom-tabs-ui.js
@@ -532,7 +532,7 @@ export default class CustomTabsUI {
         this._expandedSearchHrids = null; // Set of base hrids expanded in the item picker
         this._isApplying = false; // Guard against concurrent _applyLayout calls
         this._needsAnotherPass = false; // Deferred layout re-run flag
-        this._lastRebuildTileCount = 0; // Tile count at last full rebuild (detects inventory changes)
+        this._lastRebuildComposition = null; // Sorted tile-identity signature at last full rebuild
         this._actionBtnsEl = null; // +Tab/Export/Import appended to sort controls row on Toolasha tab
         this._tileObserver = null; // MutationObserver for instant tile visibility on React swaps
         this._observedContainer = null; // Container currently being observed by _tileObserver
@@ -825,6 +825,51 @@ export default class CustomTabsUI {
     }
 
     /**
+     * Build an order-independent signature of the current tile set's identities (hrid,
+     * including enhancement level). A plain tile count misses a production event that swaps
+     * one identity for another while the total tile count stays the same — e.g. the last unit
+     * of a material is consumed while a new output item appears — which can leave stale
+     * header/layout state on the lightweight path. Comparing this signature across passes
+     * catches that case.
+     * @param {NodeListOf<Element>|Element[]} allTiles
+     * @returns {string}
+     */
+    _computeTileComposition(allTiles) {
+        const identities = [];
+        for (const tile of allTiles) {
+            identities.push(this._getHridFromTile(tile) || '?');
+        }
+        identities.sort();
+        return identities.join('|');
+    }
+
+    /**
+     * True when the current tileMap contains at least one inventory tile not assigned to any
+     * custom tab. Mirrors the per-tile, enhancement-aware filtering used when building the
+     * Unorganized bucket (see _injectUnorganized / _updateTileVisibility), without mutating
+     * tileMap or the DOM.
+     * @param {Map} tileMap
+     * @returns {boolean}
+     */
+    _hasUnassignedTiles(tileMap) {
+        const assignedSet = getAssignedItemSet(this._config);
+        for (const [hrid, tiles] of tileMap) {
+            if (/\+\d+$/.test(hrid)) {
+                if (!assignedSet.has(hrid) && tiles.length > 0) return true;
+            } else {
+                if (assignedSet.has(hrid)) continue;
+                for (const tile of tiles) {
+                    const enhEl = tile.querySelector('[class*="Item_enhancementLevel"]');
+                    const level = enhEl ? parseInt(enhEl.textContent.trim().replace('+', ''), 10) : 0;
+                    const tileHrid = level > 0 ? `${hrid}+${level}` : hrid;
+                    if (!assignedSet.has(tileHrid)) return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Synchronous layout pass — applies CSS order and visibility to all tiles.
      * Extracted from _applyLayout so it can also be called from a MutationObserver
      * callback (which fires before the browser paints, eliminating flicker when
@@ -864,16 +909,35 @@ export default class CustomTabsUI {
             delete tile.dataset.toolashaTabId;
         }
 
-        // Force full rebuild when tile count OR config item count changed — the lightweight path
-        // reuses stale header order values that don't have enough order-space
-        // for new tiles, causing items to visually cascade into wrong sections.
+        // Force full rebuild when tile identity/composition OR config item count changed — the
+        // lightweight path reuses stale header order values that don't have enough order-space
+        // for new tiles, causing items to visually cascade into wrong sections. A signature over
+        // each tile's hrid (including enhancement level) — not just the tile count — is required
+        // because a production event can replace one identity with another (e.g. a material's
+        // last unit is consumed while a new output item appears) while the total tile count stays
+        // the same; a count-only check would miss that and leave stale header/layout state.
         const configItemCount = this._getTotalConfigItemCount();
+        const composition = this._computeTileComposition(allTiles);
         if (
             !needsFullRebuild &&
-            (allTiles.length !== this._lastRebuildTileCount || configItemCount !== this._lastRebuildConfigItemCount)
+            (composition !== this._lastRebuildComposition || configItemCount !== this._lastRebuildConfigItemCount)
         ) {
             needsFullRebuild = true;
             this._removeInjectedEls();
+        }
+
+        // Self-heal: whenever Unorganized should be shown, its header must be present exactly
+        // when unassigned tiles exist. If some other path (a leaked mutation, a partial DOM
+        // reconciliation) leaves the header missing while unassigned tiles remain — or leaves it
+        // present with nothing unassigned — the lightweight path can't fix that on its own,
+        // since it only re-applies visibility using headers that already exist. Force a full
+        // rebuild instead of trusting historical rebuild state.
+        if (!needsFullRebuild && config.getSettingValue('inventoryTabs_showUnorganized')) {
+            const hasUnorgHeader = Boolean(invContainer.querySelector('.toolasha-ct-unorg-header'));
+            if (hasUnorgHeader !== this._hasUnassignedTiles(tileMap)) {
+                needsFullRebuild = true;
+                this._removeInjectedEls();
+            }
         }
 
         if (needsFullRebuild) {
@@ -903,7 +967,7 @@ export default class CustomTabsUI {
                 orderCounter = this._injectUnorganized(invContainer, tileMap, orderCounter);
             }
 
-            this._lastRebuildTileCount = allTiles.length;
+            this._lastRebuildComposition = composition;
             this._lastRebuildConfigItemCount = configItemCount;
         } else {
             // Lightweight update: headers already exist, just re-apply tile order/visibility

--- a/src/features/inventory/custom-tabs/custom-tabs-ui.test.js
+++ b/src/features/inventory/custom-tabs/custom-tabs-ui.test.js
@@ -1,0 +1,291 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    showUnorganized: true,
+    tileGap: 4,
+}));
+
+vi.mock('../../../core/config.js', () => ({
+    default: {
+        getSettingValue: vi.fn((key, fallback) => {
+            if (key === 'inventoryTabs_showUnorganized') return mocks.showUnorganized;
+            if (key === 'inventoryTabs_tileGap') return mocks.tileGap;
+            return fallback;
+        }),
+        getSetting: vi.fn(() => false),
+        onSettingChange: vi.fn(),
+        offSettingChange: vi.fn(),
+    },
+}));
+
+vi.mock('../../../core/dom-observer.js', () => ({
+    default: { onClass: vi.fn(() => () => {}) },
+}));
+
+vi.mock('../../../core/data-manager.js', () => ({
+    default: {
+        on: vi.fn(),
+        off: vi.fn(),
+        getCurrentCharacterId: vi.fn(() => 'char-1'),
+        getInitClientData: vi.fn(() => ({
+            itemDetailMap: {
+                '/items/apple_gummy': { name: 'Apple Gummy', categoryHrid: '/item_categories/food', sortIndex: 1 },
+                '/items/milk': { name: 'Milk', categoryHrid: '/item_categories/food', sortIndex: 2 },
+                '/items/egg': { name: 'Egg', categoryHrid: '/item_categories/food', sortIndex: 3 },
+                '/items/sword': { name: 'Sword', categoryHrid: '/item_categories/weapon', sortIndex: 4 },
+            },
+            itemCategoryDetailMap: {
+                '/item_categories/food': { sortIndex: 1 },
+                '/item_categories/weapon': { sortIndex: 2 },
+            },
+        })),
+    },
+}));
+
+vi.mock('../inventory-sort.js', () => ({
+    default: { currentMode: 'none', onModeChange: vi.fn(() => () => {}) },
+}));
+
+vi.mock('../inventory-badge-manager.js', () => ({
+    default: {
+        currentInventoryElem: null,
+        isRendering: false,
+        isCalculating: false,
+        lastRenderTime: 0,
+        lastCalculationTime: 0,
+        renderAllBadges: vi.fn(async () => {}),
+    },
+}));
+
+vi.mock('../../combat/loadout-snapshot.js', () => ({
+    default: { onSnapshotChange: vi.fn(() => () => {}), getSnapshot: vi.fn(() => null) },
+}));
+
+vi.mock('../../../utils/formatters.js', () => ({
+    formatKMB: vi.fn((n) => `${n}`),
+}));
+
+import CustomTabsUI from './custom-tabs-ui.js';
+
+/**
+ * Build a fake game inventory tile matching the DOM shape _buildTileMap/_getHridFromTile expect:
+ * an `[class*="Item_itemContainer"]` element containing an `svg[aria-label]` naming the item,
+ * plus an optional `[class*="Item_enhancementLevel"]` badge for enhancement level.
+ */
+function makeTile(itemName, enhancementLevel = 0) {
+    const tile = document.createElement('div');
+    tile.className = 'Item_itemContainer_abc';
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('aria-label', itemName);
+    tile.appendChild(svg);
+
+    if (enhancementLevel > 0) {
+        const enh = document.createElement('div');
+        enh.className = 'Item_enhancementLevel_xyz';
+        enh.textContent = `+${enhancementLevel}`;
+        tile.appendChild(enh);
+    }
+
+    return tile;
+}
+
+function makeInvContainer(tiles) {
+    const container = document.createElement('div');
+    container.className = 'Inventory_items_container';
+    for (const tile of tiles) container.appendChild(tile);
+    document.body.appendChild(container);
+    return container;
+}
+
+describe('CustomTabsUI layout invalidation', () => {
+    let ui;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        mocks.showUnorganized = true;
+        mocks.tileGap = 4;
+        ui = new CustomTabsUI();
+        ui._config = { version: 1, tabs: [], selectedTabId: null };
+        // Bypass DOM lookups unrelated to the layout pass itself.
+        vi.spyOn(ui, '_findContentContainer').mockReturnValue(null);
+        vi.spyOn(ui, '_injectActionButtons').mockReturnValue(null);
+    });
+
+    afterEach(() => {
+        ui._tileObserver?.disconnect();
+    });
+
+    test('self-heals when the Unorganized header loses its identifying class while still attached', () => {
+        // areInjectedLayoutElementsAttached() only checks that injected elements are still
+        // DOM-attached (element.parentElement === container); it does not check that they still
+        // carry the class every selector-based lookup relies on. If something strips or replaces
+        // the header's className while the node itself stays attached (and composition/tile
+        // count are unchanged, so neither existing invalidation check fires), the pre-existing
+        // "injected elements attached" guard reports everything fine while
+        // `.toolasha-ct-unorg-header` can no longer find it — reproducing "header absent while
+        // unassigned tiles exist and remain hidden" without a page reload.
+        const container = makeInvContainer([makeTile('Milk'), makeTile('Egg')]);
+
+        ui._applyLayoutSync(container);
+        const header = container.querySelector('.toolasha-ct-unorg-header');
+        expect(header).not.toBeNull();
+
+        // Strip the identifying class without detaching the node — it remains a child of
+        // invContainer (and remains the same object reference inside ui._injectedEls), so the
+        // structural attachment check alone cannot detect anything wrong.
+        header.className = '';
+        expect(container.querySelector('.toolasha-ct-unorg-header')).toBeNull();
+
+        ui._applyLayoutSync(container);
+        const restored = container.querySelector('.toolasha-ct-unorg-header');
+        expect(restored).not.toBeNull();
+        expect(restored.textContent).toContain('Unorganized (2)');
+        expect(container.querySelectorAll('.toolasha-ct-visible').length).toBe(2);
+    });
+
+    test('does not recreate an Unorganized header when there is nothing unassigned', () => {
+        const container = makeInvContainer([makeTile('Milk')]);
+        ui._config = {
+            version: 1,
+            tabs: [{ id: 'tab-1', name: 'Food', color: null, open: true, items: ['/items/milk'], children: [] }],
+            selectedTabId: null,
+        };
+
+        ui._applyLayoutSync(container);
+        expect(container.querySelector('.toolasha-ct-unorg-header')).toBeNull();
+    });
+
+    test('detects a same-count identity swap and rebuilds instead of reusing stale layout', () => {
+        // Reproduces the evidence-backed hazard from the report: a production event can replace
+        // one inventory identity with another (a material's last unit consumed while a new
+        // output item appears) while the total tile DOM node count stays exactly the same. A
+        // count-only invalidation check would miss this and reuse stale header/order state.
+        const container = makeInvContainer([makeTile('Milk'), makeTile('Egg')]);
+        ui._applyLayoutSync(container);
+
+        const rebuildSpy = vi.spyOn(ui, '_injectActionButtons');
+        rebuildSpy.mockClear();
+
+        // Swap Egg out for Apple Gummy without changing the tile count.
+        container.querySelector('svg[aria-label="Egg"]').closest('.Item_itemContainer_abc').remove();
+        container.appendChild(makeTile('Apple Gummy'));
+        expect(container.querySelectorAll('[class*="Item_itemContainer"]').length).toBe(2);
+
+        ui._applyLayoutSync(container);
+
+        // A full rebuild re-invokes _injectActionButtons; the lightweight path never does.
+        expect(rebuildSpy).toHaveBeenCalled();
+        const header = container.querySelector('.toolasha-ct-unorg-header');
+        expect(header.textContent).toContain('Unorganized (2)');
+        const visibleNames = [...container.querySelectorAll('.toolasha-ct-visible')].map((tile) =>
+            tile.querySelector('svg[aria-label]').getAttribute('aria-label')
+        );
+        expect(visibleNames.sort()).toEqual(['Apple Gummy', 'Milk']);
+    });
+
+    test('an enhancement-level-only identity change at constant tile count invalidates correctly', () => {
+        const container = makeInvContainer([makeTile('Sword', 0)]);
+        ui._applyLayoutSync(container);
+        expect(container.querySelector('.toolasha-ct-unorg-header').textContent).toContain('Unorganized (1)');
+
+        // React swaps the base Sword tile for a +3 Sword tile (enhancement completed) — same
+        // count, different identity.
+        container.querySelector('.Item_itemContainer_abc').remove();
+        container.appendChild(makeTile('Sword', 3));
+
+        const rebuildSpy = vi.spyOn(ui, '_injectActionButtons');
+        rebuildSpy.mockClear();
+        ui._applyLayoutSync(container);
+
+        expect(rebuildSpy).toHaveBeenCalled();
+        // Note: the Unorganized header's displayed count for an enhanced, still-unassigned tile
+        // is a separate pre-existing defect (unrelated to this fix) — _buildTileMap registers an
+        // enhanced tile under both its base and enhanced hrid keys, so _injectUnorganized's
+        // remaining-entries loop double-counts it. What this test asserts, and what this fix is
+        // responsible for, is that the identity change is detected and triggers a rebuild (not a
+        // stale lightweight update) so the tile is at least present and visible under Unorganized.
+        const header = container.querySelector('.toolasha-ct-unorg-header');
+        expect(header).not.toBeNull();
+        const swordTile = container.querySelector('svg[aria-label="Sword"]').closest('.Item_itemContainer_abc');
+        expect(swordTile.classList.contains('toolasha-ct-visible')).toBe(true);
+    });
+
+    test('new unassigned item becomes visible under Unorganized with a correct count', () => {
+        const container = makeInvContainer([makeTile('Milk')]);
+        ui._applyLayoutSync(container);
+        expect(container.querySelector('.toolasha-ct-unorg-header').textContent).toContain('Unorganized (1)');
+
+        container.appendChild(makeTile('Apple Gummy'));
+        ui._applyLayoutSync(container);
+
+        expect(container.querySelector('.toolasha-ct-unorg-header').textContent).toContain('Unorganized (2)');
+        expect(container.querySelectorAll('.toolasha-ct-visible').length).toBe(2);
+    });
+
+    test('Unorganized membership changing without a tile-count change updates header/visibility', () => {
+        const container = makeInvContainer([makeTile('Milk'), makeTile('Egg')]);
+        ui._applyLayoutSync(container);
+        expect(container.querySelector('.toolasha-ct-unorg-header').textContent).toContain('Unorganized (2)');
+
+        // Assign Milk to a tab without adding/removing any tile DOM nodes.
+        ui._config = {
+            version: 1,
+            tabs: [{ id: 'tab-1', name: 'Food', color: null, open: true, items: ['/items/milk'], children: [] }],
+            selectedTabId: null,
+        };
+        ui._applyLayoutSync(container);
+
+        expect(container.querySelector('.toolasha-ct-unorg-header').textContent).toContain('Unorganized (1)');
+        const milkTile = container.querySelector('svg[aria-label="Milk"]').closest('.Item_itemContainer_abc');
+        expect(milkTile.dataset.toolashaTabId).toBe('tab-1');
+    });
+
+    test('does not create an Unorganized header when the setting is disabled', () => {
+        mocks.showUnorganized = false;
+        const container = makeInvContainer([makeTile('Milk')]);
+        ui._applyLayoutSync(container);
+        expect(container.querySelector('.toolasha-ct-unorg-header')).toBeNull();
+    });
+
+    test('0 -> 1 and 1 -> 0 unassigned boundaries create/remove the header at constant tile count', () => {
+        const container = makeInvContainer([makeTile('Milk')]);
+        ui._config = {
+            version: 1,
+            tabs: [{ id: 'tab-1', name: 'Food', color: null, open: true, items: ['/items/milk'], children: [] }],
+            selectedTabId: null,
+        };
+        ui._applyLayoutSync(container);
+        expect(container.querySelector('.toolasha-ct-unorg-header')).toBeNull();
+
+        // Unassign Milk (composition/count unchanged, only config changed) — 0 -> 1 unassigned.
+        ui._config = { version: 1, tabs: [], selectedTabId: null };
+        ui._applyLayoutSync(container);
+        expect(container.querySelector('.toolasha-ct-unorg-header').textContent).toContain('Unorganized (1)');
+
+        // Re-assign Milk — 1 -> 0 unassigned.
+        ui._config = {
+            version: 1,
+            tabs: [{ id: 'tab-1', name: 'Food', color: null, open: true, items: ['/items/milk'], children: [] }],
+            selectedTabId: null,
+        };
+        ui._applyLayoutSync(container);
+        expect(container.querySelector('.toolasha-ct-unorg-header')).toBeNull();
+    });
+
+    test('ordinary quantity-only updates (no identity/composition change) do not trigger a full rebuild', () => {
+        const container = makeInvContainer([makeTile('Milk'), makeTile('Egg')]);
+        ui._applyLayoutSync(container);
+
+        const rebuildSpy = vi.spyOn(ui, '_injectActionButtons');
+        rebuildSpy.mockClear();
+
+        // No DOM changes at all — simulates an items_updated event carrying only a quantity
+        // change that doesn't touch tile identity/composition.
+        ui._applyLayoutSync(container);
+
+        expect(rebuildSpy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

Two independently investigated and verified production defects, each with its own commit:

### `302e28e9` — Custom Inventory Tabs: Unorganized bucket self-heal + same-count invalidation

- Runtime snapshot evidence showed `.toolasha-ct-unorg-header` absent while 24 unassigned tiles
  remained hidden, requiring a page reload to recover.
- Replaced count-only rebuild invalidation with a sorted tile-identity signature (hrid +
  enhancement level), catching same-count composition swaps a plain tile count misses (e.g. a
  material's last unit consumed while a new output item appears).
- Added an explicit self-heal invariant: header-presence must match whether unassigned tiles
  exist; a mismatch forces a full rebuild regardless of cause (covers a gap the pre-existing
  "injected elements attached" check couldn't — a header can lose its class while staying
  DOM-attached).
- 9 new regression tests against the real `CustomTabsUI` implementation.

### `4ca12206` — House cumulative display render race

- Runtime snapshot showed 8 duplicated `Cumulative to Level` render blocks (24 children = 8×3)
  in one live container, caused by `updateCompactCumulativeDisplay()` clearing then awaiting a
  calculation with no ownership guard, while 4 different callers could overlap on the same
  container.
- Applied per-container monotonic generation ownership: only the latest request for a container
  may commit its render (single atomic `replaceChildren()`); stale completions return without
  touching the DOM. Teardown/room-completed paths also bump the generation so pending work can't
  resurrect an intentionally-cleared display.
- 3 regression tests (eight-request burst, out-of-order completion, teardown invalidation).

## Test plan

- [x] Targeted tests for both fixes (87/87)
- [x] Full test suite (628/628)
- [x] Lint clean
- [x] Format check clean
- [x] `build:dev`, production `build`, `build:enhancement` all succeed
- [x] CI bundle-size gate passes for all artifacts