### PR TITLE
fix: polish Risk of Ruin calculator based on in-game testing

### DIFF
--- a/src/features/risk-of-ruin/risk-of-ruin-ui.js
+++ b/src/features/risk-of-ruin/risk-of-ruin-ui.js
@@ -10,6 +10,7 @@ import config from '../../core/config.js';
 import dataManager from '../../core/data-manager.js';
 import { getEnhancingParams } from '../../utils/enhancement-config.js';
 import { formatWithSeparator, formatPercentage } from '../../utils/formatters.js';
+import { parseItemCount } from '../../utils/number-parser.js';
 import { createTimerRegistry } from '../../utils/timer-registry.js';
 import { registerFloatingPanel, unregisterFloatingPanel, bringPanelToFront } from '../../utils/panel-z-index.js';
 import {
@@ -20,7 +21,11 @@ import {
     findPeakExposureStep,
 } from '../../utils/risk-of-ruin-engine.js';
 import { simulateRuinAsync } from '../../utils/risk-of-ruin-worker-manager.js';
-import { buildDungeonChestModel } from '../../utils/risk-of-ruin-adapters/dungeon-chest-adapter.js';
+import expectedValueCalculator from '../market/expected-value-calculator.js';
+import {
+    buildDungeonChestModel,
+    getChestCostBreakdown,
+} from '../../utils/risk-of-ruin-adapters/dungeon-chest-adapter.js';
 import { buildAlchemyTransmuteModel } from '../../utils/risk-of-ruin-adapters/alchemy-adapter.js';
 import { buildEnhancementModel } from '../../utils/risk-of-ruin-adapters/enhancement-adapter.js';
 
@@ -46,6 +51,15 @@ function getCoinBalance() {
 
 function getTrialCount() {
     return parseInt(config.getSettingValue('riskOfRuin_trials')) || 10000;
+}
+
+/**
+ * Format a gold amount with thousands separators, rounded to a whole number.
+ * @param {number} amount
+ * @returns {string}
+ */
+function fmtGold(amount) {
+    return formatWithSeparator(Math.round(amount));
 }
 
 class RiskOfRuinUI {
@@ -183,7 +197,7 @@ class RiskOfRuinUI {
             <div id="mwi-ror-mode-inputs"></div>
 
             <label style="${labelStyle} margin-top:10px;">Starting gold</label>
-            <input id="mwi-ror-bankroll" type="number" min="0" step="1" style="${inputStyle} margin-bottom:10px;">
+            <input id="mwi-ror-bankroll" type="text" inputmode="decimal" placeholder="e.g. 5m, 1.2b" style="${inputStyle} margin-bottom:10px;">
 
             <button id="mwi-ror-run" style="
                 width: 100%;
@@ -281,12 +295,15 @@ class RiskOfRuinUI {
     _refillBankroll() {
         const bankrollInput = this.panel.querySelector('#mwi-ror-bankroll');
         if (bankrollInput && !bankrollInput.dataset.userEdited) {
-            bankrollInput.value = getCoinBalance();
+            bankrollInput.value = fmtGold(getCoinBalance());
         }
         if (bankrollInput && !bankrollInput.dataset.wired) {
             bankrollInput.dataset.wired = 'true';
             bankrollInput.addEventListener('input', () => {
                 bankrollInput.dataset.userEdited = 'true';
+            });
+            bankrollInput.addEventListener('blur', () => {
+                bankrollInput.value = fmtGold(parseItemCount(bankrollInput.value, 0));
             });
         }
     }
@@ -336,13 +353,14 @@ class RiskOfRuinUI {
         const status = this.panel.querySelector('#mwi-ror-status');
         const results = this.panel.querySelector('#mwi-ror-results');
         const mode = this.panel.querySelector('#mwi-ror-mode').value;
-        const startingBalance = parseFloat(this.panel.querySelector('#mwi-ror-bankroll').value) || 0;
+        const startingBalance = parseItemCount(this.panel.querySelector('#mwi-ror-bankroll').value, 0);
         const trials = getTrialCount();
         const rngSeed = Math.floor(Math.random() * 2 ** 31);
 
         let simModel;
         let lundberg;
         let maxSinglePossibleLoss;
+        let detailInfo;
 
         if (mode === 'chest') {
             const hrid = this.panel.querySelector('#mwi-ror-chest').value;
@@ -359,6 +377,11 @@ class RiskOfRuinUI {
                 targetActionCount,
             };
             lundberg = lundbergBound({ startingBalance, outcomeDistribution: chestModel.outcomeDistribution });
+            detailInfo = {
+                mode: 'chest',
+                costBreakdown: getChestCostBreakdown(hrid),
+                dropBreakdown: expectedValueCalculator.getDropBreakdown(hrid),
+            };
         } else if (mode === 'alchemy') {
             const name = this.panel.querySelector('#mwi-ror-item').value;
             const hrid = this._resolveItemHrid(name, 'mwi-ror-transmute-items');
@@ -379,6 +402,7 @@ class RiskOfRuinUI {
                 targetActionCount,
             };
             lundberg = lundbergBound({ startingBalance, outcomeDistribution: alchemyModel.outcomeDistribution });
+            detailInfo = { mode: 'alchemy', breakdown: alchemyModel.breakdown };
         } else {
             const name = this.panel.querySelector('#mwi-ror-item').value;
             const hrid = this._resolveItemHrid(name, 'mwi-ror-enhance-items');
@@ -423,16 +447,25 @@ class RiskOfRuinUI {
                 startingBalance,
                 perStepDistributions: enhancementModel.perLevelOutcomeDistributions,
             });
+            detailInfo = {
+                mode: 'enhancement',
+                perLevelOutcomeDistributions: enhancementModel.perLevelOutcomeDistributions,
+                costPerAttempt: enhancementModel.costPerAttempt,
+                protectionCostOnFailure: enhancementModel.protectionCostOnFailure,
+                startLevel,
+                targetLevel,
+            };
         }
 
         const simResult = await simulateRuinAsync(simModel);
-        this._renderResults(results, simResult, lundberg, maxSinglePossibleLoss, startingBalance);
-        status.textContent = `${trials.toLocaleString()} trials simulated.`;
+        const minActions = minActionsForNonZeroRisk(startingBalance, maxSinglePossibleLoss);
+        this._renderResults(results, simResult, lundberg, minActions);
+        this._renderDetails(results, detailInfo, startingBalance, maxSinglePossibleLoss, minActions);
+        status.textContent = `${formatWithSeparator(trials)} trials simulated.`;
     }
 
-    _renderResults(container, simResult, lundberg, maxSinglePossibleLoss, startingBalance) {
+    _renderResults(container, simResult, lundberg, minActions) {
         const ci = wilsonConfidenceInterval(simResult.ruinCount, simResult.trials);
-        const minActions = minActionsForNonZeroRisk(startingBalance, maxSinglePossibleLoss);
         const peakStep = findPeakExposureStep(simResult.ruinStepCounts);
 
         const lines = [];
@@ -465,7 +498,7 @@ class RiskOfRuinUI {
 
         if (simResult.meanStepsToRuin !== null) {
             lines.push(
-                `<strong>Average actions before ruin (when it occurs):</strong> ${simResult.meanStepsToRuin.toFixed(1)}`
+                `<strong>Average actions before ruin (when it occurs):</strong> ${formatWithSeparator(Math.round(simResult.meanStepsToRuin * 10) / 10)}`
             );
         }
 
@@ -478,6 +511,188 @@ class RiskOfRuinUI {
         }
 
         container.innerHTML = lines.map((line) => `<div style="margin-bottom:6px;">${line}</div>`).join('');
+    }
+
+    /**
+     * Formula line spelling out exactly how "risk becomes possible at action N" was derived,
+     * so the number in the summary above isn't a black box.
+     */
+    _riskFormulaLine(startingBalance, maxSinglePossibleLoss, minActions) {
+        if (!Number.isFinite(minActions)) {
+            return `<div>No single action can ever lose money here, so risk never becomes possible.</div>`;
+        }
+        return (
+            `<div><strong>Risk becomes possible at action</strong> = ⌈starting gold ÷ max single-action loss⌉ ` +
+            `= ⌈${fmtGold(startingBalance)} ÷ ${fmtGold(maxSinglePossibleLoss)}⌉ = ${formatWithSeparator(minActions)}</div>`
+        );
+    }
+
+    _renderDetails(container, detailInfo, startingBalance, maxSinglePossibleLoss, minActions) {
+        let html;
+        if (detailInfo.mode === 'chest') {
+            html = this._chestDetailsHTML(detailInfo, startingBalance, maxSinglePossibleLoss, minActions);
+        } else if (detailInfo.mode === 'alchemy') {
+            html = this._alchemyDetailsHTML(detailInfo, startingBalance, maxSinglePossibleLoss, minActions);
+        } else {
+            html = this._enhancementDetailsHTML(detailInfo, startingBalance, maxSinglePossibleLoss, minActions);
+        }
+        container.insertAdjacentHTML('beforeend', html);
+    }
+
+    _chestDetailsHTML({ costBreakdown, dropBreakdown }, startingBalance, maxSinglePossibleLoss, minActions) {
+        const rows = [];
+        if (costBreakdown.entryKey) {
+            rows.push(
+                `<div>Entry key (${costBreakdown.entryKey.name}): ${fmtGold(costBreakdown.entryKey.price)}</div>`
+            );
+        }
+        if (costBreakdown.chestKey) {
+            rows.push(
+                `<div>Chest key (${costBreakdown.chestKey.name}): ${fmtGold(costBreakdown.chestKey.price)}</div>`
+            );
+        }
+        rows.push(`<div><strong>Total cost per open:</strong> ${fmtGold(costBreakdown.total)}</div>`);
+        rows.push(
+            `<div style="margin-top:6px;"><strong>Max single-action loss:</strong> ${fmtGold(maxSinglePossibleLoss)} ` +
+                `(the lowest possible payout from one open is 0, so the worst case is losing the full open cost)</div>`
+        );
+        rows.push(this._riskFormulaLine(startingBalance, maxSinglePossibleLoss, minActions));
+
+        const dropRows = dropBreakdown
+            .map(
+                (drop) =>
+                    `<tr>
+                        <td style="padding:2px 6px;">${drop.itemName}</td>
+                        <td style="padding:2px 6px; text-align:right;">${formatPercentage(drop.dropRate, 2)}</td>
+                        <td style="padding:2px 6px; text-align:right;">${drop.avgCount}</td>
+                        <td style="padding:2px 6px; text-align:right;">${drop.hasPriceData ? fmtGold(drop.priceEach) : '—'}</td>
+                        <td style="padding:2px 6px; text-align:right;">${fmtGold(drop.expectedValue)}</td>
+                    </tr>`
+            )
+            .join('');
+
+        return this._wrapDetails(
+            'Cost & risk details',
+            rows.join('') +
+                this._wrapDetails(
+                    `Drop table (${dropBreakdown.length} items)`,
+                    `<table style="width:100%; border-collapse:collapse; font-size:11px;">
+                        <tr style="color:#888;"><th style="text-align:left;">Item</th><th>Drop rate</th><th>Avg count</th><th>Price</th><th>EV</th></tr>
+                        ${dropRows}
+                    </table>`,
+                    true
+                )
+        );
+    }
+
+    _alchemyDetailsHTML({ breakdown }, startingBalance, maxSinglePossibleLoss, minActions) {
+        const catalystName = breakdown.catalystHrid ? dataManager.getItemDetails(breakdown.catalystHrid)?.name : null;
+
+        const rows = [
+            `<div>Success rate: ${formatPercentage(breakdown.successRate, 2)}</div>`,
+            `<div>Material cost (paid every attempt): ${fmtGold(breakdown.materialCost)}</div>`,
+        ];
+        if (breakdown.coinCost > 0) {
+            rows.push(`<div>Coin cost (paid every attempt): ${fmtGold(breakdown.coinCost)}</div>`);
+        }
+        rows.push(
+            catalystName
+                ? `<div>Catalyst (${catalystName}, paid only on success): ${fmtGold(breakdown.catalystCostOnSuccess)}</div>`
+                : `<div>No catalyst used.</div>`
+        );
+        rows.push(`<div>Output value if successful: ${fmtGold(breakdown.outputValueGivenSuccess)}</div>`);
+        if (breakdown.selfReturnGivenSuccess > 0) {
+            rows.push(`<div>Self-return value if successful: ${fmtGold(breakdown.selfReturnGivenSuccess)}</div>`);
+        }
+        rows.push(
+            `<div style="margin-top:6px;"><strong>Net on success:</strong> ${fmtGold(breakdown.netOnSuccess)}</div>`
+        );
+        rows.push(`<div><strong>Net on failure:</strong> ${fmtGold(breakdown.netOnFail)}</div>`);
+        rows.push(`<div><strong>Max single-action loss:</strong> ${fmtGold(maxSinglePossibleLoss)}</div>`);
+        rows.push(this._riskFormulaLine(startingBalance, maxSinglePossibleLoss, minActions));
+
+        const dropRows = breakdown.dropRevenues
+            .map(
+                (drop) =>
+                    `<tr>
+                        <td style="padding:2px 6px;">${dataManager.getItemDetails(drop.itemHrid)?.name || drop.itemHrid}${drop.isSelfReturn ? ' (self-return)' : ''}</td>
+                        <td style="padding:2px 6px; text-align:right;">${formatPercentage(drop.dropRate, 2)}</td>
+                        <td style="padding:2px 6px; text-align:right;">${fmtGold(drop.price)}</td>
+                        <td style="padding:2px 6px; text-align:right;">${fmtGold(drop.revenuePerAttempt)}</td>
+                    </tr>`
+            )
+            .join('');
+
+        return this._wrapDetails(
+            'Cost & risk details',
+            rows.join('') +
+                this._wrapDetails(
+                    `Output drops (${breakdown.dropRevenues.length} items)`,
+                    `<table style="width:100%; border-collapse:collapse; font-size:11px;">
+                        <tr style="color:#888;"><th style="text-align:left;">Item</th><th>Drop rate</th><th>Price</th><th>Revenue given success</th></tr>
+                        ${dropRows}
+                    </table>`,
+                    true
+                )
+        );
+    }
+
+    _enhancementDetailsHTML(
+        { perLevelOutcomeDistributions, costPerAttempt, protectionCostOnFailure, startLevel, targetLevel },
+        startingBalance,
+        maxSinglePossibleLoss,
+        minActions
+    ) {
+        const rows = perLevelOutcomeDistributions
+            .map((outcomes, level) => {
+                const [failure] = outcomes;
+                const successRate = 1 - failure.prob;
+                const isProtected = failure.net !== -costPerAttempt;
+                return `<tr>
+                    <td style="padding:2px 6px;">+${level} → +${level + 1}</td>
+                    <td style="padding:2px 6px; text-align:right;">${formatPercentage(successRate, 2)}</td>
+                    <td style="padding:2px 6px; text-align:right;">${fmtGold(costPerAttempt)}</td>
+                    <td style="padding:2px 6px; text-align:right;">+${failure.nextLevel}</td>
+                    <td style="padding:2px 6px; text-align:right;">${isProtected ? fmtGold(protectionCostOnFailure) : '—'}</td>
+                </tr>`;
+            })
+            .join('');
+
+        const rows2 = [
+            `<div><strong>Cost per attempt (materials, every attempt):</strong> ${fmtGold(costPerAttempt)}</div>`,
+        ];
+        if (protectionCostOnFailure > 0) {
+            rows2.push(
+                `<div><strong>Protection cost (charged only on a protected failure):</strong> ${fmtGold(protectionCostOnFailure)}</div>`
+            );
+        }
+        rows2.push(
+            `<div style="margin-top:6px;"><strong>Max single-action loss:</strong> ${fmtGold(maxSinglePossibleLoss)} ` +
+                `(worst case: an attempt fails at a protected level)</div>`
+        );
+        rows2.push(this._riskFormulaLine(startingBalance, maxSinglePossibleLoss, minActions));
+
+        return this._wrapDetails(
+            `Cost & risk details (levels +${startLevel} to +${targetLevel})`,
+            rows2.join('') +
+                this._wrapDetails(
+                    `Per-level success rates & costs (${perLevelOutcomeDistributions.length} levels)`,
+                    `<table style="width:100%; border-collapse:collapse; font-size:11px;">
+                        <tr style="color:#888;"><th style="text-align:left;">Attempt</th><th>Success</th><th>Cost</th><th>Fail →</th><th>Protection cost</th></tr>
+                        ${rows}
+                    </table>`,
+                    true
+                )
+        );
+    }
+
+    _wrapDetails(summary, innerHTML, nested = false) {
+        const margin = nested ? 'margin-top:6px;' : 'margin-top:10px; border-top:1px solid #333; padding-top:8px;';
+        const summaryColor = nested ? '#aaa' : '#e05c5c';
+        return `<details style="${margin}">
+            <summary style="cursor:pointer; color:${summaryColor}; font-weight:600; font-size:${nested ? '11px' : '12px'};">${summary}</summary>
+            <div style="margin-top:8px; padding-left:4px;">${innerHTML}</div>
+        </details>`;
     }
 
     disable() {

--- a/src/features/risk-of-ruin/risk-of-ruin-ui.js
+++ b/src/features/risk-of-ruin/risk-of-ruin-ui.js
@@ -381,6 +381,7 @@ class RiskOfRuinUI {
                 mode: 'chest',
                 costBreakdown: getChestCostBreakdown(hrid),
                 dropBreakdown: expectedValueCalculator.getDropBreakdown(hrid),
+                minimumGuaranteedPayout: chestModel.minimumGuaranteedPayout,
             };
         } else if (mode === 'alchemy') {
             const name = this.panel.querySelector('#mwi-ror-item').value;
@@ -539,7 +540,12 @@ class RiskOfRuinUI {
         container.insertAdjacentHTML('beforeend', html);
     }
 
-    _chestDetailsHTML({ costBreakdown, dropBreakdown }, startingBalance, maxSinglePossibleLoss, minActions) {
+    _chestDetailsHTML(
+        { costBreakdown, dropBreakdown, minimumGuaranteedPayout },
+        startingBalance,
+        maxSinglePossibleLoss,
+        minActions
+    ) {
         const rows = [];
         if (costBreakdown.entryKey) {
             rows.push(
@@ -553,16 +559,22 @@ class RiskOfRuinUI {
         }
         rows.push(`<div><strong>Total cost per open:</strong> ${fmtGold(costBreakdown.total)}</div>`);
         rows.push(
-            `<div style="margin-top:6px;"><strong>Max single-action loss:</strong> ${fmtGold(maxSinglePossibleLoss)} ` +
-                `(the lowest possible payout from one open is 0, so the worst case is losing the full open cost)</div>`
+            `<div style="margin-top:6px;">Guaranteed minimum payout per open: ${fmtGold(minimumGuaranteedPayout)} ` +
+                `(the sum of every drop table entry with a 100% drop rate, at its minimum count — a real chest ` +
+                `always drops at least this much, it is never actually 0)</div>`
+        );
+        rows.push(
+            `<div><strong>Max single-action loss:</strong> ${fmtGold(maxSinglePossibleLoss)} ` +
+                `= cost − guaranteed minimum payout = ${fmtGold(costBreakdown.total)} − ${fmtGold(minimumGuaranteedPayout)}</div>`
         );
         rows.push(this._riskFormulaLine(startingBalance, maxSinglePossibleLoss, minActions));
 
+        const totalEV = dropBreakdown.reduce((sum, drop) => sum + drop.expectedValue, 0);
         const dropRows = dropBreakdown
             .map(
                 (drop) =>
                     `<tr>
-                        <td style="padding:2px 6px;">${drop.itemName}</td>
+                        <td style="padding:2px 6px;">${drop.itemName}${drop.dropRate === 1 ? ' (guaranteed)' : ''}</td>
                         <td style="padding:2px 6px; text-align:right;">${formatPercentage(drop.dropRate, 2)}</td>
                         <td style="padding:2px 6px; text-align:right;">${drop.avgCount}</td>
                         <td style="padding:2px 6px; text-align:right;">${drop.hasPriceData ? fmtGold(drop.priceEach) : '—'}</td>
@@ -579,6 +591,10 @@ class RiskOfRuinUI {
                     `<table style="width:100%; border-collapse:collapse; font-size:11px;">
                         <tr style="color:#888;"><th style="text-align:left;">Item</th><th>Drop rate</th><th>Avg count</th><th>Price</th><th>EV</th></tr>
                         ${dropRows}
+                        <tr style="border-top:1px solid #444; font-weight:600;">
+                            <td style="padding:2px 6px;" colspan="4">Total EV per open</td>
+                            <td style="padding:2px 6px; text-align:right;">${fmtGold(totalEV)}</td>
+                        </tr>
                     </table>`,
                     true
                 )
@@ -611,16 +627,21 @@ class RiskOfRuinUI {
         rows.push(`<div><strong>Max single-action loss:</strong> ${fmtGold(maxSinglePossibleLoss)}</div>`);
         rows.push(this._riskFormulaLine(startingBalance, maxSinglePossibleLoss, minActions));
 
+        // dropRevenues' own revenuePerAttempt is already scaled by successRate (the overall
+        // per-attempt expected revenue); divide back out to the "given success" value so each
+        // row - and its sum - lines up with outputValueGivenSuccess shown above.
+        let totalGivenSuccess = 0;
         const dropRows = breakdown.dropRevenues
-            .map(
-                (drop) =>
-                    `<tr>
+            .map((drop) => {
+                const evGivenSuccess = drop.revenuePerAttempt / breakdown.successRate;
+                totalGivenSuccess += evGivenSuccess;
+                return `<tr>
                         <td style="padding:2px 6px;">${dataManager.getItemDetails(drop.itemHrid)?.name || drop.itemHrid}${drop.isSelfReturn ? ' (self-return)' : ''}</td>
                         <td style="padding:2px 6px; text-align:right;">${formatPercentage(drop.dropRate, 2)}</td>
                         <td style="padding:2px 6px; text-align:right;">${fmtGold(drop.price)}</td>
-                        <td style="padding:2px 6px; text-align:right;">${fmtGold(drop.revenuePerAttempt)}</td>
-                    </tr>`
-            )
+                        <td style="padding:2px 6px; text-align:right;">${fmtGold(evGivenSuccess)}</td>
+                    </tr>`;
+            })
             .join('');
 
         return this._wrapDetails(
@@ -629,8 +650,12 @@ class RiskOfRuinUI {
                 this._wrapDetails(
                     `Output drops (${breakdown.dropRevenues.length} items)`,
                     `<table style="width:100%; border-collapse:collapse; font-size:11px;">
-                        <tr style="color:#888;"><th style="text-align:left;">Item</th><th>Drop rate</th><th>Price</th><th>Revenue given success</th></tr>
+                        <tr style="color:#888;"><th style="text-align:left;">Item</th><th>Drop rate</th><th>Price</th><th>EV given success</th></tr>
                         ${dropRows}
+                        <tr style="border-top:1px solid #444; font-weight:600;">
+                            <td style="padding:2px 6px;" colspan="3">Total EV given success</td>
+                            <td style="padding:2px 6px; text-align:right;">${fmtGold(totalGivenSuccess)}</td>
+                        </tr>
                     </table>`,
                     true
                 )

--- a/src/features/risk-of-ruin/risk-of-ruin-ui.js
+++ b/src/features/risk-of-ruin/risk-of-ruin-ui.js
@@ -45,7 +45,7 @@ const CHEST_HRIDS = [
 ];
 
 function getCoinBalance() {
-    const coin = dataManager.getCharacterItems()?.find((item) => item.itemHrid === '/items/coin');
+    const coin = dataManager.getInventory()?.find((item) => item.itemHrid === '/items/coin');
     return coin?.count || 0;
 }
 

--- a/src/utils/number-parser.js
+++ b/src/utils/number-parser.js
@@ -7,7 +7,7 @@
  * Parse item count from text
  * Handles various formats including:
  * - Plain numbers: "100", "1000"
- * - K/M suffixes: "1.5K", "2M"
+ * - K/M/B/T suffixes: "1.5K", "2M", "3B", "1.2T"
  * - International formats with separators: "1,000", "1 000", "1.000"
  * - Mixed decimal formats: "1.234,56" (European) or "1,234.56" (US)
  * - Prefixed formats: "x5", "Amount: 1000", "Amount: 1 000"
@@ -74,14 +74,16 @@ export function parseItemCount(text, defaultValue = 1) {
     // Remove remaining whitespace separators
     text = text.replace(/\s/g, '');
 
-    // Handle K/M/B suffixes (must end with the suffix letter)
-    if (/\d[kmb]$/.test(text)) {
+    // Handle K/M/B/T suffixes (must end with the suffix letter)
+    if (/\d[kmbt]$/.test(text)) {
         if (text.endsWith('k')) {
             return parseFloat(text) * 1000;
         } else if (text.endsWith('m')) {
             return parseFloat(text) * 1000000;
         } else if (text.endsWith('b')) {
             return parseFloat(text) * 1000000000;
+        } else if (text.endsWith('t')) {
+            return parseFloat(text) * 1000000000000;
         }
     }
 

--- a/src/utils/number-parser.test.js
+++ b/src/utils/number-parser.test.js
@@ -6,11 +6,13 @@ describe('parseItemCount', () => {
         test('parses large integer', () => expect(parseItemCount('1000000')).toBe(1000000));
     });
 
-    describe('K/M/B suffixes', () => {
+    describe('K/M/B/T suffixes', () => {
         test('parses K suffix', () => expect(parseItemCount('1.5K')).toBe(1500));
         test('parses M suffix', () => expect(parseItemCount('2M')).toBe(2000000));
         test('parses B suffix', () => expect(parseItemCount('1.2B')).toBe(1200000000));
+        test('parses T suffix', () => expect(parseItemCount('1.2T')).toBe(1200000000000));
         test('parses lowercase k', () => expect(parseItemCount('1.5k')).toBe(1500));
+        test('parses lowercase t', () => expect(parseItemCount('3t')).toBe(3000000000000));
     });
 
     describe('comma as thousands separator', () => {

--- a/src/utils/risk-of-ruin-adapters/alchemy-adapter.js
+++ b/src/utils/risk-of-ruin-adapters/alchemy-adapter.js
@@ -30,6 +30,18 @@ import { drawFromDistribution } from '../risk-of-ruin-engine.js';
  *   maxSinglePossibleLoss: number,
  *   outcomeDistribution: Array<{prob: number, net: number}>,
  *   stepFn: function(state: Object, rng: function(): number): Object,
+ *   breakdown: {
+ *     successRate: number,
+ *     materialCost: number,
+ *     coinCost: number,
+ *     catalystHrid: string|null,
+ *     catalystCostOnSuccess: number,
+ *     outputValueGivenSuccess: number,
+ *     selfReturnGivenSuccess: number,
+ *     netOnSuccess: number,
+ *     netOnFail: number,
+ *     dropRevenues: Array,
+ *   },
  * }|null} null if the item isn't transmutable or has no usable market/success-rate data.
  */
 export function buildAlchemyTransmuteModel(itemHrid, { useLiveSetup = false } = {}) {
@@ -55,5 +67,17 @@ export function buildAlchemyTransmuteModel(itemHrid, { useLiveSetup = false } = 
         maxSinglePossibleLoss: Math.max(0, -netOnSuccess, -netOnFail),
         outcomeDistribution,
         stepFn: (state, rng) => ({ balance: state.balance + drawFromDistribution(outcomeDistribution, rng).net }),
+        breakdown: {
+            successRate: profit.successRate,
+            materialCost: profit.grossMaterialCost,
+            coinCost,
+            catalystHrid: profit.catalystPrice ? profit.catalystCost?.itemHrid || null : null,
+            catalystCostOnSuccess,
+            outputValueGivenSuccess,
+            selfReturnGivenSuccess,
+            netOnSuccess,
+            netOnFail,
+            dropRevenues: profit.dropRevenues || [],
+        },
     };
 }

--- a/src/utils/risk-of-ruin-adapters/alchemy-adapter.test.js
+++ b/src/utils/risk-of-ruin-adapters/alchemy-adapter.test.js
@@ -88,4 +88,27 @@ describe('buildAlchemyTransmuteModel', () => {
         const failState = model.stepFn({ balance: 10000 }, () => 0.99);
         expect(failState.balance).toBe(10000 - 1000);
     });
+
+    test('exposes a breakdown with the individual cost/payout components for a details UI', () => {
+        mockProfit = baseProfit({
+            catalystPrice: 200,
+            catalystCost: { itemHrid: '/items/prime_catalyst' },
+            requirementCosts: [{ itemHrid: '/items/coin', costPerAction: 50 }],
+            dropRevenues: [{ itemHrid: '/items/output_item', revenuePerAttempt: 600 }],
+        });
+        const model = buildAlchemyTransmuteModel('/items/widget');
+
+        expect(model.breakdown).toEqual({
+            successRate: 0.5,
+            materialCost: 1000,
+            coinCost: 50,
+            catalystHrid: '/items/prime_catalyst',
+            catalystCostOnSuccess: 200,
+            outputValueGivenSuccess: 600,
+            selfReturnGivenSuccess: 0,
+            netOnSuccess: -1000 - 50 - 200 + 600,
+            netOnFail: -1050,
+            dropRevenues: [{ itemHrid: '/items/output_item', revenuePerAttempt: 600 }],
+        });
+    });
 });

--- a/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.js
+++ b/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.js
@@ -56,6 +56,42 @@ export function getChestOpenCost(containerHrid) {
 }
 
 /**
+ * Breaks getChestOpenCost() down into its individual key line items, for display in a
+ * cost-transparency UI.
+ * @param {string} containerHrid
+ * @returns {{
+ *   entryKey: {hrid: string, name: string, price: number}|null,
+ *   chestKey: {hrid: string, name: string, price: number}|null,
+ *   total: number,
+ * }}
+ */
+export function getChestCostBreakdown(containerHrid) {
+    const entryKeyHrid = DUNGEON_ENTRY_KEYS[containerHrid];
+    const chestKeyHrid = DUNGEON_CHEST_KEYS[containerHrid];
+
+    const entryKey = entryKeyHrid
+        ? {
+              hrid: entryKeyHrid,
+              name: dataManager.getItemDetails(entryKeyHrid)?.name || entryKeyHrid,
+              price: getKeyPrice(entryKeyHrid),
+          }
+        : null;
+    const chestKey = chestKeyHrid
+        ? {
+              hrid: chestKeyHrid,
+              name: dataManager.getItemDetails(chestKeyHrid)?.name || chestKeyHrid,
+              price: getKeyPrice(chestKeyHrid),
+          }
+        : null;
+
+    return {
+        entryKey,
+        chestKey,
+        total: (entryKey?.price || 0) + (chestKey?.price || 0),
+    };
+}
+
+/**
  * Draw one realized payout value for opening the given chest once. Prices each triggered drop
  * the same way expected-value-calculator.js's getDropBreakdown() prices its average — tax-aware
  * sell side, with coin/cowbell/dungeon-token/nested-container special cases handled by

--- a/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.js
+++ b/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.js
@@ -12,6 +12,11 @@
  *   for a large enough sample size, and the only form that's plain structured-clone-safe data
  *   a Web Worker can consume without access to dataManager/marketAPI/expectedValueCalculator).
  * - The Lundberg bound, which needs a discrete outcome-distribution input.
+ *
+ * Every real dungeon chest has at least one dropRate === 1 entry (essence + tokens on regular
+ * chests, a refinement shard on refinement chests), so the payout floor is never actually 0 —
+ * getMinimumGuaranteedPayout() computes that floor from the drop table directly rather than
+ * assuming it.
  */
 
 import dataManager from '../../core/data-manager.js';
@@ -92,6 +97,26 @@ export function getChestCostBreakdown(containerHrid) {
 }
 
 /**
+ * Price a realized drop (a specific item + count that has already been determined to occur),
+ * applying the same coin/tradeable/tax rules expected-value-calculator.js uses.
+ * @param {string} itemHrid
+ * @param {number} count
+ * @returns {number|null} Gold value, or null if no price data is available for this item.
+ */
+function priceRealizedDrop(itemHrid, count) {
+    if (count <= 0) return 0;
+
+    const price = expectedValueCalculator.getDropPrice(itemHrid);
+    if (price === null) return null;
+
+    if (itemHrid === COIN_HRID) return count * price;
+
+    const itemDetails = dataManager.getItemDetails(itemHrid);
+    const canBeSold = itemDetails?.isTradable !== false;
+    return canBeSold ? calculatePriceAfterTax(count * price) : count * price;
+}
+
+/**
  * Draw one realized payout value for opening the given chest once. Prices each triggered drop
  * the same way expected-value-calculator.js's getDropBreakdown() prices its average — tax-aware
  * sell side, with coin/cowbell/dungeon-token/nested-container special cases handled by
@@ -114,19 +139,31 @@ export function drawChestPayout(containerHrid, rng) {
         const maxCount = drop.maxCount || 0;
         if (minCount <= 0 && maxCount <= 0) continue;
         const count = minCount + Math.floor(rng() * (maxCount - minCount + 1));
-        if (count <= 0) continue;
 
-        const price = expectedValueCalculator.getDropPrice(drop.itemHrid);
-        if (price === null) continue;
+        payout += priceRealizedDrop(drop.itemHrid, count) || 0;
+    }
 
-        if (drop.itemHrid === COIN_HRID) {
-            payout += count * price;
-            continue;
-        }
+    return payout;
+}
 
-        const itemDetails = dataManager.getItemDetails(drop.itemHrid);
-        const canBeSold = itemDetails?.isTradable !== false;
-        payout += canBeSold ? calculatePriceAfterTax(count * price) : count * price;
+/**
+ * The lowest payout a single chest open can ever produce: the sum of every drop table entry
+ * that's guaranteed (dropRate === 1) at its minimum count, since a real chest's guaranteed
+ * drops (essence + tokens on regular chests, a refinement shard on refinement chests) mean the
+ * true floor is never 0 — every drop entry with dropRate < 1 is assumed to whiff in the
+ * worst case, but the dropRate === 1 entries always fire.
+ * @param {string} containerHrid
+ * @returns {number}
+ */
+export function getMinimumGuaranteedPayout(containerHrid) {
+    const initData = dataManager.getInitClientData();
+    const dropTable = initData?.openableLootDropMap?.[containerHrid];
+    if (!dropTable) return 0;
+
+    let payout = 0;
+    for (const drop of dropTable) {
+        if (drop.dropRate !== 1) continue;
+        payout += priceRealizedDrop(drop.itemHrid, drop.minCount || 0) || 0;
     }
 
     return payout;
@@ -143,6 +180,7 @@ export function drawChestPayout(containerHrid, rng) {
  * @param {number} [options.rngSeed] - Seed for the empirical sample.
  * @returns {{
  *   cost: number,
+ *   minimumGuaranteedPayout: number,
  *   maxSinglePossibleLoss: number,
  *   stepFn: function(state: Object, rng: function(): number): Object,
  *   outcomeDistribution: Array<{prob: number, net: number}>,
@@ -153,6 +191,7 @@ export function buildDungeonChestModel(
     { sampleSize = DEFAULT_EMPIRICAL_SAMPLE_SIZE, rngSeed = 1 } = {}
 ) {
     const cost = getChestOpenCost(containerHrid);
+    const minimumGuaranteedPayout = getMinimumGuaranteedPayout(containerHrid);
 
     const sampleRng = createSeededRng(rngSeed);
     const outcomeDistribution = [];
@@ -163,7 +202,8 @@ export function buildDungeonChestModel(
 
     return {
         cost,
-        maxSinglePossibleLoss: cost,
+        minimumGuaranteedPayout,
+        maxSinglePossibleLoss: Math.max(0, cost - minimumGuaranteedPayout),
         stepFn: (state, rng) => ({ balance: state.balance + drawFromDistribution(outcomeDistribution, rng).net }),
         outcomeDistribution,
     };

--- a/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.test.js
+++ b/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.test.js
@@ -33,7 +33,7 @@ vi.mock('../../features/combat-sim/combat-sim-adapter.js', () => ({
     },
 }));
 
-const { getChestOpenCost, getChestCostBreakdown, drawChestPayout, buildDungeonChestModel } =
+const { getChestOpenCost, getChestCostBreakdown, getMinimumGuaranteedPayout, drawChestPayout, buildDungeonChestModel } =
     await import('./dungeon-chest-adapter.js');
 const { createSeededRng } = await import('../risk-of-ruin-engine.js');
 
@@ -189,6 +189,49 @@ describe('drawChestPayout', () => {
     });
 });
 
+describe('getMinimumGuaranteedPayout', () => {
+    test('sums only the dropRate === 1 entries, at their minimum count', () => {
+        initData.openableLootDropMap['/items/test_chest'] = [
+            { itemHrid: '/items/guaranteed_a', dropRate: 1, minCount: 400, maxCount: 800 },
+            { itemHrid: '/items/guaranteed_b', dropRate: 1, minCount: 250, maxCount: 500 },
+            { itemHrid: '/items/rare_bonus', dropRate: 0.05, minCount: 2000, maxCount: 4000 },
+        ];
+        itemDetails['/items/guaranteed_a'] = { isTradable: true };
+        itemDetails['/items/guaranteed_b'] = { isTradable: true };
+        itemDetails['/items/rare_bonus'] = { isTradable: true };
+        dropPrices['/items/guaranteed_a'] = 10;
+        dropPrices['/items/guaranteed_b'] = 20;
+        dropPrices['/items/rare_bonus'] = 1;
+
+        // 400*10*0.98 + 250*20*0.98 = 3920 + 4900 = 8820 - the 5% bonus entry never counts,
+        // even though its own minCount*price (2000) looks bigger than either guaranteed entry.
+        expect(getMinimumGuaranteedPayout('/items/test_chest')).toBeCloseTo(8820, 6);
+    });
+
+    test('is 0 when no drop is guaranteed', () => {
+        initData.openableLootDropMap['/items/test_chest'] = [
+            { itemHrid: '/items/widget', dropRate: 0.5, minCount: 100, maxCount: 100 },
+        ];
+        itemDetails['/items/widget'] = { isTradable: true };
+        dropPrices['/items/widget'] = 10;
+
+        expect(getMinimumGuaranteedPayout('/items/test_chest')).toBe(0);
+    });
+
+    test('does not tax guaranteed coin drops', () => {
+        initData.openableLootDropMap['/items/test_chest'] = [
+            { itemHrid: COIN_HRID, dropRate: 1, minCount: 500, maxCount: 1000 },
+        ];
+        dropPrices[COIN_HRID] = 1;
+
+        expect(getMinimumGuaranteedPayout('/items/test_chest')).toBe(500);
+    });
+
+    test('returns 0 for an unknown container', () => {
+        expect(getMinimumGuaranteedPayout('/items/unknown_chest')).toBe(0);
+    });
+});
+
 describe('buildDungeonChestModel', () => {
     test('exposes cost, maxSinglePossibleLoss, and an empirical outcome distribution summing to 1', () => {
         marketPrices['/items/chimerical_entry_key'] = { ask: 1000, bid: 900 };
@@ -201,11 +244,50 @@ describe('buildDungeonChestModel', () => {
 
         const model = buildDungeonChestModel('/items/chimerical_chest', { sampleSize: 1000, rngSeed: 5 });
 
+        // No guaranteed (dropRate === 1) drop here, so the floor is genuinely 0 and the max
+        // single-action loss is the full open cost.
         expect(model.cost).toBe(3000);
+        expect(model.minimumGuaranteedPayout).toBe(0);
         expect(model.maxSinglePossibleLoss).toBe(3000);
         expect(model.outcomeDistribution).toHaveLength(1000);
         const totalProb = model.outcomeDistribution.reduce((sum, o) => sum + o.prob, 0);
         expect(totalProb).toBeCloseTo(1, 10);
+    });
+
+    test('reduces maxSinglePossibleLoss by the guaranteed minimum payout, like a real chest', () => {
+        marketPrices['/items/chimerical_entry_key'] = { ask: 1000, bid: 900 };
+        marketPrices['/items/chimerical_chest_key'] = { ask: 2000, bid: 1800 };
+        initData.openableLootDropMap['/items/chimerical_chest'] = [
+            { itemHrid: '/items/chimerical_essence', dropRate: 1, minCount: 400, maxCount: 800 },
+            { itemHrid: '/items/rare_bonus', dropRate: 0.05, minCount: 2000, maxCount: 4000 },
+        ];
+        itemDetails['/items/chimerical_essence'] = { isTradable: true };
+        itemDetails['/items/rare_bonus'] = { isTradable: true };
+        dropPrices['/items/chimerical_essence'] = 5;
+        dropPrices['/items/rare_bonus'] = 1;
+
+        const model = buildDungeonChestModel('/items/chimerical_chest', { sampleSize: 100, rngSeed: 5 });
+
+        // cost = 3000; guaranteed payout = 400 * 5 * 0.98 = 1960; max loss = 3000 - 1960 = 1040
+        expect(model.cost).toBe(3000);
+        expect(model.minimumGuaranteedPayout).toBeCloseTo(1960, 6);
+        expect(model.maxSinglePossibleLoss).toBeCloseTo(1040, 6);
+    });
+
+    test('clamps maxSinglePossibleLoss at 0 when the guaranteed payout alone covers the cost', () => {
+        marketPrices['/items/chimerical_chest_key'] = { ask: 500, bid: 500 };
+        initData.openableLootDropMap['/items/chimerical_refinement_chest'] = [
+            { itemHrid: '/items/widget', dropRate: 1, minCount: 2, maxCount: 2 },
+        ];
+        itemDetails['/items/widget'] = { isTradable: true };
+        dropPrices['/items/widget'] = 1000;
+
+        const model = buildDungeonChestModel('/items/chimerical_refinement_chest', { sampleSize: 10 });
+
+        // cost = 500; guaranteed payout = 2 * 1000 * 0.98 = 1960, which exceeds cost
+        expect(model.cost).toBe(500);
+        expect(model.minimumGuaranteedPayout).toBeCloseTo(1960, 6);
+        expect(model.maxSinglePossibleLoss).toBe(0);
     });
 
     test('stepFn deducts cost and adds the realized payout for one open', () => {

--- a/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.test.js
+++ b/src/utils/risk-of-ruin-adapters/dungeon-chest-adapter.test.js
@@ -33,7 +33,8 @@ vi.mock('../../features/combat-sim/combat-sim-adapter.js', () => ({
     },
 }));
 
-const { getChestOpenCost, drawChestPayout, buildDungeonChestModel } = await import('./dungeon-chest-adapter.js');
+const { getChestOpenCost, getChestCostBreakdown, drawChestPayout, buildDungeonChestModel } =
+    await import('./dungeon-chest-adapter.js');
 const { createSeededRng } = await import('../risk-of-ruin-engine.js');
 
 const COIN_HRID = '/items/coin';
@@ -74,6 +75,46 @@ describe('getChestOpenCost', () => {
 
     test('is zero for a chest with no known key mapping', () => {
         expect(getChestOpenCost('/items/unmapped_chest')).toBe(0);
+    });
+});
+
+describe('getChestCostBreakdown', () => {
+    test('breaks a regular chest down into entry key + chest key line items', () => {
+        marketPrices['/items/chimerical_entry_key'] = { ask: 1000, bid: 900 };
+        marketPrices['/items/chimerical_chest_key'] = { ask: 2000, bid: 1800 };
+        itemDetails['/items/chimerical_entry_key'] = { name: 'Chimerical Entry Key' };
+        itemDetails['/items/chimerical_chest_key'] = { name: 'Chimerical Chest Key' };
+
+        const breakdown = getChestCostBreakdown('/items/chimerical_chest');
+
+        expect(breakdown).toEqual({
+            entryKey: { hrid: '/items/chimerical_entry_key', name: 'Chimerical Entry Key', price: 1000 },
+            chestKey: { hrid: '/items/chimerical_chest_key', name: 'Chimerical Chest Key', price: 2000 },
+            total: 3000,
+        });
+    });
+
+    test('has a null entryKey for refinement chests', () => {
+        marketPrices['/items/chimerical_chest_key'] = { ask: 2000, bid: 1800 };
+        itemDetails['/items/chimerical_chest_key'] = { name: 'Chimerical Chest Key' };
+
+        const breakdown = getChestCostBreakdown('/items/chimerical_refinement_chest');
+
+        expect(breakdown.entryKey).toBeNull();
+        expect(breakdown.chestKey).toEqual({
+            hrid: '/items/chimerical_chest_key',
+            name: 'Chimerical Chest Key',
+            price: 2000,
+        });
+        expect(breakdown.total).toBe(2000);
+    });
+
+    test('falls back to the hrid as a name when item details are unavailable', () => {
+        marketPrices['/items/chimerical_chest_key'] = { ask: 2000, bid: 1800 };
+
+        const breakdown = getChestCostBreakdown('/items/chimerical_refinement_chest');
+
+        expect(breakdown.chestKey.name).toBe('/items/chimerical_chest_key');
     });
 });
 


### PR DESCRIPTION
## Summary

In-game testing feedback on the Risk of Ruin calculator (#639):

1. **Removed the number-input spinner** on "Starting gold" — switched to a text input.
2. **K/M/B/T shorthand now works in "Starting gold"** — extended `parseItemCount()` in
   `number-parser.js` to also support a T (trillion) suffix, matching the existing K/M/B
   support already used elsewhere in Toolasha, and reused it here instead of a bespoke parser.
3. **Added a collapsible "Cost & risk details" section** per mode, so "risk becomes possible
   at action N" isn't a black box:
   - Chests: entry key + chest key price, and the full drop table (drop rate, avg count,
     price, EV per item) via the existing `expectedValueCalculator.getDropBreakdown()`.
   - Alchemy: material/coin/catalyst cost, output value and self-return value given success,
     net-on-success vs net-on-fail, and the output drop table.
   - Enhancing: a per-level table (success rate, cost, failure destination, protection cost).
   - Every mode ends with the exact `⌈starting gold ÷ max single-action loss⌉ = N` formula
     spelled out with the real numbers plugged in.
4. **Thousands separators** applied consistently to every gold amount and count in the panel.

## Test plan

- [x] New/updated unit tests for `parseItemCount`'s T-suffix support, the chest cost
  breakdown helper, and the alchemy breakdown fields
- [x] Full suite: 723/723 passing
- [x] Lint clean, format clean
- [x] `build:dev`, production `build`, `build:enhancement` all succeed
- [x] Bundle-size gate passes locally
- [x] Verified the built `dist/libraries/toolasha-ui.js` contains the new details markup
- [ ] Manual in-game re-test of the four specific points above — not done in this sandboxed
  environment

Per your instruction, I'm stopping here rather than merging — let me know when you've had a
chance to test.