### PR TITLE
fix: heal Custom Tabs action buttons when the sort-controls row is removed

### DIFF
--- a/src/features/inventory/custom-tabs/custom-tabs-ui.js
+++ b/src/features/inventory/custom-tabs/custom-tabs-ui.js
@@ -918,7 +918,17 @@ export default class CustomTabsUI {
         // Compare BEFORE assignment — otherwise isSameNode is always true
         const isSameNode = invContainer === this._invContainer;
         const injectedStillPresent = areInjectedLayoutElementsAttached(this._injectedEls, invContainer);
-        let needsFullRebuild = !isSameNode || !injectedStillPresent;
+        // The action buttons (+Tab/Export/Import/Expand All/Collapse All) can be merged into a
+        // foreign container (.mwi-inventory-sort-controls, owned by the separate InventorySort
+        // feature — see _injectActionButtons) instead of a standalone topbar. When merged, they
+        // are never added to _injectedEls, so areInjectedLayoutElementsAttached() above cannot
+        // see their removal. If InventorySort tears down that container (e.g. toggling "Sort
+        // inventory items by value" off), the buttons disappear with it and nothing else here
+        // would notice, since tile identity/composition/config are all unchanged. Only treat
+        // this as a problem once a real injection has happened (_actionBtnsEl set) and then gone
+        // missing — before the first injection, or in a mocked-out test, there is nothing to heal.
+        const actionButtonsMissing = Boolean(this._actionBtnsEl) && !this._actionBtnsEl.isConnected;
+        let needsFullRebuild = !isSameNode || !injectedStillPresent || actionButtonsMissing;
 
         this._invContainer = invContainer;
 

--- a/src/features/inventory/custom-tabs/custom-tabs-ui.test.js
+++ b/src/features/inventory/custom-tabs/custom-tabs-ui.test.js
@@ -330,3 +330,66 @@ describe('CustomTabsUI layout invalidation', () => {
         expect(rebuildSpy).not.toHaveBeenCalled();
     });
 });
+
+describe('CustomTabsUI action buttons survive removal of the piggybacked sort-controls row', () => {
+    let ui;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        mocks.showUnorganized = true;
+        mocks.tileGap = 4;
+        ui = new CustomTabsUI();
+        ui._config = { version: 1, tabs: [], selectedTabId: null };
+        // Real _injectActionButtons() runs in this describe block (not mocked out), since the
+        // bug lives inside it. Only bypass DOM lookups unrelated to the button-injection path.
+        vi.spyOn(ui, '_findContentContainer').mockReturnValue(null);
+    });
+
+    afterEach(() => {
+        ui._tileObserver?.disconnect();
+    });
+
+    function makeSortControls() {
+        const sortControls = document.createElement('div');
+        sortControls.className = 'mwi-inventory-sort-controls';
+        document.body.appendChild(sortControls);
+        return sortControls;
+    }
+
+    test('action buttons are appended into an existing sort-controls row instead of a standalone topbar', () => {
+        makeSortControls();
+        const container = makeInvContainer([makeTile('Milk')]);
+
+        ui._applyLayoutSync(container);
+
+        const actionBtns = document.querySelector('.toolasha-ct-action-btns');
+        expect(actionBtns).not.toBeNull();
+        expect(actionBtns.parentElement.className).toBe('mwi-inventory-sort-controls');
+        // No fallback topbar was created inside the inventory container.
+        expect(container.querySelector('.toolasha-ct-topbar')).toBeNull();
+    });
+
+    test('removing the sort-controls row (e.g. toggling "Sort inventory items by value" off) does not permanently delete the tab action buttons', () => {
+        // Reproduces the reported bug: inventory-sort.js's disable() removes the whole
+        // .mwi-inventory-sort-controls element it owns, with no awareness that Custom Tabs
+        // piggybacked its +Tab/Export/Import/Expand All/Collapse All buttons inside it.
+        // Because _injectActionButtons() returns null when it merges into that row,
+        // _applyLayoutSync's dirty-check (_injectedEls / areInjectedLayoutElementsAttached)
+        // never learns the buttons exist, so it can't detect they went missing and never
+        // re-injects them on the next layout pass.
+        const sortControls = makeSortControls();
+        const container = makeInvContainer([makeTile('Milk')]);
+        ui._applyLayoutSync(container);
+        expect(document.querySelector('.toolasha-ct-action-btns')).not.toBeNull();
+
+        // Simulate InventorySort.disable() tearing down the row it owns.
+        sortControls.remove();
+        expect(document.querySelector('.toolasha-ct-action-btns')).toBeNull();
+
+        // The next layout pass (e.g. the items_updated → _applyLayout path, or the
+        // MutationObserver-driven _applyLayoutSync path) must restore the buttons.
+        ui._applyLayoutSync(container);
+
+        expect(document.querySelector('.toolasha-ct-action-btns')).not.toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- `_injectActionButtons()` merges the `+Tab`/`Export`/`Import`/`Expand All`/`Collapse All` group into `.mwi-inventory-sort-controls` (owned by the separate `InventorySort` feature) whenever that row already exists, and returns `null` since no topbar was needed. Only the topbar return value is ever tracked in `_injectedEls`, so a merged button group is invisible to `areInjectedLayoutElementsAttached()`.
- When `InventorySort.disable()` (toggling "Sort inventory items by value" off) removes the whole `.mwi-inventory-sort-controls` element it owns, the buttons go with it. Tile identity/composition/config are unchanged, so no existing invalidation check notices, and the buttons stay gone until reload — exactly the user-reported bug.
- Added an independent check in `_applyLayoutSync`: once the buttons have been injected at least once, force a full rebuild if `this._actionBtnsEl` is no longer connected, regardless of which injection path was used. Mirrors the existing self-heal pattern already used for the Unorganized header.

## Test plan
- [x] Regression test written first against unmodified source; failed for the expected reason (buttons never restored after the sort-controls row is removed), confirmed by stashing the fix and rerunning
- [x] Targeted: `custom-tabs-ui.test.js` 14/14 (12 pre-existing + 2 new), no regressions
- [x] Full suite: 646/646 passing
- [x] Lint clean, format clean
- [x] `build:dev`, `build` (production), `build:enhancement` all succeed
- [x] CI bundle-size gate (2MB) reproduced exactly — all artifacts pass
- [x] Built dev artifact contains the fix path (`actionButtonsMissing`, 2 occurrences)