### PR TITLE
fix: dedupe enhanced tile double-counting in Custom Tabs Unorganized

### DIFF
--- a/src/features/inventory/custom-tabs/custom-tabs-ui.js
+++ b/src/features/inventory/custom-tabs/custom-tabs-ui.js
@@ -816,6 +816,44 @@ export default class CustomTabsUI {
     }
 
     /**
+     * Collect inventory tiles not assigned to any custom tab, grouped by the tileMap key each
+     * group was found under. A single physical enhanced tile is registered in tileMap under
+     * both its base hrid and its enhanced hrid (see _buildTileMap), so without deduplication a
+     * still-unassigned enhanced tile can be counted/processed twice — once via each key. A
+     * shared seenTiles set ensures each physical DOM tile element is included at most once,
+     * regardless of how many tileMap keys still reference it.
+     * @param {Map} tileMap
+     * @returns {Array<{hrid: string, tiles: HTMLElement[]}>}
+     */
+    _collectUnassignedTileEntries(tileMap) {
+        const assignedSet = getAssignedItemSet(this._config);
+        const seenTiles = new Set();
+        const entries = [];
+        for (const [hrid, tiles] of tileMap) {
+            if (assignedSet.has(hrid)) continue;
+            let fresh;
+            if (/\+\d+$/.test(hrid)) {
+                // Enhanced key still in tileMap means it wasn't claimed by a tab requesting that
+                // exact level.
+                fresh = tiles.filter((tile) => !seenTiles.has(tile));
+            } else {
+                // Base key: filter per-tile so only tiles whose specific enhancement level is
+                // assigned are excluded.
+                fresh = tiles.filter((tile) => {
+                    if (seenTiles.has(tile)) return false;
+                    const enhEl = tile.querySelector('[class*="Item_enhancementLevel"]');
+                    const level = enhEl ? parseInt(enhEl.textContent.trim().replace('+', ''), 10) : 0;
+                    const tileHrid = level > 0 ? `${hrid}+${level}` : hrid;
+                    return !assignedSet.has(tileHrid);
+                });
+            }
+            for (const tile of fresh) seenTiles.add(tile);
+            if (fresh.length > 0) entries.push({ hrid, tiles: fresh });
+        }
+        return entries;
+    }
+
+    /**
      * Count total items across all tabs (recursively) for rebuild detection.
      * @returns {number}
      */
@@ -1055,27 +1093,7 @@ export default class CustomTabsUI {
         const unorgHeader = invContainer.querySelector('.toolasha-ct-unorg-header');
         if (unorgHeader && this._unorgOpen) {
             const unorgOrder = parseInt(unorgHeader.style.order, 10);
-            const assignedSet = getAssignedItemSet(this._config);
-            const unorgTiles = [];
-            for (const [hrid, tiles] of tileMap) {
-                if (/\+\d+$/.test(hrid)) {
-                    // Enhanced key still in tileMap means it wasn't claimed —
-                    // only skip if the exact enhanced hrid is assigned to a tab.
-                    if (!assignedSet.has(hrid)) {
-                        for (const tile of tiles) unorgTiles.push(tile);
-                    }
-                } else {
-                    // Base key: skip if base hrid is assigned; otherwise filter per-tile
-                    // so only tiles whose specific enhancement level is assigned are excluded
-                    if (assignedSet.has(hrid)) continue;
-                    for (const tile of tiles) {
-                        const enhEl = tile.querySelector('[class*="Item_enhancementLevel"]');
-                        const level = enhEl ? parseInt(enhEl.textContent.trim().replace('+', ''), 10) : 0;
-                        const tileHrid = level > 0 ? `${hrid}+${level}` : hrid;
-                        if (!assignedSet.has(tileHrid)) unorgTiles.push(tile);
-                    }
-                }
-            }
+            const unorgTiles = this._collectUnassignedTileEntries(tileMap).flatMap(({ tiles }) => tiles);
             this._assignTileOrders(unorgTiles, unorgOrder + 1, '');
         }
     }
