### PR TITLE
feat: add Risk of Ruin calculator for chests, alchemy, and enhancing

### DIFF
--- a/src/core/settings-schema.js
+++ b/src/core/settings-schema.js
@@ -928,6 +928,27 @@ export const settingsGroups = {
         },
     },
 
+    riskOfRuin: {
+        title: 'Risk of Ruin',
+        icon: '🎲',
+        settings: {
+            riskOfRuin: {
+                id: 'riskOfRuin',
+                label: 'Enable Risk of Ruin calculator',
+                type: 'checkbox',
+                default: true,
+                help: 'Adds a standalone calculator estimating the chance of hitting 0 gold before reaching a target number of dungeon chests, alchemy Transmute actions, or an enhancement level.',
+            },
+            riskOfRuin_trials: {
+                id: 'riskOfRuin_trials',
+                label: 'Risk of Ruin: Monte Carlo trial count',
+                type: 'text',
+                default: '10000',
+                help: 'Higher trial counts give a more precise probability estimate at the cost of a slower calculation.',
+            },
+        },
+    },
+
     marketplace: {
         title: 'Marketplace',
         icon: '🏪',

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -682,6 +682,13 @@ function registerFeatures() {
             async: false,
         },
         {
+            key: 'riskOfRuin',
+            name: 'Risk of Ruin Calculator',
+            category: 'Risk of Ruin',
+            module: UI.riskOfRuinUI,
+            async: false,
+        },
+        {
             key: 'guildXPTracker',
             name: 'Guild XP Tracker',
             category: 'Guild',

--- a/src/features/combat-sim/combat-sim-adapter.js
+++ b/src/features/combat-sim/combat-sim-adapter.js
@@ -978,7 +978,7 @@ export function calculateExpectedDrops(simResult, gameData, playerHrid = 'player
 }
 
 // Maps dungeon chest HRIDs to their required entry key HRIDs
-const DUNGEON_ENTRY_KEYS = {
+export const DUNGEON_ENTRY_KEYS = {
     '/items/chimerical_chest': '/items/chimerical_entry_key',
     '/items/sinister_chest': '/items/sinister_entry_key',
     '/items/enchanted_chest': '/items/enchanted_entry_key',
@@ -986,7 +986,7 @@ const DUNGEON_ENTRY_KEYS = {
 };
 
 // Maps dungeon chest HRIDs (regular + refinement) to their chest key HRIDs
-const DUNGEON_CHEST_KEYS = {
+export const DUNGEON_CHEST_KEYS = {
     '/items/chimerical_chest': '/items/chimerical_chest_key',
     '/items/sinister_chest': '/items/sinister_chest_key',
     '/items/enchanted_chest': '/items/enchanted_chest_key',

--- a/src/features/enhancement/tooltip-enhancement.js
+++ b/src/features/enhancement/tooltip-enhancement.js
@@ -702,6 +702,41 @@ export function getCheapestProtectionPrice(itemHrid) {
 }
 
 /**
+ * Calculate the gold cost of a single enhancement attempt's consumed materials (ask-side
+ * market price), including any direct coin line item in enhancementCosts. Materials are
+ * consumed on every attempt regardless of success/failure, and this cost is the same at every
+ * enhancement level (enhancementCosts is not level-indexed).
+ * @param {Object} itemDetails - Item details containing enhancementCosts.
+ * @returns {{cost: number, hasCost: boolean, costPartial: boolean}}
+ */
+export function calculatePerAttemptMaterialCost(itemDetails) {
+    let cost = 0;
+    let hasCost = false;
+    let costPartial = false;
+
+    if (!itemDetails.enhancementCosts?.length) {
+        return { cost: 0, hasCost: false, costPartial: false };
+    }
+
+    for (const material of itemDetails.enhancementCosts) {
+        if (material.itemHrid === '/items/coin') {
+            cost += material.count;
+            hasCost = true;
+            continue;
+        }
+        const price = marketAPI.getPrice(material.itemHrid);
+        if (price?.ask > 0) {
+            cost += material.count * price.ask;
+            hasCost = true;
+        } else {
+            costPartial = true;
+        }
+    }
+
+    return { cost, hasCost, costPartial };
+}
+
+/**
  * Fibonacci calculation for item quantities (from Enhancelator)
  * @private
  */

--- a/src/features/enhancement/tooltip-enhancement.test.js
+++ b/src/features/enhancement/tooltip-enhancement.test.js
@@ -30,7 +30,13 @@ vi.mock('../../utils/market-data.js', () => ({
     getItemPrices: () => ({ ask: 400_000_000, bid: 390_000_000 }),
 }));
 
-const { buildEnhancementTooltipHTML, calculateMinimumSellPrice } = await import('./tooltip-enhancement.js');
+const marketPrices = {};
+vi.mock('../../api/marketplace.js', () => ({
+    default: { getPrice: (itemHrid) => marketPrices[itemHrid], on: () => {} },
+}));
+
+const { buildEnhancementTooltipHTML, calculateMinimumSellPrice, calculatePerAttemptMaterialCost } =
+    await import('./tooltip-enhancement.js');
 
 function makeEnhancementData(overrides = {}) {
     return {
@@ -122,5 +128,49 @@ describe('calculateMinimumSellPrice', () => {
     test('returns just the total cost when no time has elapsed', () => {
         const result = calculateMinimumSellPrice(5_000_000, 0, 10_000_000, false);
         expect(result).toBe(5_000_000);
+    });
+});
+
+describe('calculatePerAttemptMaterialCost', () => {
+    beforeEach(() => {
+        for (const key of Object.keys(marketPrices)) delete marketPrices[key];
+    });
+
+    test('sums coin line items 1:1 and priced materials at ask, marking hasCost true', () => {
+        marketPrices['/items/enhancing_essence'] = { ask: 1000, bid: 900 };
+        const itemDetails = {
+            enhancementCosts: [
+                { itemHrid: '/items/coin', count: 5000 },
+                { itemHrid: '/items/enhancing_essence', count: 3 },
+            ],
+        };
+
+        const result = calculatePerAttemptMaterialCost(itemDetails);
+
+        expect(result.cost).toBe(5000 + 3 * 1000);
+        expect(result.hasCost).toBe(true);
+        expect(result.costPartial).toBe(false);
+    });
+
+    test('flags costPartial when a material has no ask price, without discarding priced materials', () => {
+        marketPrices['/items/priced_material'] = { ask: 200, bid: 150 };
+        const itemDetails = {
+            enhancementCosts: [
+                { itemHrid: '/items/priced_material', count: 2 },
+                { itemHrid: '/items/unpriced_material', count: 1 },
+            ],
+        };
+
+        const result = calculatePerAttemptMaterialCost(itemDetails);
+
+        expect(result.cost).toBe(400);
+        expect(result.hasCost).toBe(true);
+        expect(result.costPartial).toBe(true);
+    });
+
+    test('returns a zero-cost, non-partial result when there are no enhancement costs', () => {
+        const result = calculatePerAttemptMaterialCost({ enhancementCosts: [] });
+
+        expect(result).toEqual({ cost: 0, hasCost: false, costPartial: false });
     });
 });

--- a/src/features/enhancement/xph-calculator.js
+++ b/src/features/enhancement/xph-calculator.js
@@ -6,14 +6,13 @@
 import config from '../../core/config.js';
 import domObserver from '../../core/dom-observer.js';
 import dataManager from '../../core/data-manager.js';
-import marketAPI from '../../api/marketplace.js';
 import { calculateEnhancement } from '../../utils/enhancement-calculator.js';
 import { calculateSuccessXP, calculateFailureXP } from './enhancement-xp.js';
 import { getEnhancingParams } from '../../utils/enhancement-config.js';
 import { formatKMB, formatWithSeparator } from '../../utils/formatters.js';
 import { createTimerRegistry } from '../../utils/timer-registry.js';
 import { registerFloatingPanel, unregisterFloatingPanel, bringPanelToFront } from '../../utils/panel-z-index.js';
-import { getCheapestProtectionPrice } from './tooltip-enhancement.js';
+import { getCheapestProtectionPrice, calculatePerAttemptMaterialCost } from './tooltip-enhancement.js';
 
 const PANEL_ID = 'mwi-xph-calc-panel';
 const BTN_CLASS = 'mwi-xph-calc-btn';
@@ -65,28 +64,11 @@ function calculateItemXPH(itemHrid, itemDetails, maxLevel, protectFrom, params) 
     const xph = Math.round((totalXP / calc.totalTime) * 3600);
 
     // Material cost calculation
-    let materialCost = 0;
-    let costPartial = false;
-    let allMissing = true;
+    const perAttempt = calculatePerAttemptMaterialCost(itemDetails);
+    const materialCost = perAttempt.cost * calc.attempts;
+    let costPartial = perAttempt.costPartial;
+    const hasCost = perAttempt.hasCost;
 
-    if (itemDetails.enhancementCosts?.length) {
-        for (const cost of itemDetails.enhancementCosts) {
-            if (cost.itemHrid === '/items/coin') {
-                materialCost += cost.count * calc.attempts;
-                allMissing = false;
-                continue;
-            }
-            const price = marketAPI.getPrice(cost.itemHrid);
-            if (price?.ask > 0) {
-                materialCost += cost.count * price.ask * calc.attempts;
-                allMissing = false;
-            } else {
-                costPartial = true;
-            }
-        }
-    }
-
-    const hasCost = !allMissing;
     let goldPerXP = hasCost ? materialCost / totalXP : null;
     let costPerHour = hasCost ? goldPerXP * xph : null;
 

--- a/src/features/risk-of-ruin/risk-of-ruin-ui.js
+++ b/src/features/risk-of-ruin/risk-of-ruin-ui.js
@@ -1,0 +1,496 @@
+/**
+ * Risk of Ruin Calculator UI
+ *
+ * Standalone floating panel (same pattern as XPHCalculator) answering "how likely am I to hit
+ * 0 gold before reaching my target?" for three activities: opening dungeon chests, running
+ * Transmute alchemy actions, and enhancing an item to a target level.
+ */
+
+import config from '../../core/config.js';
+import dataManager from '../../core/data-manager.js';
+import { getEnhancingParams } from '../../utils/enhancement-config.js';
+import { formatWithSeparator, formatPercentage } from '../../utils/formatters.js';
+import { createTimerRegistry } from '../../utils/timer-registry.js';
+import { registerFloatingPanel, unregisterFloatingPanel, bringPanelToFront } from '../../utils/panel-z-index.js';
+import {
+    lundbergBound,
+    lundbergBoundVarying,
+    wilsonConfidenceInterval,
+    minActionsForNonZeroRisk,
+    findPeakExposureStep,
+} from '../../utils/risk-of-ruin-engine.js';
+import { simulateRuinAsync } from '../../utils/risk-of-ruin-worker-manager.js';
+import { buildDungeonChestModel } from '../../utils/risk-of-ruin-adapters/dungeon-chest-adapter.js';
+import { buildAlchemyTransmuteModel } from '../../utils/risk-of-ruin-adapters/alchemy-adapter.js';
+import { buildEnhancementModel } from '../../utils/risk-of-ruin-adapters/enhancement-adapter.js';
+
+const PANEL_ID = 'mwi-risk-of-ruin-panel';
+const LAUNCHER_ID = 'mwi-risk-of-ruin-launcher';
+const MAX_STEPS = 20000;
+
+const CHEST_HRIDS = [
+    '/items/chimerical_chest',
+    '/items/chimerical_refinement_chest',
+    '/items/sinister_chest',
+    '/items/sinister_refinement_chest',
+    '/items/enchanted_chest',
+    '/items/enchanted_refinement_chest',
+    '/items/pirate_chest',
+    '/items/pirate_refinement_chest',
+];
+
+function getCoinBalance() {
+    const coin = dataManager.getCharacterItems()?.find((item) => item.itemHrid === '/items/coin');
+    return coin?.count || 0;
+}
+
+function getTrialCount() {
+    return parseInt(config.getSettingValue('riskOfRuin_trials')) || 10000;
+}
+
+class RiskOfRuinUI {
+    constructor() {
+        this.isInitialized = false;
+        this.timerRegistry = createTimerRegistry();
+        this.panel = null;
+        this.isDragging = false;
+        this.dragOffset = { x: 0, y: 0 };
+    }
+
+    initialize() {
+        if (this.isInitialized) return;
+        if (!config.getSetting('riskOfRuin')) return;
+
+        this.isInitialized = true;
+        this._buildPanel();
+        this._buildLauncher();
+    }
+
+    _buildLauncher() {
+        const btn = document.createElement('button');
+        btn.id = LAUNCHER_ID;
+        btn.textContent = 'Risk of Ruin';
+        btn.style.cssText = `
+            position: fixed;
+            bottom: 12px;
+            right: 12px;
+            z-index: ${config.Z_FLOATING_PANEL};
+            background: linear-gradient(180deg, rgba(200,60,60,0.25) 0%, rgba(200,60,60,0.12) 100%);
+            color: #e0e0e0;
+            border: 1px solid rgba(200,60,60,0.5);
+            border-radius: 6px;
+            padding: 6px 12px;
+            font-size: 12px;
+            font-weight: 600;
+            cursor: pointer;
+        `;
+        btn.addEventListener('click', () => this._toggle());
+        document.body.appendChild(btn);
+    }
+
+    _toggle() {
+        if (!this.panel) return;
+        const visible = this.panel.style.display !== 'none';
+        this.panel.style.display = visible ? 'none' : 'flex';
+        if (!visible) {
+            bringPanelToFront(this.panel);
+            this._refillBankroll();
+        }
+    }
+
+    _buildPanel() {
+        this.panel = document.createElement('div');
+        this.panel.id = PANEL_ID;
+        this.panel.style.cssText = `
+            position: fixed;
+            top: 60px;
+            right: 60px;
+            z-index: ${config.Z_FLOATING_PANEL};
+            background: rgba(10, 10, 20, 0.97);
+            border: 2px solid rgba(200, 60, 60, 0.5);
+            border-radius: 10px;
+            width: 460px;
+            max-height: 620px;
+            display: none;
+            flex-direction: column;
+            font-family: 'Segoe UI', sans-serif;
+            color: #e0e0e0;
+            font-size: 13px;
+            box-shadow: 0 8px 24px rgba(0,0,0,0.6);
+        `;
+
+        const header = document.createElement('div');
+        header.style.cssText = `
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 10px 14px;
+            cursor: grab;
+            background: rgba(200,60,60,0.12);
+            border-bottom: 1px solid rgba(200,60,60,0.3);
+            border-radius: 8px 8px 0 0;
+            flex-shrink: 0;
+        `;
+        header.innerHTML = `
+            <span style="font-weight:700; font-size:14px; color:#e05c5c;">Risk of Ruin Calculator</span>
+            <button id="mwi-ror-close" style="
+                background:none; border:none; color:#aaa; font-size:22px;
+                cursor:pointer; padding:0; line-height:1;">×</button>
+        `;
+        this._setupDrag(header);
+
+        const body = document.createElement('div');
+        body.style.cssText = 'overflow-y: auto; flex: 1; padding: 12px 14px;';
+        body.innerHTML = this._bodyHTML();
+
+        const status = document.createElement('div');
+        status.id = 'mwi-ror-status';
+        status.style.cssText =
+            'padding:6px 14px; color:#555; font-size:11px; border-top:1px solid #1a1a1a; flex-shrink:0; text-align:center;';
+        status.textContent = 'Choose a mode, set your target, and click Calculate.';
+
+        this.panel.appendChild(header);
+        this.panel.appendChild(body);
+        this.panel.appendChild(status);
+        document.body.appendChild(this.panel);
+        registerFloatingPanel(this.panel);
+
+        this.panel.querySelector('#mwi-ror-close').addEventListener('click', () => {
+            this.panel.style.display = 'none';
+        });
+        this.panel.addEventListener('mousedown', () => bringPanelToFront(this.panel));
+
+        this.panel.querySelector('#mwi-ror-mode').addEventListener('change', () => this._renderModeInputs());
+        this.panel.querySelector('#mwi-ror-run').addEventListener('click', () => this._run());
+
+        this._populateItemLists();
+        this._renderModeInputs();
+    }
+
+    _bodyHTML() {
+        const labelStyle = 'color:#888; font-size:12px; display:block; margin-bottom:2px;';
+        const inputStyle =
+            'width:100%; background:#1a1a2e; color:#e0e0e0; border:1px solid #444; border-radius:4px; padding:5px 8px; font-size:12px; box-sizing:border-box;';
+
+        return `
+            <label style="${labelStyle}">Mode</label>
+            <select id="mwi-ror-mode" style="${inputStyle} margin-bottom:10px;">
+                <option value="chest">Dungeon Chest</option>
+                <option value="alchemy">Alchemy (Transmute)</option>
+                <option value="enhancement">Enhancing</option>
+            </select>
+
+            <div id="mwi-ror-mode-inputs"></div>
+
+            <label style="${labelStyle} margin-top:10px;">Starting gold</label>
+            <input id="mwi-ror-bankroll" type="number" min="0" step="1" style="${inputStyle} margin-bottom:10px;">
+
+            <button id="mwi-ror-run" style="
+                width: 100%;
+                background: rgba(200,60,60,0.2);
+                color: #e05c5c;
+                border: 1px solid rgba(200,60,60,0.4);
+                border-radius: 6px;
+                padding: 8px 14px;
+                font-size: 13px;
+                font-weight: 600;
+                cursor: pointer;
+                margin-bottom: 10px;">Calculate</button>
+
+            <div id="mwi-ror-results" style="font-size:12px; line-height:1.6;"></div>
+        `;
+    }
+
+    _renderModeInputs() {
+        const mode = this.panel.querySelector('#mwi-ror-mode').value;
+        const container = this.panel.querySelector('#mwi-ror-mode-inputs');
+        const labelStyle = 'color:#888; font-size:12px; display:block; margin-bottom:2px;';
+        const inputStyle =
+            'width:100%; background:#1a1a2e; color:#e0e0e0; border:1px solid #444; border-radius:4px; padding:5px 8px; font-size:12px; box-sizing:border-box; margin-bottom:10px;';
+
+        if (mode === 'chest') {
+            const options = CHEST_HRIDS.map((hrid) => {
+                const name = dataManager.getItemDetails(hrid)?.name || hrid;
+                return `<option value="${hrid}">${name}</option>`;
+            }).join('');
+            container.innerHTML = `
+                <label style="${labelStyle}">Chest type</label>
+                <select id="mwi-ror-chest" style="${inputStyle}">${options}</select>
+                <label style="${labelStyle}">Chests to open</label>
+                <input id="mwi-ror-target" type="number" min="1" step="1" value="100" style="${inputStyle}">
+            `;
+        } else if (mode === 'alchemy') {
+            container.innerHTML = `
+                <label style="${labelStyle}">Item to Transmute</label>
+                <input id="mwi-ror-item" list="mwi-ror-transmute-items" style="${inputStyle}" placeholder="Start typing an item name...">
+                <label style="${labelStyle}">Actions to attempt</label>
+                <input id="mwi-ror-target" type="number" min="1" step="1" value="100" style="${inputStyle}">
+            `;
+        } else {
+            container.innerHTML = `
+                <label style="${labelStyle}">Item to enhance</label>
+                <input id="mwi-ror-item" list="mwi-ror-enhance-items" style="${inputStyle}" placeholder="Start typing an item name...">
+                <label style="${labelStyle}">Target level</label>
+                <input id="mwi-ror-target" type="number" min="1" max="20" step="1" value="10" style="${inputStyle}">
+                <label style="${labelStyle}">Start level</label>
+                <input id="mwi-ror-start-level" type="number" min="0" max="19" step="1" value="0" style="${inputStyle}">
+                <label style="${labelStyle}">Protect from level (0 = never)</label>
+                <input id="mwi-ror-protect-from" type="number" min="0" max="19" step="1" value="0" style="${inputStyle}">
+            `;
+        }
+    }
+
+    _populateItemLists() {
+        const gameData = dataManager.getInitClientData();
+        if (!gameData?.itemDetailMap) return;
+
+        const transmuteList = document.createElement('datalist');
+        transmuteList.id = 'mwi-ror-transmute-items';
+        const enhanceList = document.createElement('datalist');
+        enhanceList.id = 'mwi-ror-enhance-items';
+
+        for (const [hrid, details] of Object.entries(gameData.itemDetailMap)) {
+            if (details.alchemyDetail?.transmuteDropTable?.length) {
+                const option = document.createElement('option');
+                option.value = details.name;
+                option.dataset.hrid = hrid;
+                transmuteList.appendChild(option);
+            }
+            if (details.enhancementCosts?.length) {
+                const option = document.createElement('option');
+                option.value = details.name;
+                option.dataset.hrid = hrid;
+                enhanceList.appendChild(option);
+            }
+        }
+
+        this.panel.appendChild(transmuteList);
+        this.panel.appendChild(enhanceList);
+    }
+
+    _resolveItemHrid(name, datalistId) {
+        const gameData = dataManager.getInitClientData();
+        if (!gameData?.itemDetailMap) return null;
+        if (gameData.itemDetailMap[name]) return name;
+
+        const datalist = this.panel.querySelector(`#${datalistId}`);
+        const option = Array.from(datalist?.options || []).find((o) => o.value === name);
+        return option?.dataset.hrid || null;
+    }
+
+    _refillBankroll() {
+        const bankrollInput = this.panel.querySelector('#mwi-ror-bankroll');
+        if (bankrollInput && !bankrollInput.dataset.userEdited) {
+            bankrollInput.value = getCoinBalance();
+        }
+        if (bankrollInput && !bankrollInput.dataset.wired) {
+            bankrollInput.dataset.wired = 'true';
+            bankrollInput.addEventListener('input', () => {
+                bankrollInput.dataset.userEdited = 'true';
+            });
+        }
+    }
+
+    _setupDrag(header) {
+        header.addEventListener('mousedown', (e) => {
+            if (e.target.id === 'mwi-ror-close') return;
+            this.isDragging = true;
+            header.style.cursor = 'grabbing';
+            const rect = this.panel.getBoundingClientRect();
+            this.dragOffset = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+            bringPanelToFront(this.panel);
+
+            const onMove = (ev) => {
+                if (!this.isDragging) return;
+                this.panel.style.left = `${ev.clientX - this.dragOffset.x}px`;
+                this.panel.style.top = `${ev.clientY - this.dragOffset.y}px`;
+                this.panel.style.right = 'auto';
+            };
+            const onUp = () => {
+                this.isDragging = false;
+                header.style.cursor = 'grab';
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+            };
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
+        });
+    }
+
+    _run() {
+        const status = this.panel.querySelector('#mwi-ror-status');
+        const results = this.panel.querySelector('#mwi-ror-results');
+        status.textContent = 'Calculating…';
+        results.innerHTML = '';
+
+        const t = setTimeout(() => {
+            this._compute().catch((err) => {
+                console.error('[RiskOfRuinUI] Calculation failed:', err);
+                status.textContent = 'Error during calculation.';
+            });
+        }, 10);
+        this.timerRegistry.registerTimeout(t);
+    }
+
+    async _compute() {
+        const status = this.panel.querySelector('#mwi-ror-status');
+        const results = this.panel.querySelector('#mwi-ror-results');
+        const mode = this.panel.querySelector('#mwi-ror-mode').value;
+        const startingBalance = parseFloat(this.panel.querySelector('#mwi-ror-bankroll').value) || 0;
+        const trials = getTrialCount();
+        const rngSeed = Math.floor(Math.random() * 2 ** 31);
+
+        let simModel;
+        let lundberg;
+        let maxSinglePossibleLoss;
+
+        if (mode === 'chest') {
+            const hrid = this.panel.querySelector('#mwi-ror-chest').value;
+            const targetActionCount = parseInt(this.panel.querySelector('#mwi-ror-target').value) || 0;
+            const chestModel = buildDungeonChestModel(hrid);
+            maxSinglePossibleLoss = chestModel.maxSinglePossibleLoss;
+            simModel = {
+                type: 'fixedOutcome',
+                startingBalance,
+                trials,
+                maxSteps: MAX_STEPS,
+                rngSeed,
+                outcomeDistribution: chestModel.outcomeDistribution,
+                targetActionCount,
+            };
+            lundberg = lundbergBound({ startingBalance, outcomeDistribution: chestModel.outcomeDistribution });
+        } else if (mode === 'alchemy') {
+            const name = this.panel.querySelector('#mwi-ror-item').value;
+            const hrid = this._resolveItemHrid(name, 'mwi-ror-transmute-items');
+            const targetActionCount = parseInt(this.panel.querySelector('#mwi-ror-target').value) || 0;
+            const alchemyModel = hrid ? buildAlchemyTransmuteModel(hrid) : null;
+            if (!alchemyModel) {
+                status.textContent = 'Enter a valid transmutable item name.';
+                return;
+            }
+            maxSinglePossibleLoss = alchemyModel.maxSinglePossibleLoss;
+            simModel = {
+                type: 'fixedOutcome',
+                startingBalance,
+                trials,
+                maxSteps: MAX_STEPS,
+                rngSeed,
+                outcomeDistribution: alchemyModel.outcomeDistribution,
+                targetActionCount,
+            };
+            lundberg = lundbergBound({ startingBalance, outcomeDistribution: alchemyModel.outcomeDistribution });
+        } else {
+            const name = this.panel.querySelector('#mwi-ror-item').value;
+            const hrid = this._resolveItemHrid(name, 'mwi-ror-enhance-items');
+            const targetLevel = parseInt(this.panel.querySelector('#mwi-ror-target').value) || 0;
+            const startLevel = parseInt(this.panel.querySelector('#mwi-ror-start-level').value) || 0;
+            const protectFrom = parseInt(this.panel.querySelector('#mwi-ror-protect-from').value) || 0;
+            const itemDetails = hrid ? dataManager.getItemDetails(hrid) : null;
+            if (!itemDetails) {
+                status.textContent = 'Enter a valid enhanceable item name.';
+                return;
+            }
+
+            const enhancingParams = getEnhancingParams();
+            const enhancementModel = buildEnhancementModel(hrid, {
+                enhancingLevel: enhancingParams.enhancingLevel,
+                houseLevel: enhancingParams.houseLevel,
+                toolBonus: enhancingParams.toolBonus,
+                speedBonus: enhancingParams.speedBonus,
+                itemLevel: itemDetails.itemLevel || 1,
+                targetLevel,
+                startLevel,
+                protectFrom,
+                blessedTea: enhancingParams.teas.blessed,
+                guzzlingBonus: enhancingParams.guzzlingBonus,
+            });
+            if (!enhancementModel) {
+                status.textContent = 'Could not build an enhancement model for these parameters.';
+                return;
+            }
+            maxSinglePossibleLoss = enhancementModel.maxSinglePossibleLoss;
+            simModel = {
+                type: 'levelWalk',
+                startingBalance,
+                trials,
+                maxSteps: MAX_STEPS,
+                rngSeed,
+                perLevelOutcomeDistributions: enhancementModel.perLevelOutcomeDistributions,
+                targetLevel,
+                startLevel,
+            };
+            lundberg = lundbergBoundVarying({
+                startingBalance,
+                perStepDistributions: enhancementModel.perLevelOutcomeDistributions,
+            });
+        }
+
+        const simResult = await simulateRuinAsync(simModel);
+        this._renderResults(results, simResult, lundberg, maxSinglePossibleLoss, startingBalance);
+        status.textContent = `${trials.toLocaleString()} trials simulated.`;
+    }
+
+    _renderResults(container, simResult, lundberg, maxSinglePossibleLoss, startingBalance) {
+        const ci = wilsonConfidenceInterval(simResult.ruinCount, simResult.trials);
+        const minActions = minActionsForNonZeroRisk(startingBalance, maxSinglePossibleLoss);
+        const peakStep = findPeakExposureStep(simResult.ruinStepCounts);
+
+        const lines = [];
+        lines.push(
+            `<strong>Ruin probability:</strong> ${formatPercentage(simResult.ruinProbability, 2)} ` +
+                `(95% CI: ${formatPercentage(ci.low, 2)} – ${formatPercentage(ci.high, 2)})`
+        );
+
+        if (lundberg.meaningful) {
+            lines.push(`<strong>Lundberg upper bound:</strong> ≤ ${formatPercentage(Math.min(1, lundberg.bound), 2)}`);
+        } else {
+            lines.push(
+                `<strong>Lundberg upper bound:</strong> not meaningful — this setup does not have ` +
+                    `positive expected gold gain per action, so the closed-form bound is trivial. ` +
+                    `Only the Monte Carlo estimate above applies.`
+            );
+        }
+
+        lines.push(
+            `<strong>Risk becomes possible at action:</strong> ` +
+                (Number.isFinite(minActions)
+                    ? formatWithSeparator(minActions)
+                    : 'never (no single action can lose money)')
+        );
+
+        lines.push(
+            `<strong>Peak ruin exposure at action:</strong> ` +
+                (peakStep !== null ? formatWithSeparator(peakStep) : 'no ruin occurred in the simulation')
+        );
+
+        if (simResult.meanStepsToRuin !== null) {
+            lines.push(
+                `<strong>Average actions before ruin (when it occurs):</strong> ${simResult.meanStepsToRuin.toFixed(1)}`
+            );
+        }
+
+        if (simResult.undecidedCount > 0) {
+            lines.push(
+                `<span style="color:#c98;">${formatWithSeparator(simResult.undecidedCount)} of ${formatWithSeparator(simResult.trials)} ` +
+                    `trials neither ruined nor reached the target within the simulation's step cap — ` +
+                    `the result may be imprecise for this very long-horizon scenario.</span>`
+            );
+        }
+
+        container.innerHTML = lines.map((line) => `<div style="margin-bottom:6px;">${line}</div>`).join('');
+    }
+
+    disable() {
+        this.timerRegistry.clearAll();
+        if (this.panel) {
+            unregisterFloatingPanel(this.panel);
+            this.panel.remove();
+            this.panel = null;
+        }
+        document.getElementById(LAUNCHER_ID)?.remove();
+        this.isInitialized = false;
+    }
+}
+
+const riskOfRuinUI = new RiskOfRuinUI();
+export default riskOfRuinUI;

--- a/src/libraries/ui.js
+++ b/src/libraries/ui.js
@@ -68,6 +68,9 @@ import alchemyActionProtection from '../features/alchemy/alchemy-action-protecti
 import enhancementFeature from '../features/enhancement/enhancement-feature.js';
 import xphCalculator from '../features/enhancement/xph-calculator.js';
 
+// Risk of Ruin
+import riskOfRuinUI from '../features/risk-of-ruin/risk-of-ruin-ui.js';
+
 // Guild
 import guildXPTracker from '../features/guild/guild-xp-tracker.js';
 import guildXPDisplay from '../features/guild/guild-xp-display.js';
@@ -136,6 +139,7 @@ toolashaRoot.UI = {
     alchemyActionProtection,
     enhancementFeature,
     xphCalculator,
+    riskOfRuinUI,
     guildXPTracker,
     guildXPDisplay,
     guildCreditValue,

--- a/src/utils/risk-of-ruin-adapters/alchemy-adapter.js
+++ b/src/utils/risk-of-ruin-adapters/alchemy-adapter.js
@@ -1,0 +1,59 @@
+/**
+ * Alchemy Transmute Risk-of-Ruin Adapter
+ *
+ * Builds a two-outcome-per-attempt cost/payout model for a Transmute action, from
+ * alchemyProfitCalculator.calculateTransmuteProfit() — the same per-attempt economics
+ * (material cost net of self-return, catalyst cost, output drop-table EV, success rate) the
+ * live action panel and best-item ranking already use, not a re-derived approximation.
+ *
+ * Catalyst is consumed only on success (per alchemy-profit-display.js's own label: "consumed
+ * only on success"), so it is charged only in the success branch. Materials — including any
+ * direct coin cost — are consumed on every attempt regardless of outcome.
+ *
+ * calculateTransmuteProfit() itself blends the success/fail split together into hourly EVs
+ * (e.g. catalystCostPerHour, selfReturnValue are already scaled by successRate). This adapter
+ * un-blends those back into the two discrete branches a single attempt can land in, using only
+ * the function's public return fields — no private internals are touched.
+ */
+
+import alchemyProfitCalculator from '../../features/market/alchemy-profit-calculator.js';
+import { drawFromDistribution } from '../risk-of-ruin-engine.js';
+
+/**
+ * Build the two-outcome risk-of-ruin model for repeatedly Transmuting one item.
+ * @param {string} itemHrid - Item being transmuted.
+ * @param {Object} [options]
+ * @param {boolean} [options.useLiveSetup] - Use the currently-open action panel's live
+ *   catalyst/tea selection instead of the automatically-best combination.
+ * @returns {{
+ *   cost: number,
+ *   maxSinglePossibleLoss: number,
+ *   outcomeDistribution: Array<{prob: number, net: number}>,
+ *   stepFn: function(state: Object, rng: function(): number): Object,
+ * }|null} null if the item isn't transmutable or has no usable market/success-rate data.
+ */
+export function buildAlchemyTransmuteModel(itemHrid, { useLiveSetup = false } = {}) {
+    const profit = alchemyProfitCalculator.calculateTransmuteProfit(itemHrid, useLiveSetup);
+    if (!profit || !(profit.successRate > 0)) return null;
+
+    const coinCost = profit.requirementCosts.find((r) => r.itemHrid === '/items/coin')?.costPerAction ?? 0;
+    const attemptCost = profit.grossMaterialCost + coinCost;
+    const catalystCostOnSuccess = profit.catalystPrice || 0;
+    const outputValueGivenSuccess = profit.incomePerAttempt / profit.successRate;
+    const selfReturnGivenSuccess = profit.selfReturnValue / profit.successRate;
+
+    const netOnSuccess = -attemptCost - catalystCostOnSuccess + outputValueGivenSuccess + selfReturnGivenSuccess;
+    const netOnFail = -attemptCost;
+
+    const outcomeDistribution = [
+        { prob: profit.successRate, net: netOnSuccess },
+        { prob: 1 - profit.successRate, net: netOnFail },
+    ];
+
+    return {
+        cost: attemptCost,
+        maxSinglePossibleLoss: Math.max(0, -netOnSuccess, -netOnFail),
+        outcomeDistribution,
+        stepFn: (state, rng) => ({ balance: state.balance + drawFromDistribution(outcomeDistribution, rng).net }),
+    };
+}

--- a/src/utils/risk-of-ruin-adapters/alchemy-adapter.test.js
+++ b/src/utils/risk-of-ruin-adapters/alchemy-adapter.test.js
@@ -1,0 +1,91 @@
+import { describe, expect, test, vi } from 'vitest';
+
+let mockProfit = null;
+
+vi.mock('../../features/market/alchemy-profit-calculator.js', () => ({
+    default: { calculateTransmuteProfit: () => mockProfit },
+}));
+
+const { buildAlchemyTransmuteModel } = await import('./alchemy-adapter.js');
+
+function baseProfit(overrides = {}) {
+    return {
+        successRate: 0.5,
+        grossMaterialCost: 1000,
+        requirementCosts: [],
+        catalystPrice: 0,
+        incomePerAttempt: 300, // expectedOutputValue(600) * successRate(0.5)
+        selfReturnValue: 0,
+        ...overrides,
+    };
+}
+
+describe('buildAlchemyTransmuteModel', () => {
+    test('returns null when the item is not transmutable (no profit data)', () => {
+        mockProfit = null;
+        expect(buildAlchemyTransmuteModel('/items/not_transmutable')).toBeNull();
+    });
+
+    test('returns null when success rate is zero', () => {
+        mockProfit = baseProfit({ successRate: 0 });
+        expect(buildAlchemyTransmuteModel('/items/impossible')).toBeNull();
+    });
+
+    test('splits into a success/fail two-outcome distribution with materials lost on both', () => {
+        mockProfit = baseProfit();
+        const model = buildAlchemyTransmuteModel('/items/widget');
+
+        expect(model.cost).toBe(1000);
+        expect(model.outcomeDistribution).toEqual([
+            { prob: 0.5, net: -1000 + 600 }, // success: -materials + output value given success
+            { prob: 0.5, net: -1000 }, // failure: -materials only
+        ]);
+    });
+
+    test('includes a direct coin line item in the per-attempt cost charged on both branches', () => {
+        mockProfit = baseProfit({ requirementCosts: [{ itemHrid: '/items/coin', costPerAction: 50 }] });
+        const model = buildAlchemyTransmuteModel('/items/widget');
+
+        expect(model.cost).toBe(1050);
+        expect(model.outcomeDistribution[0].net).toBe(-1050 + 600);
+        expect(model.outcomeDistribution[1].net).toBe(-1050);
+    });
+
+    test('charges catalyst cost only on the success branch', () => {
+        mockProfit = baseProfit({ catalystPrice: 200 });
+        const model = buildAlchemyTransmuteModel('/items/widget');
+
+        expect(model.outcomeDistribution[0].net).toBe(-1000 - 200 + 600); // success pays catalyst
+        expect(model.outcomeDistribution[1].net).toBe(-1000); // failure does not
+    });
+
+    test('un-blends the hourly-scaled self-return value back to a given-success amount', () => {
+        // selfReturnValue is already successRate-scaled by the real calculator: 0.4 * 100 = 40
+        mockProfit = baseProfit({ successRate: 0.4, incomePerAttempt: 240, selfReturnValue: 40 });
+        const model = buildAlchemyTransmuteModel('/items/widget');
+
+        // outputValueGivenSuccess = 240 / 0.4 = 600; selfReturnGivenSuccess = 40 / 0.4 = 100
+        expect(model.outcomeDistribution[0].net).toBeCloseTo(-1000 + 600 + 100, 6);
+    });
+
+    test('maxSinglePossibleLoss is the worst-case branch even when the success branch is the bigger loss', () => {
+        // Expensive catalyst with a tiny output value makes success worse than failure.
+        mockProfit = baseProfit({ catalystPrice: 5000, incomePerAttempt: 5 });
+        const model = buildAlchemyTransmuteModel('/items/widget');
+
+        const [successOutcome, failOutcome] = model.outcomeDistribution;
+        expect(-successOutcome.net).toBeGreaterThan(-failOutcome.net);
+        expect(model.maxSinglePossibleLoss).toBeCloseTo(-successOutcome.net, 6);
+    });
+
+    test('stepFn resolves via the outcome distribution using the supplied rng', () => {
+        mockProfit = baseProfit();
+        const model = buildAlchemyTransmuteModel('/items/widget');
+
+        const successState = model.stepFn({ balance: 10000 }, () => 0);
+        expect(successState.balance).toBe(10000 - 1000 + 600);
+
+        const failState = model.stepFn({ balance: 10000 }, () => 0.99);
+        expect(failState.balance).toBe(10000 - 1000);
+    });
+});

--- a/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.js
+++ b/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.js
@@ -1,0 +1,134 @@
+/**
+ * Dungeon Chest Risk-of-Ruin Adapter
+ *
+ * Builds a per-open cost/payout model for a dungeon chest, for the risk-of-ruin engine.
+ *
+ * A single chest open's payout is the SUM of many independent per-drop-entry
+ * Bernoulli(dropRate) x Uniform(minCount, maxCount) draws (openableLootDropMap) - not one
+ * categorical pick. The exact combined distribution has combinatorially many outcomes and
+ * isn't enumerable in closed form, so a large empirical sample of realized payouts (drawn via
+ * drawChestPayout) stands in as the outcome distribution for both:
+ * - The Monte Carlo simulation itself (a bootstrap resample of the true distribution, valid
+ *   for a large enough sample size, and the only form that's plain structured-clone-safe data
+ *   a Web Worker can consume without access to dataManager/marketAPI/expectedValueCalculator).
+ * - The Lundberg bound, which needs a discrete outcome-distribution input.
+ */
+
+import dataManager from '../../core/data-manager.js';
+import marketAPI from '../../api/marketplace.js';
+import config from '../../core/config.js';
+import expectedValueCalculator from '../../features/market/expected-value-calculator.js';
+import { calculatePriceAfterTax } from '../profit-helpers.js';
+import { createSeededRng, drawFromDistribution } from '../risk-of-ruin-engine.js';
+import { DUNGEON_ENTRY_KEYS, DUNGEON_CHEST_KEYS } from '../../features/combat-sim/combat-sim-adapter.js';
+
+const COIN_HRID = '/items/coin';
+const DEFAULT_EMPIRICAL_SAMPLE_SIZE = 5000;
+
+function getKeyPricingMode() {
+    return config.getSettingValue('profitCalc_keyPricingMode') || 'ask';
+}
+
+function getKeyPrice(keyHrid) {
+    const priceData = marketAPI.getPrice(keyHrid);
+    if (!priceData) return 0;
+    const priceKey = getKeyPricingMode();
+    return priceData[priceKey] ?? priceData.ask ?? 0;
+}
+
+/**
+ * Gold cost to open one chest: entry key (regular, non-refinement chests only) + chest key,
+ * priced via the existing profitCalc_keyPricingMode setting — the same model
+ * combat-stats-calculator.js's calculateKeyCosts() already uses.
+ * @param {string} containerHrid
+ * @returns {number}
+ */
+export function getChestOpenCost(containerHrid) {
+    let cost = 0;
+
+    const entryKeyHrid = DUNGEON_ENTRY_KEYS[containerHrid];
+    if (entryKeyHrid) cost += getKeyPrice(entryKeyHrid);
+
+    const chestKeyHrid = DUNGEON_CHEST_KEYS[containerHrid];
+    if (chestKeyHrid) cost += getKeyPrice(chestKeyHrid);
+
+    return cost;
+}
+
+/**
+ * Draw one realized payout value for opening the given chest once. Prices each triggered drop
+ * the same way expected-value-calculator.js's getDropBreakdown() prices its average — tax-aware
+ * sell side, with coin/cowbell/dungeon-token/nested-container special cases handled by
+ * getDropPrice() — but against the actually-realized random count, not the average.
+ * @param {string} containerHrid
+ * @param {function(): number} rng
+ * @returns {number}
+ */
+export function drawChestPayout(containerHrid, rng) {
+    const initData = dataManager.getInitClientData();
+    const dropTable = initData?.openableLootDropMap?.[containerHrid];
+    if (!dropTable) return 0;
+
+    let payout = 0;
+    for (const drop of dropTable) {
+        const dropRate = drop.dropRate || 0;
+        if (dropRate <= 0 || rng() >= dropRate) continue;
+
+        const minCount = drop.minCount || 0;
+        const maxCount = drop.maxCount || 0;
+        if (minCount <= 0 && maxCount <= 0) continue;
+        const count = minCount + Math.floor(rng() * (maxCount - minCount + 1));
+        if (count <= 0) continue;
+
+        const price = expectedValueCalculator.getDropPrice(drop.itemHrid);
+        if (price === null) continue;
+
+        if (drop.itemHrid === COIN_HRID) {
+            payout += count * price;
+            continue;
+        }
+
+        const itemDetails = dataManager.getItemDetails(drop.itemHrid);
+        const canBeSold = itemDetails?.isTradable !== false;
+        payout += canBeSold ? calculatePriceAfterTax(count * price) : count * price;
+    }
+
+    return payout;
+}
+
+/**
+ * Build the full risk-of-ruin model for repeatedly opening one chest type. The Monte Carlo
+ * simulation draws from the same empirical outcomeDistribution used for the Lundberg bound,
+ * rather than re-running drawChestPayout() live every step (see module docblock for why).
+ * @param {string} containerHrid
+ * @param {Object} [options]
+ * @param {number} [options.sampleSize] - Empirical sample count backing both the simulation and
+ *   the Lundberg bound.
+ * @param {number} [options.rngSeed] - Seed for the empirical sample.
+ * @returns {{
+ *   cost: number,
+ *   maxSinglePossibleLoss: number,
+ *   stepFn: function(state: Object, rng: function(): number): Object,
+ *   outcomeDistribution: Array<{prob: number, net: number}>,
+ * }}
+ */
+export function buildDungeonChestModel(
+    containerHrid,
+    { sampleSize = DEFAULT_EMPIRICAL_SAMPLE_SIZE, rngSeed = 1 } = {}
+) {
+    const cost = getChestOpenCost(containerHrid);
+
+    const sampleRng = createSeededRng(rngSeed);
+    const outcomeDistribution = [];
+    for (let i = 0; i < sampleSize; i++) {
+        const payout = drawChestPayout(containerHrid, sampleRng);
+        outcomeDistribution.push({ prob: 1 / sampleSize, net: payout - cost });
+    }
+
+    return {
+        cost,
+        maxSinglePossibleLoss: cost,
+        stepFn: (state, rng) => ({ balance: state.balance + drawFromDistribution(outcomeDistribution, rng).net }),
+        outcomeDistribution,
+    };
+}

--- a/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.test.js
+++ b/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.test.js
@@ -1,0 +1,185 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+const initData = { openableLootDropMap: {} };
+const itemDetails = {};
+const marketPrices = {};
+let keyPricingMode = 'ask';
+const dropPrices = {};
+
+vi.mock('../../core/data-manager.js', () => ({
+    default: {
+        getInitClientData: () => initData,
+        getItemDetails: (itemHrid) => itemDetails[itemHrid],
+    },
+}));
+
+vi.mock('../../api/marketplace.js', () => ({
+    default: { getPrice: (itemHrid) => marketPrices[itemHrid], on: () => {} },
+}));
+
+vi.mock('../../core/config.js', () => ({
+    default: { getSettingValue: () => keyPricingMode },
+}));
+
+vi.mock('../../features/market/expected-value-calculator.js', () => ({
+    default: { getDropPrice: (itemHrid) => (itemHrid in dropPrices ? dropPrices[itemHrid] : null) },
+}));
+
+vi.mock('../../features/combat-sim/combat-sim-adapter.js', () => ({
+    DUNGEON_ENTRY_KEYS: { '/items/chimerical_chest': '/items/chimerical_entry_key' },
+    DUNGEON_CHEST_KEYS: {
+        '/items/chimerical_chest': '/items/chimerical_chest_key',
+        '/items/chimerical_refinement_chest': '/items/chimerical_chest_key',
+    },
+}));
+
+const { getChestOpenCost, drawChestPayout, buildDungeonChestModel } = await import('./dungeon-chest-adapter.js');
+const { createSeededRng } = await import('../risk-of-ruin-engine.js');
+
+const COIN_HRID = '/items/coin';
+
+function fixedRng(value) {
+    return () => value;
+}
+
+beforeEach(() => {
+    initData.openableLootDropMap = {};
+    for (const key of Object.keys(itemDetails)) delete itemDetails[key];
+    for (const key of Object.keys(marketPrices)) delete marketPrices[key];
+    for (const key of Object.keys(dropPrices)) delete dropPrices[key];
+    keyPricingMode = 'ask';
+});
+
+describe('getChestOpenCost', () => {
+    test('sums entry key + chest key ask price for a regular chest', () => {
+        marketPrices['/items/chimerical_entry_key'] = { ask: 1000, bid: 900 };
+        marketPrices['/items/chimerical_chest_key'] = { ask: 2000, bid: 1800 };
+
+        expect(getChestOpenCost('/items/chimerical_chest')).toBe(3000);
+    });
+
+    test('uses bid price when profitCalc_keyPricingMode is bid', () => {
+        keyPricingMode = 'bid';
+        marketPrices['/items/chimerical_entry_key'] = { ask: 1000, bid: 900 };
+        marketPrices['/items/chimerical_chest_key'] = { ask: 2000, bid: 1800 };
+
+        expect(getChestOpenCost('/items/chimerical_chest')).toBe(2700);
+    });
+
+    test('refinement chests have no entry key cost, only a chest key cost', () => {
+        marketPrices['/items/chimerical_chest_key'] = { ask: 2000, bid: 1800 };
+
+        expect(getChestOpenCost('/items/chimerical_refinement_chest')).toBe(2000);
+    });
+
+    test('is zero for a chest with no known key mapping', () => {
+        expect(getChestOpenCost('/items/unmapped_chest')).toBe(0);
+    });
+});
+
+describe('drawChestPayout', () => {
+    test('applies market tax to a triggered, sellable drop at its realized count', () => {
+        initData.openableLootDropMap['/items/test_chest'] = [
+            { itemHrid: '/items/widget', dropRate: 1, minCount: 5, maxCount: 5 },
+        ];
+        itemDetails['/items/widget'] = { isTradable: true };
+        dropPrices['/items/widget'] = 100;
+
+        const payout = drawChestPayout('/items/test_chest', fixedRng(0));
+        expect(payout).toBeCloseTo(5 * 100 * 0.98, 6);
+    });
+
+    test('does not tax coin drops', () => {
+        initData.openableLootDropMap['/items/test_chest'] = [
+            { itemHrid: COIN_HRID, dropRate: 1, minCount: 1000, maxCount: 1000 },
+        ];
+        dropPrices[COIN_HRID] = 1;
+
+        expect(drawChestPayout('/items/test_chest', fixedRng(0))).toBe(1000);
+    });
+
+    test('does not tax untradeable drops', () => {
+        initData.openableLootDropMap['/items/test_chest'] = [
+            { itemHrid: '/items/soulbound_thing', dropRate: 1, minCount: 3, maxCount: 3 },
+        ];
+        itemDetails['/items/soulbound_thing'] = { isTradable: false };
+        dropPrices['/items/soulbound_thing'] = 50;
+
+        expect(drawChestPayout('/items/test_chest', fixedRng(0))).toBe(150);
+    });
+
+    test('contributes nothing when the roll misses the drop rate', () => {
+        initData.openableLootDropMap['/items/test_chest'] = [
+            { itemHrid: '/items/widget', dropRate: 0.1, minCount: 5, maxCount: 5 },
+        ];
+        itemDetails['/items/widget'] = { isTradable: true };
+        dropPrices['/items/widget'] = 100;
+
+        // rng() = 0.5 misses a 0.1 drop rate (0.5 >= 0.1)
+        expect(drawChestPayout('/items/test_chest', fixedRng(0.5))).toBe(0);
+    });
+
+    test('contributes nothing when price data is unavailable', () => {
+        initData.openableLootDropMap['/items/test_chest'] = [
+            { itemHrid: '/items/unpriced', dropRate: 1, minCount: 1, maxCount: 1 },
+        ];
+
+        expect(drawChestPayout('/items/test_chest', fixedRng(0))).toBe(0);
+    });
+
+    test('returns 0 when the container has no drop table', () => {
+        expect(drawChestPayout('/items/unknown_chest', fixedRng(0))).toBe(0);
+    });
+
+    test('triggers roughly at the drop rate over many draws', () => {
+        initData.openableLootDropMap['/items/test_chest'] = [
+            { itemHrid: '/items/widget', dropRate: 0.5, minCount: 1, maxCount: 1 },
+        ];
+        itemDetails['/items/widget'] = { isTradable: true };
+        dropPrices['/items/widget'] = 1;
+
+        const rng = createSeededRng(123);
+        let triggerCount = 0;
+        const samples = 20000;
+        for (let i = 0; i < samples; i++) {
+            if (drawChestPayout('/items/test_chest', rng) > 0) triggerCount += 1;
+        }
+        expect(triggerCount / samples).toBeCloseTo(0.5, 1);
+    });
+});
+
+describe('buildDungeonChestModel', () => {
+    test('exposes cost, maxSinglePossibleLoss, and an empirical outcome distribution summing to 1', () => {
+        marketPrices['/items/chimerical_entry_key'] = { ask: 1000, bid: 900 };
+        marketPrices['/items/chimerical_chest_key'] = { ask: 2000, bid: 1800 };
+        initData.openableLootDropMap['/items/chimerical_chest'] = [
+            { itemHrid: '/items/widget', dropRate: 0.5, minCount: 1, maxCount: 1 },
+        ];
+        itemDetails['/items/widget'] = { isTradable: true };
+        dropPrices['/items/widget'] = 100;
+
+        const model = buildDungeonChestModel('/items/chimerical_chest', { sampleSize: 1000, rngSeed: 5 });
+
+        expect(model.cost).toBe(3000);
+        expect(model.maxSinglePossibleLoss).toBe(3000);
+        expect(model.outcomeDistribution).toHaveLength(1000);
+        const totalProb = model.outcomeDistribution.reduce((sum, o) => sum + o.prob, 0);
+        expect(totalProb).toBeCloseTo(1, 10);
+    });
+
+    test('stepFn deducts cost and adds the realized payout for one open', () => {
+        marketPrices['/items/chimerical_chest_key'] = { ask: 500, bid: 500 };
+        initData.openableLootDropMap['/items/chimerical_refinement_chest'] = [
+            { itemHrid: '/items/widget', dropRate: 1, minCount: 2, maxCount: 2 },
+        ];
+        itemDetails['/items/widget'] = { isTradable: true };
+        dropPrices['/items/widget'] = 1000;
+
+        const model = buildDungeonChestModel('/items/chimerical_refinement_chest');
+        const nextState = model.stepFn({ balance: 10000 }, fixedRng(0));
+
+        // cost = 500 (chest key only, no entry key for a refinement chest)
+        // payout = 2 * 1000 * 0.98 = 1960
+        expect(nextState.balance).toBeCloseTo(10000 - 500 + 1960, 6);
+    });
+});

--- a/src/utils/risk-of-ruin-adapters/enhancement-adapter.js
+++ b/src/utils/risk-of-ruin-adapters/enhancement-adapter.js
@@ -1,0 +1,132 @@
+/**
+ * Enhancement Risk-of-Ruin Adapter
+ *
+ * Walks the same per-level success-rate / failure-destination / blessed-tea-skip transition
+ * model as calculateEnhancement()'s exact Markov chain (src/utils/enhancement-calculator.js),
+ * but as a step-by-step Monte Carlo walk against a gold balance instead of a closed-form
+ * expectation. Every attempt costs materials (calculatePerAttemptMaterialCost, same value at
+ * every level) regardless of outcome, plus a protection-item cost specifically when a
+ * protected attempt fails.
+ *
+ * Unlike chests/alchemy, enhancing has no monetary payout branch at all — every outcome is a
+ * pure cost, there is no "success revenue" modeled here (the target level itself is the goal,
+ * not a resale value). That means the expected per-attempt gold change is always negative, so
+ * the Lundberg bound is never meaningful for this mode (findAdjustmentCoefficient always
+ * returns null) — only the Monte Carlo estimate applies. This is the correct, expected
+ * behavior of a pure-cost process, not a defect; callers must surface it as such rather than
+ * treating a `meaningful: false` result as broken.
+ */
+
+import dataManager from '../../core/data-manager.js';
+import { calculateEnhancement } from '../enhancement-calculator.js';
+import {
+    calculatePerAttemptMaterialCost,
+    getCheapestProtectionPrice,
+} from '../../features/enhancement/tooltip-enhancement.js';
+import { drawFromDistribution } from '../risk-of-ruin-engine.js';
+
+/**
+ * Build the per-level outcome list a single attempt at enhancement level `i` can produce,
+ * mirroring calculateEnhancement()'s markov.set(...) transitions exactly.
+ * @returns {Array<{prob: number, nextLevel: number, net: number}>}
+ */
+function buildLevelOutcomes({
+    i,
+    successChance,
+    targetLevel,
+    protectFrom,
+    blessedTea,
+    skipRatio,
+    costPerAttempt,
+    protectionCostOnFailure,
+}) {
+    const isProtected = protectFrom > 0 && i >= protectFrom;
+    const failureDestination = isProtected ? i - 1 : 0;
+    const failureNet = -(costPerAttempt + (isProtected ? protectionCostOnFailure : 0));
+
+    const outcomes = [{ prob: 1 - successChance, nextLevel: failureDestination, net: failureNet }];
+
+    if (blessedTea) {
+        const skipChance = successChance * skipRatio;
+        const remainingSuccess = successChance - skipChance;
+        const normalDestination = Math.min(targetLevel, i + 1);
+        const skipDestination = Math.min(targetLevel, i + 2);
+
+        if (normalDestination === skipDestination) {
+            outcomes.push({ prob: successChance, nextLevel: normalDestination, net: -costPerAttempt });
+        } else {
+            outcomes.push({ prob: remainingSuccess, nextLevel: normalDestination, net: -costPerAttempt });
+            outcomes.push({ prob: skipChance, nextLevel: skipDestination, net: -costPerAttempt });
+        }
+    } else {
+        outcomes.push({ prob: successChance, nextLevel: Math.min(targetLevel, i + 1), net: -costPerAttempt });
+    }
+
+    return outcomes;
+}
+
+/**
+ * Build the level-by-level risk-of-ruin model for enhancing one item to a target level.
+ * @param {string} itemHrid - Item being enhanced.
+ * @param {Object} params - Same shape as calculateEnhancement()'s params (enhancingLevel,
+ *   toolBonus, itemLevel, targetLevel, startLevel, protectFrom, blessedTea, guzzlingBonus, ...).
+ * @returns {{
+ *   costPerAttempt: number,
+ *   protectionCostOnFailure: number,
+ *   maxSinglePossibleLoss: number,
+ *   perLevelOutcomeDistributions: Array<Array<{prob: number, net: number}>>,
+ *   stepFn: function(state: Object, rng: function(): number): Object,
+ *   isTargetReached: function(state: Object): boolean,
+ *   initialState: {level: number},
+ * }|null} null if the item/params are invalid or have no usable cost data.
+ */
+export function buildEnhancementModel(itemHrid, params) {
+    const itemDetails = dataManager.getItemDetails(itemHrid);
+    if (!itemDetails) return null;
+
+    const { targetLevel, startLevel = 0, protectFrom = 0, blessedTea = false, guzzlingBonus = 1.0 } = params;
+
+    let calc;
+    try {
+        calc = calculateEnhancement(params);
+    } catch {
+        return null;
+    }
+    if (!calc?.successRates?.length) return null;
+
+    const perAttemptMaterial = calculatePerAttemptMaterialCost(itemDetails);
+    const costPerAttempt = perAttemptMaterial.cost;
+
+    let protectionCostOnFailure = 0;
+    if (protectFrom > 0) {
+        protectionCostOnFailure = getCheapestProtectionPrice(itemHrid)?.price || 0;
+    }
+
+    const skipRatio = blessedTea ? Math.max(0, Math.min(1, 0.01 * guzzlingBonus)) : 0;
+
+    const perLevelOutcomeDistributions = calc.successRates.map(({ actualRate }, i) =>
+        buildLevelOutcomes({
+            i,
+            successChance: Math.max(0, Math.min(1, actualRate / 100)),
+            targetLevel,
+            protectFrom,
+            blessedTea,
+            skipRatio,
+            costPerAttempt,
+            protectionCostOnFailure,
+        })
+    );
+
+    return {
+        costPerAttempt,
+        protectionCostOnFailure,
+        maxSinglePossibleLoss: costPerAttempt + protectionCostOnFailure,
+        perLevelOutcomeDistributions,
+        stepFn: (state, rng) => {
+            const chosen = drawFromDistribution(perLevelOutcomeDistributions[state.level], rng);
+            return { balance: state.balance + chosen.net, level: chosen.nextLevel };
+        },
+        isTargetReached: (state) => state.level >= targetLevel,
+        initialState: { level: startLevel },
+    };
+}

--- a/src/utils/risk-of-ruin-adapters/enhancement-adapter.test.js
+++ b/src/utils/risk-of-ruin-adapters/enhancement-adapter.test.js
@@ -1,0 +1,125 @@
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+import * as mathJs from 'mathjs';
+
+beforeAll(() => {
+    globalThis.math = mathJs;
+});
+
+const itemDetailsMap = { '/items/widget': { enhancementCosts: [{ itemHrid: '/items/coin', count: 1000 }] } };
+
+vi.mock('../../core/data-manager.js', () => ({
+    default: { getItemDetails: (itemHrid) => itemDetailsMap[itemHrid] },
+}));
+
+let protectionPrice = 5000;
+vi.mock('../../features/enhancement/tooltip-enhancement.js', () => ({
+    calculatePerAttemptMaterialCost: () => ({ cost: 1000, hasCost: true, costPartial: false }),
+    getCheapestProtectionPrice: () => ({ price: protectionPrice, itemHrid: '/items/mirror_of_protection' }),
+}));
+
+const { buildEnhancementModel } = await import('./enhancement-adapter.js');
+
+// enhancingLevel === itemLevel with 0 toolBonus gives a successMultiplier of exactly 1, so
+// actualRate == BASE_SUCCESS_RATES, making outcomes hand-verifiable without extra arithmetic.
+const NEUTRAL_PARAMS = Object.freeze({
+    enhancingLevel: 1,
+    houseLevel: 0,
+    toolBonus: 0,
+    speedBonus: 0,
+    itemLevel: 1,
+    blessedTea: false,
+    guzzlingBonus: 1,
+});
+
+describe('buildEnhancementModel', () => {
+    test('returns null for an unknown item', () => {
+        expect(buildEnhancementModel('/items/unknown', { ...NEUTRAL_PARAMS, targetLevel: 2 })).toBeNull();
+    });
+
+    test('returns null when calculateEnhancement rejects the params', () => {
+        // targetLevel 0 is invalid per calculateEnhancement's own validation
+        expect(buildEnhancementModel('/items/widget', { ...NEUTRAL_PARAMS, targetLevel: 0 })).toBeNull();
+    });
+
+    test('builds unprotected two-outcome level distributions matching BASE_SUCCESS_RATES', () => {
+        const model = buildEnhancementModel('/items/widget', { ...NEUTRAL_PARAMS, targetLevel: 2, protectFrom: 0 });
+
+        expect(model.costPerAttempt).toBe(1000);
+        expect(model.protectionCostOnFailure).toBe(0);
+        expect(model.maxSinglePossibleLoss).toBe(1000);
+
+        // Level 0: BASE_SUCCESS_RATES[0] = 50%
+        const [failure0, success0] = model.perLevelOutcomeDistributions[0];
+        expect(failure0).toEqual({ prob: 0.5, nextLevel: 0, net: -1000 });
+        expect(success0).toEqual({ prob: 0.5, nextLevel: 1, net: -1000 });
+
+        // Level 1: BASE_SUCCESS_RATES[1] = 45%
+        const [failure1, success1] = model.perLevelOutcomeDistributions[1];
+        expect(failure1).toEqual({ prob: 0.55, nextLevel: 0, net: -1000 });
+        expect(success1).toEqual({ prob: 0.45, nextLevel: 2, net: -1000 });
+    });
+
+    test('charges protection cost on failure only once protectFrom is reached', () => {
+        protectionPrice = 5000;
+        const model = buildEnhancementModel('/items/widget', { ...NEUTRAL_PARAMS, targetLevel: 3, protectFrom: 1 });
+
+        // Level 0 (below protectFrom): unprotected failure, back to 0
+        const [failure0] = model.perLevelOutcomeDistributions[0];
+        expect(failure0).toEqual({ prob: 0.5, nextLevel: 0, net: -1000 });
+
+        // Level 1 (at protectFrom): protected failure, drops only to level 0, costs protection too
+        const [failure1] = model.perLevelOutcomeDistributions[1];
+        expect(failure1).toEqual({ prob: 0.55, nextLevel: 0, net: -6000 });
+
+        expect(model.protectionCostOnFailure).toBe(5000);
+        expect(model.maxSinglePossibleLoss).toBe(6000);
+    });
+
+    test('splits blessed tea success into a normal +1 and a skip +2 branch', () => {
+        const model = buildEnhancementModel('/items/widget', {
+            ...NEUTRAL_PARAMS,
+            targetLevel: 5,
+            protectFrom: 0,
+            blessedTea: true,
+            guzzlingBonus: 1,
+        });
+
+        const [failure0, normal0, skip0] = model.perLevelOutcomeDistributions[0];
+        const successChance = 0.5;
+        const skipChance = successChance * 0.01;
+        const remaining = successChance - skipChance;
+
+        expect(failure0.prob).toBeCloseTo(0.5, 10);
+        expect(normal0).toMatchObject({ nextLevel: 1, net: -1000 });
+        expect(normal0.prob).toBeCloseTo(remaining, 10);
+        expect(skip0).toMatchObject({ nextLevel: 2, net: -1000 });
+        expect(skip0.prob).toBeCloseTo(skipChance, 10);
+    });
+
+    test('collapses the blessed tea skip branch when +1 and +2 both land on the target', () => {
+        // targetLevel 2, at level 1: normalDestination = min(2, 2) = 2, skipDestination = min(2, 3) = 2 -> same
+        const model = buildEnhancementModel('/items/widget', {
+            ...NEUTRAL_PARAMS,
+            targetLevel: 2,
+            protectFrom: 0,
+            blessedTea: true,
+            guzzlingBonus: 1,
+        });
+
+        expect(model.perLevelOutcomeDistributions[1]).toHaveLength(2);
+        const [, success1] = model.perLevelOutcomeDistributions[1];
+        expect(success1).toEqual({ prob: 0.45, nextLevel: 2, net: -1000 });
+    });
+
+    test('stepFn resolves the chosen branch and isTargetReached/initialState match startLevel/targetLevel', () => {
+        const model = buildEnhancementModel('/items/widget', { ...NEUTRAL_PARAMS, targetLevel: 2, startLevel: 0 });
+
+        expect(model.initialState).toEqual({ level: 0 });
+        expect(model.isTargetReached({ level: 2 })).toBe(true);
+        expect(model.isTargetReached({ level: 1 })).toBe(false);
+
+        // rng() = 0.9 misses the 0.5 failure-branch cumulative, landing on the success branch
+        const nextState = model.stepFn({ balance: 10000, level: 0 }, () => 0.9);
+        expect(nextState).toEqual({ balance: 9000, level: 1 });
+    });
+});

--- a/src/utils/risk-of-ruin-engine.js
+++ b/src/utils/risk-of-ruin-engine.js
@@ -1,0 +1,283 @@
+/**
+ * Risk of Ruin Engine
+ *
+ * Pure statistical core for "how likely am I to hit 0 gold before reaching my target?".
+ * Has zero knowledge of chests/alchemy/enhancing — callers (adapters) supply a per-action
+ * outcome generator (stepFn) and a target-reached check (isTargetReached); everything here
+ * operates on plain { balance, ...custom } state objects.
+ *
+ * Two independent estimates are provided:
+ * - simulateRuin(): Monte Carlo point estimate + confidence interval.
+ * - lundbergBound() / lundbergBoundVarying(): closed-form upper bound (Lundberg inequality).
+ */
+
+/**
+ * Deterministic PRNG (mulberry32) so simulations are reproducible for a given seed.
+ * @param {number} seed
+ * @returns {function(): number} Generator of floats in [0, 1)
+ */
+export function createSeededRng(seed) {
+    let a = seed >>> 0;
+    return function () {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+/**
+ * Draw a random outcome from a discrete distribution of { prob, ...payload } entries.
+ * Probabilities need not sum to exactly 1 (floating point); the last entry catches the remainder.
+ * @param {Array<{prob: number}>} distribution
+ * @param {function(): number} rng
+ * @returns {Object} The chosen entry
+ */
+export function drawFromDistribution(distribution, rng) {
+    const roll = rng();
+    let cumulative = 0;
+    for (let i = 0; i < distribution.length; i++) {
+        cumulative += distribution[i].prob;
+        if (roll < cumulative || i === distribution.length - 1) {
+            return distribution[i];
+        }
+    }
+    return distribution[distribution.length - 1];
+}
+
+/**
+ * Run a Monte Carlo simulation of repeated actions against a starting balance.
+ * @param {Object} params
+ * @param {number} params.startingBalance - Gold on hand before the first action.
+ * @param {number} params.trials - Number of independent simulated walks.
+ * @param {function(state: Object, rng: function(): number): Object} params.stepFn -
+ *   Returns the next state (must include an updated `balance`) after one action.
+ * @param {function(state: Object): boolean} params.isTargetReached - True once the goal is met.
+ * @param {Object} [params.initialState] - Extra domain fields merged into the starting state.
+ * @param {number} [params.maxSteps] - Safety cap on actions per trial.
+ * @param {number} [params.rngSeed] - Seed for reproducibility.
+ * @returns {{
+ *   ruinProbability: number,
+ *   ruinCount: number,
+ *   trials: number,
+ *   ruinStepCounts: number[],
+ *   meanStepsToRuin: number|null,
+ *   undecidedCount: number,
+ * }}
+ */
+export function simulateRuin({
+    startingBalance,
+    trials,
+    stepFn,
+    isTargetReached,
+    initialState = {},
+    maxSteps = 100000,
+    rngSeed = 1,
+}) {
+    if (startingBalance <= 0) {
+        return {
+            ruinProbability: 1,
+            ruinCount: trials,
+            trials,
+            ruinStepCounts: [0],
+            meanStepsToRuin: 0,
+            undecidedCount: 0,
+        };
+    }
+
+    const rng = createSeededRng(rngSeed);
+    const ruinStepCounts = [];
+    let ruinCount = 0;
+    let undecidedCount = 0;
+    let totalRuinSteps = 0;
+
+    for (let trial = 0; trial < trials; trial++) {
+        let state = { balance: startingBalance, ...initialState };
+        let step = 0;
+        let ruined = false;
+
+        while (step < maxSteps && !isTargetReached(state)) {
+            state = stepFn(state, rng);
+            step += 1;
+            if (state.balance <= 0) {
+                ruined = true;
+                break;
+            }
+        }
+
+        if (ruined) {
+            ruinCount += 1;
+            totalRuinSteps += step;
+            ruinStepCounts[step] = (ruinStepCounts[step] || 0) + 1;
+        } else if (!isTargetReached(state)) {
+            undecidedCount += 1;
+        }
+    }
+
+    return {
+        ruinProbability: ruinCount / trials,
+        ruinCount,
+        trials,
+        ruinStepCounts,
+        meanStepsToRuin: ruinCount > 0 ? totalRuinSteps / ruinCount : null,
+        undecidedCount,
+    };
+}
+
+/**
+ * Wilson score confidence interval for a binomial proportion — more reliable than the Wald
+ * interval when the estimated probability is near 0 or 1, which is the common case here.
+ * @param {number} successCount
+ * @param {number} trials
+ * @param {number} [z] - Z-score (1.96 = 95% CI)
+ * @returns {{low: number, high: number}}
+ */
+export function wilsonConfidenceInterval(successCount, trials, z = 1.96) {
+    if (trials === 0) return { low: 0, high: 1 };
+    const p = successCount / trials;
+    const z2 = z * z;
+    const denom = 1 + z2 / trials;
+    const center = p + z2 / (2 * trials);
+    const margin = z * Math.sqrt((p * (1 - p)) / trials + z2 / (4 * trials * trials));
+    return {
+        low: Math.max(0, (center - margin) / denom),
+        high: Math.min(1, (center + margin) / denom),
+    };
+}
+
+/**
+ * The last action count at which ruin is still analytically impossible, computed from the
+ * worst single-action loss rather than simulated — cheap and exact, no trials needed.
+ * @param {number} startingBalance
+ * @param {number} maxSinglePossibleLoss - Largest possible net loss from one action.
+ * @returns {number} First action count at which risk becomes non-zero (Infinity if it never can).
+ */
+export function minActionsForNonZeroRisk(startingBalance, maxSinglePossibleLoss) {
+    if (maxSinglePossibleLoss <= 0) return Infinity;
+    return Math.ceil(startingBalance / maxSinglePossibleLoss);
+}
+
+/**
+ * The action index at which trials most often actually went bust, read directly off the
+ * ruin-step histogram produced by simulateRuin() — no extra simulation required.
+ * @param {number[]} ruinStepCounts
+ * @returns {number|null} Step index of peak exposure, or null if no trial ever ruined.
+ */
+export function findPeakExposureStep(ruinStepCounts) {
+    let peakStep = null;
+    let peakCount = 0;
+    for (let step = 0; step < ruinStepCounts.length; step++) {
+        const count = ruinStepCounts[step] || 0;
+        if (count > peakCount) {
+            peakCount = count;
+            peakStep = step;
+        }
+    }
+    return peakStep;
+}
+
+/**
+ * Expected net gold change per action for a discrete outcome distribution.
+ * @param {Array<{prob: number, net: number}>} outcomeDistribution
+ * @returns {number}
+ */
+export function expectedNetPerAction(outcomeDistribution) {
+    return outcomeDistribution.reduce((sum, o) => sum + o.prob * o.net, 0);
+}
+
+function outcomeMgf(outcomeDistribution, r) {
+    return outcomeDistribution.reduce((sum, o) => sum + o.prob * Math.exp(-r * o.net), 0);
+}
+
+/**
+ * Solve E[e^(-R*X)] = 1 for the positive adjustment coefficient R, where X is the per-action
+ * net gold change. Only exists when the distribution has positive expected drift (a "safety
+ * loading"); returns null otherwise, since the classical Lundberg bound is not meaningful
+ * without positive drift (it would be trivially ~1).
+ * @param {Array<{prob: number, net: number}>} outcomeDistribution
+ * @returns {number|null}
+ */
+export function findAdjustmentCoefficient(outcomeDistribution) {
+    if (expectedNetPerAction(outcomeDistribution) <= 0) return null;
+
+    // f(R) = mgf(R) - 1. f(0) = 0 and f'(0) = -E[X] < 0, so f dips negative just above 0 then
+    // rises back through 0 at the adjustment coefficient (as long as a loss outcome exists).
+    let lower = 1e-9;
+    let guard = 0;
+    while (outcomeMgf(outcomeDistribution, lower) - 1 >= 0 && guard < 20) {
+        lower *= 10;
+        guard += 1;
+    }
+
+    let upper = Math.max(lower * 2, 1e-8);
+    guard = 0;
+    while (outcomeMgf(outcomeDistribution, upper) - 1 <= 0 && guard < 200) {
+        upper *= 2;
+        guard += 1;
+    }
+    if (outcomeMgf(outcomeDistribution, upper) - 1 <= 0) return null;
+
+    for (let i = 0; i < 100; i++) {
+        const mid = (lower + upper) / 2;
+        if (outcomeMgf(outcomeDistribution, mid) - 1 > 0) {
+            upper = mid;
+        } else {
+            lower = mid;
+        }
+    }
+    return (lower + upper) / 2;
+}
+
+/**
+ * Closed-form upper bound on ruin probability for an i.i.d. per-action distribution (chests,
+ * alchemy Transmute). This bounds infinite-horizon ruin, which is itself an upper bound on our
+ * finite-horizon question ("ruin before N actions" <= "ruin ever") — always a valid but
+ * conservative bound, never an exact match to the Monte Carlo estimate.
+ * @param {Object} params
+ * @param {number} params.startingBalance
+ * @param {Array<{prob: number, net: number}>} params.outcomeDistribution
+ * @returns {{bound: number, meaningful: boolean, adjustmentCoefficient: number|null}}
+ */
+export function lundbergBound({ startingBalance, outcomeDistribution }) {
+    const adjustmentCoefficient = findAdjustmentCoefficient(outcomeDistribution);
+    if (adjustmentCoefficient === null) {
+        return { bound: 1, meaningful: false, adjustmentCoefficient: null };
+    }
+    return {
+        bound: Math.exp(-adjustmentCoefficient * startingBalance),
+        meaningful: true,
+        adjustmentCoefficient,
+    };
+}
+
+/**
+ * Approximate closed-form upper bound for a per-action distribution that varies by position
+ * (enhancing: success rate and cost both change per level). The classical inequality assumes
+ * i.i.d. increments, which doesn't strictly hold here — this is a documented approximation,
+ * not a proven tight bound. It uses the single least-favorable level's distribution (the one
+ * with the smallest adjustment coefficient, i.e. the most conservative/largest resulting bound)
+ * as a stand-in for the whole walk.
+ * @param {Object} params
+ * @param {number} params.startingBalance
+ * @param {Array<Array<{prob: number, net: number}>>} params.perStepDistributions
+ * @returns {{bound: number, meaningful: boolean, adjustmentCoefficient: number|null}}
+ */
+export function lundbergBoundVarying({ startingBalance, perStepDistributions }) {
+    let worstCoefficient = null;
+    for (const distribution of perStepDistributions) {
+        const coefficient = findAdjustmentCoefficient(distribution);
+        if (coefficient === null) continue;
+        if (worstCoefficient === null || coefficient < worstCoefficient) {
+            worstCoefficient = coefficient;
+        }
+    }
+    if (worstCoefficient === null) {
+        return { bound: 1, meaningful: false, adjustmentCoefficient: null };
+    }
+    return {
+        bound: Math.exp(-worstCoefficient * startingBalance),
+        meaningful: true,
+        adjustmentCoefficient: worstCoefficient,
+    };
+}

--- a/src/utils/risk-of-ruin-engine.test.js
+++ b/src/utils/risk-of-ruin-engine.test.js
@@ -1,0 +1,210 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+    createSeededRng,
+    drawFromDistribution,
+    simulateRuin,
+    wilsonConfidenceInterval,
+    minActionsForNonZeroRisk,
+    findPeakExposureStep,
+    expectedNetPerAction,
+    findAdjustmentCoefficient,
+    lundbergBound,
+    lundbergBoundVarying,
+} from './risk-of-ruin-engine.js';
+
+// Simple asymmetric random walk: win prob p, +1 net; lose prob q=1-p, -1 net. With absorbing
+// barriers at balance 0 (ruin) and balance N (target), the exact ruin probability starting at
+// balance i is (r^N - r^i) / (r^N - 1) where r = q/p. This lets every engine primitive be
+// checked against a hand-derivable closed form instead of just "runs without throwing".
+function gamblersRuinStepFn(winProb) {
+    return (state, rng) => {
+        const net = rng() < winProb ? 1 : -1;
+        return { balance: state.balance + net };
+    };
+}
+
+describe('simulateRuin', () => {
+    test('converges to the exact two-barrier gambler-ruin probability', () => {
+        const winProb = 0.6;
+        const startingBalance = 4;
+        const target = 10; // absolute balance target (barrier), i.e. a gain of 6
+        const r = (1 - winProb) / winProb;
+        const exactRuinProbability = (r ** target - r ** startingBalance) / (r ** target - 1);
+
+        const result = simulateRuin({
+            startingBalance,
+            trials: 500000,
+            stepFn: gamblersRuinStepFn(winProb),
+            isTargetReached: (state) => state.balance >= target,
+            rngSeed: 42,
+        });
+
+        expect(Math.abs(result.ruinProbability - exactRuinProbability)).toBeLessThan(0.01);
+        expect(result.ruinCount + result.undecidedCount).toBeLessThanOrEqual(result.trials);
+        expect(result.meanStepsToRuin).toBeGreaterThan(0);
+    });
+
+    test('returns certain ruin when starting balance is already non-positive', () => {
+        const result = simulateRuin({
+            startingBalance: 0,
+            trials: 100,
+            stepFn: gamblersRuinStepFn(0.9),
+            isTargetReached: () => false,
+        });
+
+        expect(result.ruinProbability).toBe(1);
+        expect(result.ruinCount).toBe(100);
+    });
+
+    test('is deterministic for a fixed seed', () => {
+        const options = {
+            startingBalance: 5,
+            trials: 1000,
+            stepFn: gamblersRuinStepFn(0.55),
+            isTargetReached: (state) => state.balance >= 15,
+            rngSeed: 7,
+        };
+
+        expect(simulateRuin(options).ruinProbability).toBe(simulateRuin(options).ruinProbability);
+    });
+});
+
+describe('createSeededRng / drawFromDistribution', () => {
+    test('produces floats in [0, 1) deterministically for a given seed', () => {
+        const rngA = createSeededRng(123);
+        const rngB = createSeededRng(123);
+        for (let i = 0; i < 10; i++) {
+            const a = rngA();
+            const b = rngB();
+            expect(a).toBe(b);
+            expect(a).toBeGreaterThanOrEqual(0);
+            expect(a).toBeLessThan(1);
+        }
+    });
+
+    test('draws respect the given probabilities over many samples', () => {
+        const distribution = [
+            { prob: 0.2, label: 'a' },
+            { prob: 0.8, label: 'b' },
+        ];
+        const rng = createSeededRng(99);
+        let aCount = 0;
+        const samples = 20000;
+        for (let i = 0; i < samples; i++) {
+            if (drawFromDistribution(distribution, rng).label === 'a') aCount += 1;
+        }
+        expect(aCount / samples).toBeCloseTo(0.2, 1);
+    });
+});
+
+describe('wilsonConfidenceInterval', () => {
+    test('brackets the point estimate and widens for small trial counts', () => {
+        const large = wilsonConfidenceInterval(500, 1000);
+        const small = wilsonConfidenceInterval(5, 10);
+
+        expect(large.low).toBeLessThan(0.5);
+        expect(large.high).toBeGreaterThan(0.5);
+        expect(small.high - small.low).toBeGreaterThan(large.high - large.low);
+    });
+
+    test('clamps to [0, 1] at the extremes', () => {
+        const allSuccess = wilsonConfidenceInterval(1000, 1000);
+        expect(allSuccess.high).toBeLessThanOrEqual(1);
+        const allFailure = wilsonConfidenceInterval(0, 1000);
+        expect(allFailure.low).toBeGreaterThanOrEqual(0);
+    });
+});
+
+describe('minActionsForNonZeroRisk', () => {
+    test('computes the exact worst-case action count analytically', () => {
+        expect(minActionsForNonZeroRisk(100, 25)).toBe(4);
+        expect(minActionsForNonZeroRisk(101, 25)).toBe(5);
+    });
+
+    test('is infinite when no single action can ever lose money', () => {
+        expect(minActionsForNonZeroRisk(100, 0)).toBe(Infinity);
+    });
+});
+
+describe('findPeakExposureStep', () => {
+    test('reads the mode directly off a ruin-step histogram', () => {
+        const ruinStepCounts = [];
+        ruinStepCounts[3] = 10;
+        ruinStepCounts[7] = 50;
+        ruinStepCounts[12] = 20;
+        expect(findPeakExposureStep(ruinStepCounts)).toBe(7);
+    });
+
+    test('returns null when no trial ever ruined', () => {
+        expect(findPeakExposureStep([])).toBeNull();
+    });
+});
+
+describe('Lundberg bound', () => {
+    // For the simple +-1 random walk, the adjustment coefficient has the closed form
+    // R = ln(p/q), and e^(-R*u) is exactly (q/p)^u — a known special case where the Lundberg
+    // bound is tight, not just an upper bound, giving a precise value to assert against.
+    const winProb = 0.6;
+    const distribution = [
+        { prob: winProb, net: 1 },
+        { prob: 1 - winProb, net: -1 },
+    ];
+
+    test('adjustment coefficient matches ln(p/q)', () => {
+        const r = findAdjustmentCoefficient(distribution);
+        expect(r).toBeCloseTo(Math.log(winProb / (1 - winProb)), 6);
+    });
+
+    test('bound matches the exact tight-case value (q/p)^startingBalance', () => {
+        const startingBalance = 4;
+        const result = lundbergBound({ startingBalance, outcomeDistribution: distribution });
+        const exact = ((1 - winProb) / winProb) ** startingBalance;
+
+        expect(result.meaningful).toBe(true);
+        expect(result.bound).toBeCloseTo(exact, 6);
+    });
+
+    test('is not meaningful when expected drift is non-positive', () => {
+        const losingDistribution = [
+            { prob: 0.4, net: 1 },
+            { prob: 0.6, net: -1 },
+        ];
+        expect(expectedNetPerAction(losingDistribution)).toBeLessThan(0);
+        expect(findAdjustmentCoefficient(losingDistribution)).toBeNull();
+
+        const result = lundbergBound({ startingBalance: 4, outcomeDistribution: losingDistribution });
+        expect(result.meaningful).toBe(false);
+        expect(result.bound).toBe(1);
+    });
+
+    test('varying-distribution bound picks the least-favorable level conservatively', () => {
+        const favorableLevel = [
+            { prob: 0.9, net: 1 },
+            { prob: 0.1, net: -1 },
+        ];
+        const unfavorableLevel = distribution; // winProb 0.6, the worse of the two
+
+        const result = lundbergBoundVarying({
+            startingBalance: 4,
+            perStepDistributions: [favorableLevel, unfavorableLevel],
+        });
+        const soloUnfavorable = lundbergBound({ startingBalance: 4, outcomeDistribution: unfavorableLevel });
+
+        expect(result.meaningful).toBe(true);
+        expect(result.bound).toBeCloseTo(soloUnfavorable.bound, 10);
+    });
+
+    test('varying-distribution bound is not meaningful when every level has non-positive drift', () => {
+        const result = lundbergBoundVarying({
+            startingBalance: 4,
+            perStepDistributions: [
+                [
+                    { prob: 0.4, net: 1 },
+                    { prob: 0.6, net: -1 },
+                ],
+            ],
+        });
+        expect(result.meaningful).toBe(false);
+    });
+});

--- a/src/utils/risk-of-ruin-worker-manager.js
+++ b/src/utils/risk-of-ruin-worker-manager.js
@@ -1,0 +1,320 @@
+/**
+ * Risk of Ruin Worker Manager
+ * Runs Monte Carlo trial batches off the main thread via a worker pool.
+ *
+ * Benchmarked need: an unprotected/huge-balance enhancement scenario where every trial runs to
+ * the step cap took ~6s synchronously on the main thread for 20000 trials — a real freeze risk,
+ * not a speculative one. Splitting trials across workers keeps the tab responsive.
+ *
+ * Both risk-of-ruin adapter shapes reduce to one of two plain, structured-clone-safe models:
+ * - 'fixedOutcome' (chests, alchemy): a flat per-action {prob, net} outcome list, walked for a
+ *   fixed number of actions.
+ * - 'levelWalk' (enhancing): a per-level {prob, nextLevel, net} outcome list, walked until a
+ *   target level is reached.
+ * Each worker re-implements risk-of-ruin-engine.js's createSeededRng/drawFromDistribution/
+ * simulateRuin core inline (the same duplication tradeoff ev-worker-manager.js and
+ * enhancement-worker-manager.js already accept, since a Blob-URL worker can't import this
+ * project's ES modules) — kept deliberately tiny and mirrored closely so the two stay in sync.
+ */
+
+import WorkerPool from './worker-pool.js';
+import { createSeededRng, drawFromDistribution } from './risk-of-ruin-engine.js';
+
+let workerPool = null;
+
+/**
+ * Run a batch of 'fixedOutcome' trials (chests, alchemy): a flat per-action outcome list,
+ * walked for a fixed number of actions. Exported so the exact same logic that runs inside the
+ * worker (see WORKER_SCRIPT below, kept manually in sync) is directly unit-testable.
+ */
+export function runFixedOutcomeTrials(model, rng) {
+    const { startingBalance, trials, maxSteps, outcomeDistribution, targetActionCount } = model;
+    let ruinCount = 0;
+    let totalRuinSteps = 0;
+    let undecidedCount = 0;
+    const ruinStepCounts = [];
+
+    for (let trial = 0; trial < trials; trial++) {
+        let balance = startingBalance;
+        let step = 0;
+        let ruined = false;
+
+        while (step < maxSteps && step < targetActionCount) {
+            balance += drawFromDistribution(outcomeDistribution, rng).net;
+            step += 1;
+            if (balance <= 0) {
+                ruined = true;
+                break;
+            }
+        }
+
+        if (ruined) {
+            ruinCount += 1;
+            totalRuinSteps += step;
+            ruinStepCounts[step] = (ruinStepCounts[step] || 0) + 1;
+        } else if (step < targetActionCount) {
+            undecidedCount += 1;
+        }
+    }
+
+    return { ruinCount, trials, totalRuinSteps, undecidedCount, ruinStepCounts };
+}
+
+/**
+ * Run a batch of 'levelWalk' trials (enhancing): a per-level outcome list, walked until a
+ * target level is reached. Exported for the same testability reason as above.
+ */
+export function runLevelWalkTrials(model, rng) {
+    const { startingBalance, trials, maxSteps, perLevelOutcomeDistributions, targetLevel, startLevel } = model;
+    let ruinCount = 0;
+    let totalRuinSteps = 0;
+    let undecidedCount = 0;
+    const ruinStepCounts = [];
+
+    for (let trial = 0; trial < trials; trial++) {
+        let balance = startingBalance;
+        let level = startLevel;
+        let step = 0;
+        let ruined = false;
+
+        while (step < maxSteps && level < targetLevel) {
+            const chosen = drawFromDistribution(perLevelOutcomeDistributions[level], rng);
+            balance += chosen.net;
+            level = chosen.nextLevel;
+            step += 1;
+            if (balance <= 0) {
+                ruined = true;
+                break;
+            }
+        }
+
+        if (ruined) {
+            ruinCount += 1;
+            totalRuinSteps += step;
+            ruinStepCounts[step] = (ruinStepCounts[step] || 0) + 1;
+        } else if (level < targetLevel) {
+            undecidedCount += 1;
+        }
+    }
+
+    return { ruinCount, trials, totalRuinSteps, undecidedCount, ruinStepCounts };
+}
+
+/**
+ * Run one chunk's worth of trials for either model type. Exported for the same testability
+ * reason as above.
+ */
+export function runBatch(model) {
+    if (model.startingBalance <= 0) {
+        return {
+            ruinCount: model.trials,
+            trials: model.trials,
+            totalRuinSteps: 0,
+            undecidedCount: 0,
+            ruinStepCounts: [0],
+        };
+    }
+    const rng = createSeededRng(model.rngSeed);
+    return model.type === 'levelWalk' ? runLevelWalkTrials(model, rng) : runFixedOutcomeTrials(model, rng);
+}
+
+// Inline copy of createSeededRng/drawFromDistribution/runFixedOutcomeTrials/runLevelWalkTrials/
+// runBatch above, since a Blob-URL worker can't import this project's ES modules — the same
+// duplication tradeoff ev-worker-manager.js and enhancement-worker-manager.js already accept.
+// Keep this manually in sync with the exported functions above; risk-of-ruin-worker-manager.test.js
+// exercises the real exported versions, not this string.
+const WORKER_SCRIPT = `
+function createSeededRng(seed) {
+    let a = seed >>> 0;
+    return function () {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+function drawFromDistribution(distribution, rng) {
+    const roll = rng();
+    let cumulative = 0;
+    for (let i = 0; i < distribution.length; i++) {
+        cumulative += distribution[i].prob;
+        if (roll < cumulative || i === distribution.length - 1) return distribution[i];
+    }
+    return distribution[distribution.length - 1];
+}
+
+function runFixedOutcomeTrials(model, rng) {
+    const { startingBalance, trials, maxSteps, outcomeDistribution, targetActionCount } = model;
+    let ruinCount = 0;
+    let totalRuinSteps = 0;
+    let undecidedCount = 0;
+    const ruinStepCounts = [];
+
+    for (let trial = 0; trial < trials; trial++) {
+        let balance = startingBalance;
+        let step = 0;
+        let ruined = false;
+
+        while (step < maxSteps && step < targetActionCount) {
+            balance += drawFromDistribution(outcomeDistribution, rng).net;
+            step += 1;
+            if (balance <= 0) {
+                ruined = true;
+                break;
+            }
+        }
+
+        if (ruined) {
+            ruinCount += 1;
+            totalRuinSteps += step;
+            ruinStepCounts[step] = (ruinStepCounts[step] || 0) + 1;
+        } else if (step < targetActionCount) {
+            undecidedCount += 1;
+        }
+    }
+
+    return { ruinCount, trials, totalRuinSteps, undecidedCount, ruinStepCounts };
+}
+
+function runLevelWalkTrials(model, rng) {
+    const { startingBalance, trials, maxSteps, perLevelOutcomeDistributions, targetLevel, startLevel } = model;
+    let ruinCount = 0;
+    let totalRuinSteps = 0;
+    let undecidedCount = 0;
+    const ruinStepCounts = [];
+
+    for (let trial = 0; trial < trials; trial++) {
+        let balance = startingBalance;
+        let level = startLevel;
+        let step = 0;
+        let ruined = false;
+
+        while (step < maxSteps && level < targetLevel) {
+            const chosen = drawFromDistribution(perLevelOutcomeDistributions[level], rng);
+            balance += chosen.net;
+            level = chosen.nextLevel;
+            step += 1;
+            if (balance <= 0) {
+                ruined = true;
+                break;
+            }
+        }
+
+        if (ruined) {
+            ruinCount += 1;
+            totalRuinSteps += step;
+            ruinStepCounts[step] = (ruinStepCounts[step] || 0) + 1;
+        } else if (level < targetLevel) {
+            undecidedCount += 1;
+        }
+    }
+
+    return { ruinCount, trials, totalRuinSteps, undecidedCount, ruinStepCounts };
+}
+
+function runBatch(model) {
+    if (model.startingBalance <= 0) {
+        return { ruinCount: model.trials, trials: model.trials, totalRuinSteps: 0, undecidedCount: 0, ruinStepCounts: [0] };
+    }
+    const rng = createSeededRng(model.rngSeed);
+    return model.type === 'levelWalk' ? runLevelWalkTrials(model, rng) : runFixedOutcomeTrials(model, rng);
+}
+
+self.onmessage = function (e) {
+    const { taskId, data } = e.data;
+    try {
+        self.postMessage({ taskId, result: runBatch(data.model) });
+    } catch (error) {
+        self.postMessage({ taskId, error: error.message || String(error) });
+    }
+};
+`;
+
+async function getWorkerPool() {
+    if (workerPool) return workerPool;
+
+    const blob = new Blob([WORKER_SCRIPT], { type: 'application/javascript' });
+    workerPool = new WorkerPool(blob);
+    await workerPool.initialize();
+    return workerPool;
+}
+
+/**
+ * Split a Monte Carlo model's trial count into per-worker chunks, each with a distinct rngSeed
+ * derived from the base seed so chunks don't sample identically.
+ * @param {Object} model
+ * @param {number} poolSize
+ * @returns {Array<{model: Object}>} Task list ready for WorkerPool#executeAll.
+ */
+export function buildChunkTasks(model, poolSize) {
+    const chunkCount = Math.min(poolSize, model.trials) || 1;
+    const baseChunkSize = Math.floor(model.trials / chunkCount);
+    const remainder = model.trials % chunkCount;
+
+    const tasks = [];
+    for (let i = 0; i < chunkCount; i++) {
+        const chunkTrials = baseChunkSize + (i < remainder ? 1 : 0);
+        if (chunkTrials <= 0) continue;
+        tasks.push({ model: { ...model, trials: chunkTrials, rngSeed: (model.rngSeed || 1) + i * 104729 } });
+    }
+    return tasks;
+}
+
+/**
+ * Merge per-chunk trial results back into the same shape risk-of-ruin-engine.js's
+ * simulateRuin() returns.
+ * @param {Array<{ruinCount: number, trials: number, totalRuinSteps: number, undecidedCount: number, ruinStepCounts: number[]}>} chunkResults
+ * @returns {{ruinProbability: number, ruinCount: number, trials: number, ruinStepCounts: number[], meanStepsToRuin: number|null, undecidedCount: number}}
+ */
+export function mergeRuinChunks(chunkResults) {
+    let ruinCount = 0;
+    let trials = 0;
+    let totalRuinSteps = 0;
+    let undecidedCount = 0;
+    const ruinStepCounts = [];
+
+    for (const chunk of chunkResults) {
+        ruinCount += chunk.ruinCount;
+        trials += chunk.trials;
+        totalRuinSteps += chunk.totalRuinSteps;
+        undecidedCount += chunk.undecidedCount;
+        for (let step = 0; step < chunk.ruinStepCounts.length; step++) {
+            const count = chunk.ruinStepCounts[step];
+            if (!count) continue;
+            ruinStepCounts[step] = (ruinStepCounts[step] || 0) + count;
+        }
+    }
+
+    return {
+        ruinProbability: ruinCount / trials,
+        ruinCount,
+        trials,
+        ruinStepCounts,
+        meanStepsToRuin: ruinCount > 0 ? totalRuinSteps / ruinCount : null,
+        undecidedCount,
+    };
+}
+
+/**
+ * Run a Monte Carlo ruin simulation split across the worker pool.
+ * @param {Object} model - { startingBalance, trials, maxSteps, rngSeed, type, ...type-specific fields }
+ * @returns {Promise<{ruinProbability: number, ruinCount: number, trials: number, ruinStepCounts: number[], meanStepsToRuin: number|null, undecidedCount: number}>}
+ */
+export async function simulateRuinAsync(model) {
+    const pool = await getWorkerPool();
+    const tasks = buildChunkTasks(model, pool.getStats().poolSize);
+    const chunkResults = await pool.executeAll(tasks);
+    return mergeRuinChunks(chunkResults);
+}
+
+/**
+ * Terminate the worker pool.
+ */
+export function terminateRiskOfRuinWorkerPool() {
+    if (workerPool) {
+        workerPool.terminate();
+        workerPool = null;
+    }
+}

--- a/src/utils/risk-of-ruin-worker-manager.test.js
+++ b/src/utils/risk-of-ruin-worker-manager.test.js
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+    runFixedOutcomeTrials,
+    runLevelWalkTrials,
+    runBatch,
+    buildChunkTasks,
+    mergeRuinChunks,
+} from './risk-of-ruin-worker-manager.js';
+import { createSeededRng } from './risk-of-ruin-engine.js';
+
+describe('runFixedOutcomeTrials', () => {
+    test('matches the exact two-barrier gambler-ruin probability (cross-checks the main engine)', () => {
+        const winProb = 0.6;
+        const startingBalance = 4;
+        const target = 6; // action count, since fixedOutcome walks a step count, not a balance barrier
+        const outcomeDistribution = [
+            { prob: winProb, net: 1 },
+            { prob: 1 - winProb, net: -1 },
+        ];
+
+        const rng = createSeededRng(42);
+        const result = runFixedOutcomeTrials(
+            { startingBalance, trials: 200000, maxSteps: 100000, outcomeDistribution, targetActionCount: target },
+            rng
+        );
+
+        // Exact ruin probability via DP over (step, balance) alive-mass, absorbing at balance
+        // <= 0. A naive bitmask enumeration over all 2^6 win/loss sequences overcounts early-
+        // ruin paths (it double-counts "irrelevant" trailing flips that never actually happen
+        // once the walk is absorbed), so this DP is the correct hand-checkable reference.
+        let alive = new Map([[startingBalance, 1]]);
+        let exactRuin = 0;
+        for (let step = 0; step < target; step++) {
+            const next = new Map();
+            for (const [balance, p] of alive) {
+                for (const { prob, net } of outcomeDistribution) {
+                    const nextBalance = balance + net;
+                    const nextProb = p * prob;
+                    if (nextBalance <= 0) {
+                        exactRuin += nextProb;
+                    } else {
+                        next.set(nextBalance, (next.get(nextBalance) || 0) + nextProb);
+                    }
+                }
+            }
+            alive = next;
+        }
+
+        expect(Math.abs(result.ruinCount / result.trials - exactRuin)).toBeLessThan(0.005);
+    });
+
+    test('reports undecided when neither ruin nor the target is reached within maxSteps', () => {
+        const rng = createSeededRng(1);
+        const result = runFixedOutcomeTrials(
+            {
+                startingBalance: 1000,
+                trials: 10,
+                maxSteps: 3,
+                outcomeDistribution: [{ prob: 1, net: -1 }],
+                targetActionCount: 100,
+            },
+            rng
+        );
+
+        expect(result.ruinCount).toBe(0);
+        expect(result.undecidedCount).toBe(10);
+    });
+});
+
+describe('runLevelWalkTrials', () => {
+    test('always ruins immediately when the only outcome is a guaranteed loss exceeding balance', () => {
+        const rng = createSeededRng(1);
+        const result = runLevelWalkTrials(
+            {
+                startingBalance: 50,
+                trials: 100,
+                maxSteps: 10,
+                perLevelOutcomeDistributions: [[{ prob: 1, nextLevel: 1, net: -100 }]],
+                targetLevel: 1,
+                startLevel: 0,
+            },
+            rng
+        );
+
+        expect(result.ruinCount).toBe(100);
+        expect(result.ruinStepCounts[1]).toBe(100);
+    });
+
+    test('always succeeds when the only outcome is a guaranteed win reaching target level', () => {
+        const rng = createSeededRng(1);
+        const result = runLevelWalkTrials(
+            {
+                startingBalance: 50,
+                trials: 100,
+                maxSteps: 10,
+                perLevelOutcomeDistributions: [[{ prob: 1, nextLevel: 1, net: -10 }]],
+                targetLevel: 1,
+                startLevel: 0,
+            },
+            rng
+        );
+
+        expect(result.ruinCount).toBe(0);
+        expect(result.undecidedCount).toBe(0);
+    });
+});
+
+describe('runBatch', () => {
+    test('is certain ruin when starting balance is already non-positive', () => {
+        const result = runBatch({ startingBalance: 0, trials: 42, type: 'fixedOutcome' });
+        expect(result.ruinCount).toBe(42);
+        expect(result.trials).toBe(42);
+    });
+
+    test('dispatches to the level-walk path for type "levelWalk"', () => {
+        const result = runBatch({
+            startingBalance: 50,
+            trials: 5,
+            maxSteps: 10,
+            rngSeed: 1,
+            type: 'levelWalk',
+            perLevelOutcomeDistributions: [[{ prob: 1, nextLevel: 1, net: -100 }]],
+            targetLevel: 1,
+            startLevel: 0,
+        });
+        expect(result.ruinCount).toBe(5);
+    });
+
+    test('dispatches to the fixed-outcome path for any other type', () => {
+        const result = runBatch({
+            startingBalance: 50,
+            trials: 5,
+            maxSteps: 10,
+            rngSeed: 1,
+            type: 'fixedOutcome',
+            outcomeDistribution: [{ prob: 1, net: -100 }],
+            targetActionCount: 10,
+        });
+        expect(result.ruinCount).toBe(5);
+    });
+});
+
+describe('buildChunkTasks', () => {
+    test('splits trials evenly across the pool with a distinct rngSeed per chunk', () => {
+        const tasks = buildChunkTasks({ trials: 100, rngSeed: 1 }, 4);
+        expect(tasks).toHaveLength(4);
+        expect(tasks.map((t) => t.model.trials)).toEqual([25, 25, 25, 25]);
+        const seeds = tasks.map((t) => t.model.rngSeed);
+        expect(new Set(seeds).size).toBe(4);
+    });
+
+    test('distributes the remainder across the first chunks', () => {
+        const tasks = buildChunkTasks({ trials: 10, rngSeed: 1 }, 3);
+        expect(tasks.map((t) => t.model.trials)).toEqual([4, 3, 3]);
+    });
+
+    test('never creates more chunks than there are trials', () => {
+        const tasks = buildChunkTasks({ trials: 2, rngSeed: 1 }, 8);
+        expect(tasks).toHaveLength(2);
+        expect(tasks.every((t) => t.model.trials === 1)).toBe(true);
+    });
+});
+
+describe('mergeRuinChunks', () => {
+    test('sums counts and merges the ruin-step histogram index-wise', () => {
+        const merged = mergeRuinChunks([
+            { ruinCount: 3, trials: 10, totalRuinSteps: 9, undecidedCount: 1, ruinStepCounts: [, 2, 1] },
+            { ruinCount: 2, trials: 10, totalRuinSteps: 4, undecidedCount: 0, ruinStepCounts: [, 1, , 1] },
+        ]);
+
+        expect(merged.ruinCount).toBe(5);
+        expect(merged.trials).toBe(20);
+        expect(merged.undecidedCount).toBe(1);
+        expect(merged.ruinProbability).toBe(0.25);
+        expect(merged.meanStepsToRuin).toBe((9 + 4) / 5);
+        expect(merged.ruinStepCounts[1]).toBe(3);
+        expect(merged.ruinStepCounts[2]).toBe(1);
+        expect(merged.ruinStepCounts[3]).toBe(1);
+    });
+
+    test('reports null meanStepsToRuin when nothing ever ruined', () => {
+        const merged = mergeRuinChunks([
+            { ruinCount: 0, trials: 5, totalRuinSteps: 0, undecidedCount: 5, ruinStepCounts: [] },
+        ]);
+        expect(merged.meanStepsToRuin).toBeNull();
+        expect(merged.ruinProbability).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

Adds a standalone "Risk of Ruin" calculator: the probability of hitting 0 gold before
reaching a target, across three modes:

- **Dungeon chests** — cost = entry key + chest key market price (existing
  `profitCalc_keyPricingMode` setting), payout = a realized draw from the real
  `openableLootDropMap` drop table (not just its mean).
- **Alchemy Transmute** — reuses `alchemyProfitCalculator.calculateTransmuteProfit()`'s
  exact per-attempt economics (materials, self-return, catalyst-on-success-only, output
  drop-table EV), un-blended back into a two-outcome success/fail model.
- **Enhancing** — walks the same per-level success-rate / failure-destination / blessed-tea
  transition model as `calculateEnhancement()`'s exact Markov chain, but as a Monte Carlo
  walk against a gold balance instead of a closed-form expectation (enhancing has no
  monetary payout branch, so the Lundberg bound is correctly never meaningful for this mode).

Method: Monte Carlo simulation (seeded, deterministic) as the headline estimate, with a
closed-form Lundberg-inequality upper bound shown alongside as a sanity check, plus two
derived numbers read off the same simulation data at no extra cost — the action count at
which risk first becomes possible (computed analytically) and the action index of peak
ruin exposure.

Benchmarking an unfavorable/high-target scenario showed a synchronous run could block the
main thread for several seconds, so the simulation runs in a Web Worker pool
(`risk-of-ruin-worker-manager.js`, mirroring the existing `ev-worker-manager.js` pattern).

New standalone floating panel, following the existing `XPHCalculator` panel pattern —
not integrated into existing enhancement/alchemy/market panels. Starting gold defaults to
the live coin balance and is editable.

### Incidental refactor
Extracted `calculatePerAttemptMaterialCost()` out of `xph-calculator.js`'s inlined
materials-cost loop into `tooltip-enhancement.js`, so both the XPH calculator and the new
enhancement adapter share one implementation. Pure extraction — same formula, same
inputs/outputs, covered by new unit tests.

## Test plan

- [x] New unit tests for the engine, all three adapters, and the worker manager (all
  hand-verified against closed-form probability math, not just "runs without throwing")
- [x] Full suite: 717/717 passing
- [x] Lint clean
- [x] Format clean
- [x] `build:dev`, production `build`, and `build:enhancement` all succeed
- [x] CI bundle-size gate passes locally (all bundles well under the 2MB limit)
- [x] Verified the built artifacts (`dist/Toolasha-dev.user.js`, `dist/libraries/toolasha-ui.js`) actually contain the new code
- [ ] Manual in-game smoke test (install `dist/Toolasha-dev.user.js`, open the new panel, try all three modes) — not done in this sandboxed environment; recommend a quick manual check before merging