### PR TITLE
fix: keep Unorganized visible when the config cache is empty mid-layout-pass

### DIFF
--- a/src/features/inventory/custom-tabs/custom-tabs-ui.js
+++ b/src/features/inventory/custom-tabs/custom-tabs-ui.js
@@ -980,7 +980,14 @@ export default class CustomTabsUI {
         // present with nothing unassigned — the lightweight path can't fix that on its own,
         // since it only re-applies visibility using headers that already exist. Force a full
         // rebuild instead of trusting historical rebuild state.
-        if (!needsFullRebuild && config.getSettingValue('inventoryTabs_showUnorganized')) {
+        // getSetting() (not getSettingValue()) is required here: it has a schema-default
+        // fallback for boolean checkbox settings, so a config-cache-empty window (e.g. between
+        // clearSettingsCache() and the next successful loadSettings() during a character
+        // switch) still resolves to this setting's true schema default instead of a falsy
+        // "missing key" value. getSettingValue() has no such fallback, and previously returning
+        // it here (or below) is what let a decisive rebuild permanently miss the Unorganized
+        // header/self-heal on 2.87.9.
+        if (!needsFullRebuild && config.getSetting('inventoryTabs_showUnorganized')) {
             const hasUnorgHeader = Boolean(invContainer.querySelector('.toolasha-ct-unorg-header'));
             if (hasUnorgHeader !== this._hasUnassignedTiles(tileMap)) {
                 needsFullRebuild = true;
@@ -1011,7 +1018,7 @@ export default class CustomTabsUI {
                 orderCounter = this._injectAccordionHeaders(invContainer, this._config.tabs, 0, tileMap, orderCounter);
             }
 
-            if (config.getSettingValue('inventoryTabs_showUnorganized')) {
+            if (config.getSetting('inventoryTabs_showUnorganized')) {
                 orderCounter = this._injectUnorganized(invContainer, tileMap, orderCounter);
             }
 

--- a/src/features/inventory/custom-tabs/custom-tabs-ui.test.js
+++ b/src/features/inventory/custom-tabs/custom-tabs-ui.test.js
@@ -4,17 +4,32 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
     showUnorganized: true,
+    // Simulates config.settingsMap lacking 'inventoryTabs_showUnorganized' entirely — e.g. the
+    // window between config.clearSettingsCache() and the next successful config.loadSettings()
+    // during a character switch. Real Config.getSettingValue(key, defaultValue) returns
+    // defaultValue verbatim when settingsMap[key] is absent; it has no schema-default fallback
+    // the way getSetting() does.
+    showUnorganizedCacheEmpty: false,
     tileGap: 4,
 }));
 
 vi.mock('../../../core/config.js', () => ({
     default: {
         getSettingValue: vi.fn((key, fallback) => {
-            if (key === 'inventoryTabs_showUnorganized') return mocks.showUnorganized;
+            if (key === 'inventoryTabs_showUnorganized') {
+                return mocks.showUnorganizedCacheEmpty ? fallback : mocks.showUnorganized;
+            }
             if (key === 'inventoryTabs_tileGap') return mocks.tileGap;
             return fallback;
         }),
-        getSetting: vi.fn(() => false),
+        getSetting: vi.fn((key) => {
+            // getSetting() has a schema-default fallback for boolean settings in real
+            // production code, so — unlike the getSettingValue() branch above — it is
+            // deliberately NOT affected by showUnorganizedCacheEmpty here: that's the whole
+            // point of the fix this file's cache-empty-window tests verify.
+            if (key === 'inventoryTabs_showUnorganized') return mocks.showUnorganized;
+            return false;
+        }),
         onSettingChange: vi.fn(),
         offSettingChange: vi.fn(),
     },
@@ -106,6 +121,7 @@ describe('CustomTabsUI layout invalidation', () => {
     beforeEach(() => {
         document.body.innerHTML = '';
         mocks.showUnorganized = true;
+        mocks.showUnorganizedCacheEmpty = false;
         mocks.tileGap = 4;
         ui = new CustomTabsUI();
         ui._config = { version: 1, tabs: [], selectedTabId: null };
@@ -328,6 +344,48 @@ describe('CustomTabsUI layout invalidation', () => {
         ui._applyLayoutSync(container);
 
         expect(rebuildSpy).not.toHaveBeenCalled();
+    });
+
+    test('Unorganized still appears on a full rebuild that runs while the config cache is empty (2.87.9 recurrence)', () => {
+        // Reproduces the confirmed 2.87.9 mechanism: config.clearSettingsCache() (fired during
+        // character-switching, and again by an independent settings-ui.js character_initialized
+        // listener that never repairs it) synchronously empties config.settingsMap.
+        // custom-tabs-ui.js reads inventoryTabs_showUnorganized via getSettingValue() with NO
+        // default argument at both call sites, so while settingsMap lacks the key it resolves
+        // to whatever the caller passed as fallback (undefined here) — falsy — even though the
+        // checkbox's schema default is true. getSetting() has a schema-fallback for exactly this
+        // case; getSettingValue() does not, and that's the gap this exercises.
+        mocks.showUnorganizedCacheEmpty = true;
+
+        const container = makeInvContainer([makeTile('Milk')]);
+        ui._applyLayoutSync(container);
+
+        const header = container.querySelector('.toolasha-ct-unorg-header');
+        expect(header).not.toBeNull();
+        expect(header.textContent).toContain('Unorganized (1)');
+        const milkTile = container.querySelector('svg[aria-label="Milk"]').closest('.Item_itemContainer_abc');
+        expect(milkTile.classList.contains('toolasha-ct-visible')).toBe(true);
+    });
+
+    test('the Unorganized self-heal invariant on the lightweight path is not defeated by a config-cache-empty window', () => {
+        // Exercises the OTHER getSettingValue('inventoryTabs_showUnorganized') call site — the
+        // self-heal check gating a lightweight-path rebuild — not the full-rebuild injection
+        // call site covered above.
+        const container = makeInvContainer([makeTile('Milk'), makeTile('Egg')]);
+        ui._applyLayoutSync(container);
+        expect(container.querySelector('.toolasha-ct-unorg-header').textContent).toContain('Unorganized (2)');
+
+        // Assign Milk to a tab (membership change, no composition/count change) at the exact
+        // moment the config cache happens to be empty.
+        ui._config = {
+            version: 1,
+            tabs: [{ id: 'tab-1', name: 'Food', color: null, open: true, items: ['/items/milk'], children: [] }],
+            selectedTabId: null,
+        };
+        mocks.showUnorganizedCacheEmpty = true;
+        ui._applyLayoutSync(container);
+
+        expect(container.querySelector('.toolasha-ct-unorg-header').textContent).toContain('Unorganized (1)');
     });
 });
 


### PR DESCRIPTION
## Summary
- Independently confirmed against current 2.87.10 source, using the 2.87.9 recurrence evidence package: both of `custom-tabs-ui.js`'s decisive Unorganized checks read `inventoryTabs_showUnorganized` via `config.getSettingValue(key)` with **no default argument**. `getSettingValue(key, defaultValue = null)` returns `defaultValue` verbatim when `settingsMap[key]` is absent — unlike `getSetting()`, it has no schema-default fallback.
- `config.clearSettingsCache()` synchronously empties `settingsMap` during character-switching, and — independently, with no repair of its own — again from a `settings-ui.js` `character_initialized` listener on every switch beyond the first. If either Unorganized check runs during that window, it reads `null` (falsy) even though the checkbox's schema default is `true`. The same read also gates the self-heal invariant on every later pass, so nothing recovers it until the cache happens to repopulate before another decisive pass, or the page reloads.
- This explains every fact in the evidence: ordinary section headers (backed by a separate per-character IndexedDB config) stayed correct, only Unorganized vanished and stayed gone, 22/24 previously-proven identities remained hidden, and recovery only came after a full reload.
- Fixed both call sites to use `config.getSetting('inventoryTabs_showUnorganized')` — the same accessor already used for every other checkbox in this file, which already has the schema-default fallback `getSettingValue()` lacks. This makes the read itself immune to any config-cache-empty window, regardless of which exact timing race causes it — the smallest general fix, not another blind header self-heal special case.

## Test plan
- [x] Two new regression tests written first against unmodified source; both failed for the correct reason (header is `null`), confirmed by stashing the fix and rerunning, then restoring it
- [x] Targeted: `custom-tabs-ui.test.js` 16/16 (14 pre-existing + 2 new), no regressions
- [x] Full suite: 655/655 passing
- [x] Lint clean, format clean
- [x] `build:dev`, `build` (production), `build:enhancement` all succeed
- [x] CI bundle-size gate reproduced exactly — all artifacts pass
- [x] Built dev artifact verified: 2 occurrences of the fixed `getSetting(...)` call, 0 occurrences of the old `getSettingValue(...)` pattern