@@ -1901,31 +1919,7 @@ export default class CustomTabsUI {
      * @returns {number} updated orderCounter
      */
     _injectUnorganized(invContainer, tileMap, orderCounter) {
-        const assignedSet = getAssignedItemSet(this._config);
-        const remainingEntries = [];
-        for (const [hrid, tiles] of tileMap) {
-            if (/\+\d+$/.test(hrid)) {
-                // Enhanced key still in tileMap means it wasn't claimed by the base tab
-                // (reserved for a specific enhanced-hrid tab that doesn't exist).
-                // Only skip if the exact enhanced hrid is assigned to a tab.
-                if (!assignedSet.has(hrid)) {
-                    remainingEntries.push({ hrid, tiles });
-                }
-            } else {
-                // Base key: skip if base hrid is assigned; otherwise filter per-tile
-                // so only tiles whose specific enhancement level is assigned are excluded
-                if (assignedSet.has(hrid)) continue;
-                const unassignedTiles = tiles.filter((tile) => {
-                    const enhEl = tile.querySelector('[class*="Item_enhancementLevel"]');
-                    const level = enhEl ? parseInt(enhEl.textContent.trim().replace('+', ''), 10) : 0;
-                    const tileHrid = level > 0 ? `${hrid}+${level}` : hrid;
-                    return !assignedSet.has(tileHrid);
-                });
-                if (unassignedTiles.length > 0) {
-                    remainingEntries.push({ hrid, tiles: unassignedTiles });
-                }
-            }
-        }
+        const remainingEntries = this._collectUnassignedTileEntries(tileMap);
         if (remainingEntries.length === 0) return orderCounter;
 
         const totalTiles = remainingEntries.reduce((sum, e) => sum + e.tiles.length, 0);

--- a/src/features/inventory/custom-tabs/custom-tabs-ui.test.js
+++ b/src/features/inventory/custom-tabs/custom-tabs-ui.test.js
@@ -201,16 +201,57 @@ describe('CustomTabsUI layout invalidation', () => {
         ui._applyLayoutSync(container);
 
         expect(rebuildSpy).toHaveBeenCalled();
-        // Note: the Unorganized header's displayed count for an enhanced, still-unassigned tile
-        // is a separate pre-existing defect (unrelated to this fix) — _buildTileMap registers an
-        // enhanced tile under both its base and enhanced hrid keys, so _injectUnorganized's
-        // remaining-entries loop double-counts it. What this test asserts, and what this fix is
-        // responsible for, is that the identity change is detected and triggers a rebuild (not a
-        // stale lightweight update) so the tile is at least present and visible under Unorganized.
         const header = container.querySelector('.toolasha-ct-unorg-header');
         expect(header).not.toBeNull();
+        expect(header.textContent).toContain('Unorganized (1)');
         const swordTile = container.querySelector('svg[aria-label="Sword"]').closest('.Item_itemContainer_abc');
         expect(swordTile.classList.contains('toolasha-ct-visible')).toBe(true);
+    });
+
+    test('a single unassigned enhanced physical tile is counted once in Unorganized, not once per key', () => {
+        // _buildTileMap registers one physical enhanced tile under BOTH its base hrid
+        // ('/items/sword') and its enhanced hrid ('/items/sword+3') keys — same DOM element,
+        // two map entries. _injectUnorganized iterates every tileMap entry and pushes tiles from
+        // each one into remainingEntries without deduplicating by tile identity, so a single
+        // unassigned enhanced tile can be counted/processed twice: once via its base key, once
+        // via its enhanced key.
+        const container = makeInvContainer([makeTile('Sword', 3)]);
+        ui._applyLayoutSync(container);
+
+        const header = container.querySelector('.toolasha-ct-unorg-header');
+        expect(header).not.toBeNull();
+        // There is exactly one physical tile in the DOM — the header must say so.
+        expect(header.textContent).toContain('Unorganized (1)');
+        expect(container.querySelectorAll('.toolasha-ct-visible').length).toBe(1);
+    });
+
+    test('an enhanced tile assigned to a tab by its exact enhanced hrid does not leak into Unorganized', () => {
+        const container = makeInvContainer([makeTile('Sword', 3), makeTile('Milk')]);
+        ui._config = {
+            version: 1,
+            tabs: [{ id: 'tab-1', name: 'Weapons', color: null, open: true, items: ['/items/sword+3'], children: [] }],
+            selectedTabId: null,
+        };
+        ui._applyLayoutSync(container);
+
+        const header = container.querySelector('.toolasha-ct-unorg-header');
+        expect(header).not.toBeNull();
+        // Only Milk is unassigned; the +3 Sword belongs to the Weapons tab.
+        expect(header.textContent).toContain('Unorganized (1)');
+        const swordTile = container.querySelector('svg[aria-label="Sword"]').closest('.Item_itemContainer_abc');
+        expect(swordTile.dataset.toolashaTabId).toBe('tab-1');
+        const milkTile = container.querySelector('svg[aria-label="Milk"]').closest('.Item_itemContainer_abc');
+        expect(milkTile.classList.contains('toolasha-ct-visible')).toBe(true);
+    });
+
+    test('a mix of enhanced and unenhanced unassigned tiles all count correctly with no double-count', () => {
+        const container = makeInvContainer([makeTile('Sword', 3), makeTile('Milk'), makeTile('Egg')]);
+        ui._applyLayoutSync(container);
+
+        const header = container.querySelector('.toolasha-ct-unorg-header');
+        expect(header).not.toBeNull();
+        expect(header.textContent).toContain('Unorganized (3)');
+        expect(container.querySelectorAll('.toolasha-ct-visible').length).toBe(3);
     });
 
     test('new unassigned item becomes visible under Unorganized with a correct count', () => {


### PR DESCRIPTION
## Summary

- `_buildTileMap()` registers one physical enhanced inventory tile under both its base hrid
  and enhanced hrid keys (same DOM element, two map entries). `_injectUnorganized()` and
  `_updateTileVisibility()`'s Unorganized handling each iterated every tileMap entry
  independently, so a single still-unassigned enhanced tile was counted/processed once per key
  — inflating the Unorganized count and double-assigning CSS order to the same element.
- Extracted the duplicated per-tile assignment-filtering logic into one
  `_collectUnassignedTileEntries(tileMap)` helper with a shared `seenTiles` set, so a physical
  DOM element is included at most once. Both the full-rebuild and lightweight paths now share
  this helper. No item-specific logic.

## Test plan

- [x] New regression tests reproduce the double-count against the real `CustomTabsUI`
      implementation and fail on pre-fix source for the correct reason
- [x] Targeted custom-tabs suite: 15/15
- [x] Full test suite: 631/631
- [x] Lint clean
- [x] Format check clean
- [x] `build:dev`, production `build`, `build:enhancement` all succeed
- [x] CI bundle-size gate passes for all artifacts