### PR TITLE
fix: resync Action Filter pricing mode/profit displays after character switch

### DIFF
--- a/src/core/config-settings-loaded.test.js
+++ b/src/core/config-settings-loaded.test.js
@@ -1,0 +1,104 @@
+/**
+ * Regression test: config.onSettingsLoaded fires whenever loadSettings() repopulates
+ * settingsMap from storage, even when notifyChanges is false (the character-switch path).
+ * Long-lived infrastructure outside the feature registry (e.g. the persistent Action
+ * Filter) relies on this to resync after a character switch, since per-setting
+ * onSettingChange callbacks are intentionally suppressed during that reinitialization.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('./settings-storage.js', () => ({
+    default: {
+        getSetting: vi.fn(() => null),
+        onSettingChange: vi.fn(),
+        setCharacterId: vi.fn(),
+        loadSettings: vi.fn(async () => ({})),
+        buildDefaults: vi.fn(() => ({})),
+    },
+}));
+vi.mock('./settings-schema.js', () => ({ settingsGroups: [] }));
+vi.mock('./data-manager.js', () => ({
+    default: {
+        on: vi.fn(),
+        off: vi.fn(),
+        getCurrentCharacterId: vi.fn(() => 'char-1'),
+        getCurrentCharacterName: vi.fn(() => 'TestCharacter'),
+    },
+}));
+
+const { default: config } = await import('./config.js');
+const { default: settingsStorage } = await import('./settings-storage.js');
+
+describe('Config — onSettingsLoaded (character-switch settings resync)', () => {
+    beforeEach(() => {
+        config.settingsMap = {};
+        config.settingsLoadedCallbacks = [];
+        config.settingChangeCallbacks = {};
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('fires after loadSettings() completes, even when notifyChanges is false', async () => {
+        settingsStorage.loadSettings.mockResolvedValueOnce({
+            profitCalc_pricingMode: { value: 'optimistic' },
+        });
+        const loadedSpy = vi.fn();
+        config.onSettingsLoaded(loadedSpy);
+
+        await config.loadSettings({ notifyChanges: false });
+
+        expect(loadedSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('fires after loadSettings() completes when notifyChanges is true (default)', async () => {
+        settingsStorage.loadSettings.mockResolvedValueOnce({
+            profitCalc_pricingMode: { value: 'optimistic' },
+        });
+        const loadedSpy = vi.fn();
+        config.onSettingsLoaded(loadedSpy);
+
+        await config.loadSettings();
+
+        expect(loadedSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not preserve or restore per-setting onSettingChange suppression: those callbacks stay suppressed when notifyChanges is false', async () => {
+        config.settingsMap = { profitCalc_pricingMode: { value: 'hybrid' } };
+        settingsStorage.loadSettings.mockResolvedValueOnce({
+            profitCalc_pricingMode: { value: 'optimistic' },
+        });
+        const changeSpy = vi.fn();
+        config.onSettingChange('profitCalc_pricingMode', changeSpy);
+
+        await config.loadSettings({ notifyChanges: false });
+
+        expect(changeSpy).not.toHaveBeenCalled();
+    });
+
+    test('offSettingsLoaded unregisters the callback', async () => {
+        settingsStorage.loadSettings.mockResolvedValueOnce({
+            profitCalc_pricingMode: { value: 'optimistic' },
+        });
+        const loadedSpy = vi.fn();
+        config.onSettingsLoaded(loadedSpy);
+        config.offSettingsLoaded(loadedSpy);
+
+        await config.loadSettings({ notifyChanges: false });
+
+        expect(loadedSpy).not.toHaveBeenCalled();
+    });
+
+    test('does not fire when characterId is unknown (settingsMap only populated with schema defaults)', async () => {
+        const dataManager = (await import('./data-manager.js')).default;
+        dataManager.getCurrentCharacterId.mockReturnValueOnce(null);
+        const loadedSpy = vi.fn();
+        config.onSettingsLoaded(loadedSpy);
+
+        await config.loadSettings({ notifyChanges: false });
+
+        expect(loadedSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -69,6 +69,13 @@ class Config {
         // Map of setting keys to callback functions
         this.settingChangeCallbacks = {};
 
+        // Callbacks fired whenever loadSettings() repopulates settingsMap from storage,
+        // regardless of the notifyChanges option. Long-lived infrastructure that is not
+        // torn down/reinitialized by the feature registry (e.g. the persistent Action
+        // Filter) uses this to resynchronize after a character switch, where per-setting
+        // onSettingChange callbacks are intentionally suppressed.
+        this.settingsLoadedCallbacks = [];
+
         // Feature toggles with metadata for future UI
         this.features = {
             // Market Features
@@ -467,6 +474,11 @@ class Config {
                 }
             }
         }
+
+        // Fire regardless of notifyChanges: this signals settingsMap has been repopulated
+        // from storage, which persistent infrastructure needs even when per-setting change
+        // callbacks are intentionally suppressed (e.g. character switch reinitialization).
+        for (const cb of this.settingsLoadedCallbacks) cb();
     }
 
     /**
@@ -626,6 +638,24 @@ class Config {
         if (this.settingChangeCallbacks[key]) {
             this.settingChangeCallbacks[key] = this.settingChangeCallbacks[key].filter((cb) => cb !== callback);
         }
+    }
+
+    /**
+     * Register a callback to be called whenever loadSettings() repopulates settingsMap from
+     * storage, regardless of the notifyChanges option. Intended for long-lived infrastructure
+     * that is not torn down/reinitialized by the feature registry on character switch.
+     * @param {Function} callback - Callback function, called with no arguments
+     */
+    onSettingsLoaded(callback) {
+        this.settingsLoadedCallbacks.push(callback);
+    }
+
+    /**
+     * Unregister a specific callback registered via onSettingsLoaded
+     * @param {Function} callback - The exact callback reference to remove
+     */
+    offSettingsLoaded(callback) {
+        this.settingsLoadedCallbacks = this.settingsLoadedCallbacks.filter((cb) => cb !== callback);
     }
 
     /**

--- a/src/features/actions/action-filter.js
+++ b/src/features/actions/action-filter.js
@@ -30,6 +30,7 @@ class ActionFilter {
         this._updateSortBtn = null;
         this.pricingModeHandler = null;
         this.craftUpgradeHandler = null;
+        this.settingsLoadedHandler = null;
         this.unregisterSortModeHandler = null;
     }
 
@@ -60,6 +61,19 @@ class ActionFilter {
             if (this._updateCraftBtn) this._updateCraftBtn();
         };
         config.onSettingChange('profitCalc_craftUpgradeItems', this.craftUpgradeHandler);
+
+        // Character switches load the new character's settings with per-setting
+        // onSettingChange callbacks suppressed (the feature registry fully reinitializes
+        // regular features instead). This filter is persistent infrastructure outside that
+        // lifecycle (see Actions.initActionPanelObserver), so it resyncs its own mode/craft
+        // labels and any already-rendered profit sections once settings actually finish
+        // loading, regardless of that suppression.
+        this.settingsLoadedHandler = () => {
+            if (this._updateModeBtn) this._updateModeBtn();
+            if (this._updateCraftBtn) this._updateCraftBtn();
+            this._refreshProfitDisplays();
+        };
+        config.onSettingsLoaded(this.settingsLoadedHandler);
 
         this.unregisterSortModeHandler = actionPanelSort.onSortModeChange(() => {
             if (this._updateSortBtn) this._updateSortBtn();
@@ -569,6 +583,10 @@ class ActionFilter {
         if (this.craftUpgradeHandler) {
             config.offSettingChange('profitCalc_craftUpgradeItems', this.craftUpgradeHandler);
             this.craftUpgradeHandler = null;
+        }
+        if (this.settingsLoadedHandler) {
+            config.offSettingsLoaded(this.settingsLoadedHandler);
+            this.settingsLoadedHandler = null;
         }
         if (this.unregisterSortModeHandler) {
             this.unregisterSortModeHandler();

--- a/src/features/actions/action-filter.test.js
+++ b/src/features/actions/action-filter.test.js
@@ -1,0 +1,159 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const PRICING_LABELS = {
+    conservative: 'Buy: Ask / Sell: Bid',
+    hybrid: 'Buy: Ask / Sell: Ask',
+    optimistic: 'Buy: Bid / Sell: Ask',
+    patientBuy: 'Buy: Bid / Sell: Bid',
+};
+
+const mocks = vi.hoisted(() => ({
+    settingsLoadedHandlers: [],
+    settings: {
+        actionPanel_showFilter: true,
+        actionPanel_showSort: true,
+        actionPanel_showPricingMode: true,
+        actionPanel_showCraftToggle: true,
+        profitCalc_craftUpgradeItems: false,
+    },
+    pricingMode: 'hybrid',
+    titleCallback: null,
+}));
+
+vi.mock('../../core/config.js', () => ({
+    default: {
+        getSetting: vi.fn((key) => mocks.settings[key] ?? false),
+        getSettingValue: vi.fn((key, fallback) => (key === 'profitCalc_pricingMode' ? mocks.pricingMode : fallback)),
+        setSettingValue: vi.fn(),
+        setSetting: vi.fn(),
+        getPricingModeLabel: vi.fn((mode) => PRICING_LABELS[mode] || PRICING_LABELS.hybrid),
+        onSettingChange: vi.fn(),
+        offSettingChange: vi.fn(),
+        onSettingsLoaded: vi.fn((cb) => mocks.settingsLoadedHandlers.push(cb)),
+        offSettingsLoaded: vi.fn((cb) => {
+            mocks.settingsLoadedHandlers = mocks.settingsLoadedHandlers.filter((h) => h !== cb);
+        }),
+        COLOR_ACCENT: '#22c55e',
+    },
+}));
+
+vi.mock('../../core/dom-observer.js', () => ({
+    default: {
+        onClass: vi.fn((_name, _cls, cb) => {
+            mocks.titleCallback = cb;
+            return () => {};
+        }),
+    },
+}));
+
+vi.mock('./action-panel-sort.js', () => ({
+    default: {
+        getSortMode: vi.fn(() => 'default'),
+        onSortModeChange: vi.fn(() => () => {}),
+        setSortMode: vi.fn(),
+        sortPanelsByProfit: vi.fn(),
+    },
+}));
+
+vi.mock('./profit-display.js', () => ({
+    displayGatheringProfit: vi.fn(async () => {}),
+    displayProductionProfit: vi.fn(async () => {}),
+}));
+
+import config from '../../core/config.js';
+import actionFilter from './action-filter.js';
+import { displayProductionProfit } from './profit-display.js';
+
+function makeTitle() {
+    const title = document.createElement('h1');
+    title.className = 'GatheringProductionSkillPanel_title__3VihQ';
+    const nameDiv = document.createElement('div');
+    nameDiv.textContent = 'Cooking';
+    title.appendChild(nameDiv);
+    document.body.appendChild(title);
+    return title;
+}
+
+function fireSettingsLoaded() {
+    mocks.settingsLoadedHandlers.slice().forEach((cb) => cb());
+}
+
+describe('ActionFilter mode/profit synchronization after a character-switch settings reload', () => {
+    beforeEach(async () => {
+        document.body.innerHTML = '';
+        mocks.settingsLoadedHandlers = [];
+        mocks.pricingMode = 'hybrid';
+        mocks.titleCallback = null;
+        vi.clearAllMocks();
+        await actionFilter.initialize();
+    });
+
+    afterEach(() => {
+        actionFilter.cleanup();
+    });
+
+    test('registers a settings-loaded listener at initialize, separate from the per-setting pricing mode callback', () => {
+        expect(config.onSettingsLoaded).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    test('mode button resyncs to the loaded pricing mode once settings finish loading, without a click', () => {
+        const title = makeTitle();
+        mocks.titleCallback(title);
+
+        const modeBtn = document.getElementById('mwi-action-profit-mode');
+        // Injected while the config cache was still empty, so it shows the fallback mode.
+        expect(modeBtn.textContent).toBe(`Mode: ${PRICING_LABELS.hybrid}`);
+
+        // The new character's saved mode is optimistic; settings finish loading.
+        mocks.pricingMode = 'optimistic';
+        fireSettingsLoaded();
+
+        expect(modeBtn.textContent).toBe(`Mode: ${PRICING_LABELS.optimistic}`);
+    });
+
+    test('does not write a fallback mode back to storage merely from the settings-loaded resync', () => {
+        const title = makeTitle();
+        mocks.titleCallback(title);
+
+        mocks.pricingMode = 'optimistic';
+        fireSettingsLoaded();
+
+        expect(config.setSettingValue).not.toHaveBeenCalled();
+        expect(config.setSetting).not.toHaveBeenCalled();
+    });
+
+    test('an already-rendered production profit section recomputes exactly once from the loaded mode', async () => {
+        const title = makeTitle();
+        mocks.titleCallback(title);
+
+        // A profit section rendered while the mode lookup would still fall back to hybrid.
+        const panel = document.createElement('div');
+        panel.className = 'SkillActionDetail_regularComponent__3oCgr';
+        const section = document.createElement('div');
+        section.dataset.mwiActionHrid = '/actions/cooking/yogurt_can';
+        section.dataset.mwiActionType = 'production';
+        panel.appendChild(section);
+        document.body.appendChild(panel);
+
+        mocks.pricingMode = 'optimistic';
+        fireSettingsLoaded();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(displayProductionProfit).toHaveBeenCalledTimes(1);
+        expect(displayProductionProfit).toHaveBeenCalledWith(
+            panel,
+            '/actions/cooking/yogurt_can',
+            'div.SkillActionDetail_dropTable__3ViVp'
+        );
+    });
+
+    test('re-initializing an already-initialized filter does not register a duplicate settings-loaded listener', async () => {
+        // beforeEach already called initialize() once (count 1); a second call must be a no-op.
+        await actionFilter.initialize();
+
+        expect(config.onSettingsLoaded).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary
- The persistent Action Filter (initialized once as a special case, outside `cleanupFeatures()`/`initializeFeatures()`) only refreshed its mode button via `config.onSettingChange('profitCalc_pricingMode', ...)`, which character switches intentionally suppress (`config.loadSettings({ notifyChanges: false })`) since ordinary features get a full reinit cycle instead — a cycle this filter never participates in.
- Combined with `clearSettingsCache()` synchronously emptying `settingsMap` during `character_switching`, a mode button (re)injected in that window renders the fallback `hybrid` label (`Buy: Ask / Sell: Ask`) and never resyncs once the real per-character setting (e.g. `optimistic`) loads. The same window can leave already-rendered gathering/production profit sections computed from the fallback mode.
- Added `config.onSettingsLoaded()`/`offSettingsLoaded()` — a separate channel fired whenever `loadSettings()` repopulates `settingsMap`, regardless of `notifyChanges`, so it doesn't touch the existing per-setting suppression semantics ordinary features rely on. The Action Filter subscribes once to resync its mode/craft labels and re-render visible profit sections via the existing `_refreshProfitDisplays()` helper — no click, navigation, or timeout guessing, and nothing written back to storage.

## Test plan
- [x] Regression test written first against unmodified source; 8/10 new assertions failed for the expected reason (missing sync mechanism), confirmed by stashing the fix and rerunning
- [x] Targeted: `config-settings-loaded.test.js` (5/5), `action-filter.test.js` (5/5), `config.test.js` (21/21, no regressions)
- [x] Full suite: 644/644 passing
- [x] Lint clean, format clean
- [x] `build:dev`, `build` (production), `build:enhancement` all succeed
- [x] CI bundle-size gate (2MB) reproduced exactly — all artifacts pass
- [x] Built dev artifact contains the fix path (`onSettingsLoaded`/`settingsLoadedCallbacks`, 7 occurrences)