### PR TITLE
fix: Risk of Ruin catalyst modeling, live toggle, and marketplace auto-click-max

### DIFF
--- a/src/features/market/alchemy-profit-calculator.js
+++ b/src/features/market/alchemy-profit-calculator.js
@@ -441,6 +441,74 @@ class AlchemyProfitCalculator {
     }
 
     /**
+     * Compute one specific, caller-chosen catalyst combination (no live tea/profit search) —
+     * for callers that need a forced "none" / type-specific / prime catalyst rather than
+     * whichever combo is most profitable or whatever the live action panel has equipped.
+     * Live tea bonus is still applied, matching _bestCatalystCombo's "with tea" combos.
+     * @param {Object} params - Same shape as _bestCatalystCombo, plus:
+     * @param {'none'|'typeSpecific'|'prime'} params.catalystChoice
+     * @returns {Object} Same shape as _bestCatalystCombo/_liveSetupCombo's return value.
+     */
+    _forcedCatalystCombo({
+        actionType,
+        baseSuccessRate,
+        actionsPerHour,
+        efficiencyDecimal,
+        actionTime,
+        alchemyBonusRevenue,
+        computeNetProfit,
+        computeTeaCost,
+        levelPenalty = 0,
+        teaBonusOverride = null,
+        catalystChoice = 'none',
+    }) {
+        const liveTeaBonus = teaBonusOverride !== null ? teaBonusOverride : getAlchemySuccessBonus();
+
+        let catalystBonus = 0;
+        let catalystHrid = null;
+        let catalystPrice = 0;
+
+        if (catalystChoice === 'typeSpecific') {
+            catalystBonus = CATALYST_BONUSES.typeSpecific;
+            catalystHrid = CATALYST_HRIDS[actionType];
+        } else if (catalystChoice === 'prime') {
+            catalystBonus = CATALYST_BONUSES.prime;
+            catalystHrid = CATALYST_HRIDS.prime;
+        }
+        if (catalystHrid) {
+            catalystPrice = getItemPrice(catalystHrid, { context: 'profit', side: 'buy' }) ?? 0;
+        }
+
+        const successRateBreakdown = this.calculateSuccessRateBreakdown(
+            baseSuccessRate,
+            catalystBonus,
+            liveTeaBonus,
+            levelPenalty
+        );
+        const successRate = successRateBreakdown.total;
+        const catalystCostPerAttempt = catalystPrice * successRate;
+        const catalystCostPerHour = catalystCostPerAttempt * actionsPerHour;
+        const teaCostPerHour = liveTeaBonus > 0 ? computeTeaCost(liveTeaBonus) : 0;
+        const netProfitPerAttempt = computeNetProfit(successRate) - catalystCostPerAttempt;
+        const profitPerSecond = (netProfitPerAttempt * (1 + efficiencyDecimal)) / actionTime;
+        const profitPerHour = profitPerSecond * SECONDS_PER_HOUR + alchemyBonusRevenue - teaCostPerHour;
+
+        return {
+            catalystBonus,
+            catalystHrid,
+            catalystPrice,
+            teaBonus: liveTeaBonus,
+            successRateBreakdown,
+            successRate,
+            catalystCostPerAttempt,
+            catalystCostPerHour,
+            teaCostPerHour,
+            netProfitPerAttempt,
+            profitPerHour,
+        };
+    }
+
+    /**
      * @param {string} itemHrid - Item HRID
      * @param {number} enhancementLevel - Enhancement level (default 0)
      * @returns {Object|null} Detailed profit data or null if not coinifiable
@@ -1008,9 +1076,14 @@ class AlchemyProfitCalculator {
     /**
      * Calculate Transmute profit for an item with full detailed breakdown
      * @param {string} itemHrid - Item HRID
+     * @param {boolean} [useLiveSetup] - Read the live action panel's catalyst/tea instead of
+     *   searching for the best combination. Ignored when catalystChoice is given.
+     * @param {number|null} [teaBonusOverride]
+     * @param {'none'|'typeSpecific'|'prime'|null} [catalystChoice] - Force a specific catalyst
+     *   instead of searching for the best one or reading the live panel.
      * @returns {Object|null} Profit data or null if not transmutable
      */
-    calculateTransmuteProfit(itemHrid, useLiveSetup = false, teaBonusOverride = null) {
+    calculateTransmuteProfit(itemHrid, useLiveSetup = false, teaBonusOverride = null, catalystChoice = null) {
         try {
             const gameData = dataManager.getInitClientData();
             const itemDetails = dataManager.getItemDetails(itemHrid);
@@ -1166,9 +1239,14 @@ class AlchemyProfitCalculator {
                 getItemPrice: (hrid) => getItemPrice(hrid, { context: 'profit', side: 'buy' }),
             });
 
-            // Find the best catalyst+tea combination (tooltip) or use live setup (action page).
+            // Force a specific catalyst if the caller asked for one; otherwise find the best
+            // catalyst+tea combination (tooltip) or use live setup (action page).
             // Note: selfReturnValue depends on successRate so it must be computed inside the combo loop.
-            const _comboFn = useLiveSetup ? this._liveSetupCombo.bind(this) : this._bestCatalystCombo.bind(this);
+            const _comboFn = catalystChoice
+                ? this._forcedCatalystCombo.bind(this)
+                : useLiveSetup
+                  ? this._liveSetupCombo.bind(this)
+                  : this._bestCatalystCombo.bind(this);
             const combo = _comboFn({
                 actionType: 'transmute',
                 baseSuccessRate,
@@ -1184,6 +1262,7 @@ class AlchemyProfitCalculator {
                 computeTeaCost: () => teaCostData.totalCostPerHour,
                 levelPenalty,
                 teaBonusOverride,
+                catalystChoice,
             });
 
             const {

--- a/src/features/market/alchemy-profit-calculator.test.js
+++ b/src/features/market/alchemy-profit-calculator.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, test, vi } from 'vitest';
+
+const marketPrices = {};
+
+vi.mock('../../utils/market-data.js', () => ({
+    getItemPrice: (hrid) => (hrid in marketPrices ? marketPrices[hrid] : null),
+}));
+
+vi.mock('../../core/data-manager.js', () => ({ default: {} }));
+vi.mock('../../api/marketplace.js', () => ({ default: { getPrice: () => null, on: () => {} } }));
+vi.mock('./expected-value-calculator.js', () => ({ default: {} }));
+
+const { default: alchemyProfitCalculator } = await import('./alchemy-profit-calculator.js');
+
+function baseParams(overrides = {}) {
+    return {
+        actionType: 'transmute',
+        baseSuccessRate: 0.5,
+        actionsPerHour: 100,
+        efficiencyDecimal: 0,
+        actionTime: 20,
+        alchemyBonusRevenue: 0,
+        computeNetProfit: (successRate) => 1000 * successRate,
+        computeTeaCost: () => 0,
+        teaBonusOverride: 0, // avoid needing to mock getAlchemySuccessBonus
+        ...overrides,
+    };
+}
+
+describe('_forcedCatalystCombo', () => {
+    test('"none" applies no catalyst bonus or cost regardless of price data', () => {
+        marketPrices['/items/catalyst_of_transmutation'] = 5000;
+        marketPrices['/items/prime_catalyst'] = 50000;
+
+        const combo = alchemyProfitCalculator._forcedCatalystCombo(baseParams({ catalystChoice: 'none' }));
+
+        expect(combo.catalystHrid).toBeNull();
+        expect(combo.catalystBonus).toBe(0);
+        expect(combo.catalystPrice).toBe(0);
+        expect(combo.successRateBreakdown.total).toBe(0.5); // unmodified base rate
+    });
+
+    test('"typeSpecific" forces the type-specific catalyst for the given actionType', () => {
+        marketPrices['/items/catalyst_of_transmutation'] = 5000;
+
+        const combo = alchemyProfitCalculator._forcedCatalystCombo(baseParams({ catalystChoice: 'typeSpecific' }));
+
+        expect(combo.catalystHrid).toBe('/items/catalyst_of_transmutation');
+        expect(combo.catalystBonus).toBe(0.15);
+        expect(combo.catalystPrice).toBe(5000);
+        expect(combo.successRateBreakdown.total).toBeCloseTo(0.5 * 1.15, 10);
+    });
+
+    test('"prime" forces the prime catalyst regardless of actionType', () => {
+        marketPrices['/items/prime_catalyst'] = 50000;
+
+        const combo = alchemyProfitCalculator._forcedCatalystCombo(baseParams({ catalystChoice: 'prime' }));
+
+        expect(combo.catalystHrid).toBe('/items/prime_catalyst');
+        expect(combo.catalystBonus).toBe(0.25);
+        expect(combo.catalystPrice).toBe(50000);
+        expect(combo.successRateBreakdown.total).toBeCloseTo(0.5 * 1.25, 10);
+    });
+
+    test('catalyst cost is charged per attempt scaled by the resulting success rate', () => {
+        marketPrices['/items/prime_catalyst'] = 1000;
+
+        const combo = alchemyProfitCalculator._forcedCatalystCombo(baseParams({ catalystChoice: 'prime' }));
+
+        // successRate = 0.5 * 1.25 = 0.625; catalystCostPerAttempt = price * successRate
+        expect(combo.catalystCostPerAttempt).toBeCloseTo(1000 * 0.625, 10);
+    });
+
+    test('does not choose a catalyst just because it is not the most profitable one', () => {
+        // A forced "none" choice must be honored even when a catalyst would clearly be more
+        // profitable - this method never searches for the best option, unlike _bestCatalystCombo.
+        marketPrices['/items/prime_catalyst'] = 1; // trivially cheap, would win any search
+        const combo = alchemyProfitCalculator._forcedCatalystCombo(
+            baseParams({ catalystChoice: 'none', computeNetProfit: () => 1_000_000 })
+        );
+
+        expect(combo.catalystHrid).toBeNull();
+    });
+});

--- a/src/features/market/auto-click-max.js
+++ b/src/features/market/auto-click-max.js
@@ -84,8 +84,15 @@ class AutoClickMax {
             return;
         }
 
+        // Sell Listing dialogs have two "Max" buttons since the marketplace update added a
+        // tradable-range price row (Min/-/+/Max) ahead of the quantity row (1/Max) in DOM
+        // order. Scope the search to the quantity row so this only ever maxes quantity, never
+        // price - matching auto-fill-price.js's own container-scoping for the price row.
+        const quantityContainer = modal.querySelector('div[class*="MarketplacePanel_quantityInputs"]');
+        const searchRoot = quantityContainer || modal;
+
         // Find Max button (Sell Listing) or All button (Sell Now)
-        const allButtons = modal.querySelectorAll('button');
+        const allButtons = searchRoot.querySelectorAll('button');
         const maxButton = Array.from(allButtons).find((btn) => {
             const text = btn.textContent.trim();
             return text === 'Max' || text === 'All';

--- a/src/features/risk-of-ruin/risk-of-ruin-ui.js
+++ b/src/features/risk-of-ruin/risk-of-ruin-ui.js
@@ -14,8 +14,6 @@ import { parseItemCount } from '../../utils/number-parser.js';
 import { createTimerRegistry } from '../../utils/timer-registry.js';
 import { registerFloatingPanel, unregisterFloatingPanel, bringPanelToFront } from '../../utils/panel-z-index.js';
 import {
-    lundbergBound,
-    lundbergBoundVarying,
     wilsonConfidenceInterval,
     minActionsForNonZeroRisk,
     findPeakExposureStep,
@@ -237,6 +235,13 @@ class RiskOfRuinUI {
             container.innerHTML = `
                 <label style="${labelStyle}">Item to Transmute</label>
                 <input id="mwi-ror-item" list="mwi-ror-transmute-items" style="${inputStyle}" placeholder="Start typing an item name...">
+                <label style="${labelStyle}">Catalyst</label>
+                <select id="mwi-ror-catalyst" style="${inputStyle}">
+                    <option value="best">Best available (auto)</option>
+                    <option value="none">None</option>
+                    <option value="typeSpecific">Type-specific catalyst</option>
+                    <option value="prime">Prime catalyst</option>
+                </select>
                 <label style="${labelStyle}">Actions to attempt</label>
                 <input id="mwi-ror-target" type="number" min="1" step="1" value="100" style="${inputStyle}">
             `;
@@ -358,7 +363,6 @@ class RiskOfRuinUI {
         const rngSeed = Math.floor(Math.random() * 2 ** 31);
 
         let simModel;
-        let lundberg;
         let maxSinglePossibleLoss;
         let detailInfo;
 
@@ -376,7 +380,6 @@ class RiskOfRuinUI {
                 outcomeDistribution: chestModel.outcomeDistribution,
                 targetActionCount,
             };
-            lundberg = lundbergBound({ startingBalance, outcomeDistribution: chestModel.outcomeDistribution });
             detailInfo = {
                 mode: 'chest',
                 costBreakdown: getChestCostBreakdown(hrid),
@@ -387,7 +390,9 @@ class RiskOfRuinUI {
             const name = this.panel.querySelector('#mwi-ror-item').value;
             const hrid = this._resolveItemHrid(name, 'mwi-ror-transmute-items');
             const targetActionCount = parseInt(this.panel.querySelector('#mwi-ror-target').value) || 0;
-            const alchemyModel = hrid ? buildAlchemyTransmuteModel(hrid) : null;
+            const catalystSelection = this.panel.querySelector('#mwi-ror-catalyst').value;
+            const catalystChoice = catalystSelection === 'best' ? null : catalystSelection;
+            const alchemyModel = hrid ? buildAlchemyTransmuteModel(hrid, { catalystChoice }) : null;
             if (!alchemyModel) {
                 status.textContent = 'Enter a valid transmutable item name.';
                 return;
@@ -402,7 +407,6 @@ class RiskOfRuinUI {
                 outcomeDistribution: alchemyModel.outcomeDistribution,
                 targetActionCount,
             };
-            lundberg = lundbergBound({ startingBalance, outcomeDistribution: alchemyModel.outcomeDistribution });
             detailInfo = { mode: 'alchemy', breakdown: alchemyModel.breakdown };
         } else {
             const name = this.panel.querySelector('#mwi-ror-item').value;
@@ -444,10 +448,6 @@ class RiskOfRuinUI {
                 targetLevel,
                 startLevel,
             };
-            lundberg = lundbergBoundVarying({
-                startingBalance,
-                perStepDistributions: enhancementModel.perLevelOutcomeDistributions,
-            });
             detailInfo = {
                 mode: 'enhancement',
                 perLevelOutcomeDistributions: enhancementModel.perLevelOutcomeDistributions,
@@ -460,12 +460,12 @@ class RiskOfRuinUI {
 
         const simResult = await simulateRuinAsync(simModel);
         const minActions = minActionsForNonZeroRisk(startingBalance, maxSinglePossibleLoss);
-        this._renderResults(results, simResult, lundberg, minActions);
+        this._renderResults(results, simResult, minActions);
         this._renderDetails(results, detailInfo, startingBalance, maxSinglePossibleLoss, minActions);
         status.textContent = `${formatWithSeparator(trials)} trials simulated.`;
     }
 
-    _renderResults(container, simResult, lundberg, minActions) {
+    _renderResults(container, simResult, minActions) {
         const ci = wilsonConfidenceInterval(simResult.ruinCount, simResult.trials);
         const peakStep = findPeakExposureStep(simResult.ruinStepCounts);
 
@@ -474,16 +474,6 @@ class RiskOfRuinUI {
             `<strong>Ruin probability:</strong> ${formatPercentage(simResult.ruinProbability, 2)} ` +
                 `(95% CI: ${formatPercentage(ci.low, 2)} – ${formatPercentage(ci.high, 2)})`
         );
-
-        if (lundberg.meaningful) {
-            lines.push(`<strong>Lundberg upper bound:</strong> ≤ ${formatPercentage(Math.min(1, lundberg.bound), 2)}`);
-        } else {
-            lines.push(
-                `<strong>Lundberg upper bound:</strong> not meaningful — this setup does not have ` +
-                    `positive expected gold gain per action, so the closed-form bound is trivial. ` +
-                    `Only the Monte Carlo estimate above applies.`
-            );
-        }
 
         lines.push(
             `<strong>Risk becomes possible at action:</strong> ` +
@@ -616,49 +606,71 @@ class RiskOfRuinUI {
                 ? `<div>Catalyst (${catalystName}, paid only on success): ${fmtGold(breakdown.catalystCostOnSuccess)}</div>`
                 : `<div>No catalyst used.</div>`
         );
-        rows.push(`<div>Output value if successful: ${fmtGold(breakdown.outputValueGivenSuccess)}</div>`);
-        if (breakdown.selfReturnGivenSuccess > 0) {
-            rows.push(`<div>Self-return value if successful: ${fmtGold(breakdown.selfReturnGivenSuccess)}</div>`);
-        }
         rows.push(
-            `<div style="margin-top:6px;"><strong>Net on success:</strong> ${fmtGold(breakdown.netOnSuccess)}</div>`
+            `<div style="margin-top:6px;">The output drop table (below) is a single mutually-exclusive roll ` +
+                `<em>given success</em> — each branch is its own separate outcome, not averaged together, so a ` +
+                `rare high-value branch's real tail risk shows up in the simulation instead of being smoothed away.</div>`
         );
         rows.push(`<div><strong>Net on failure:</strong> ${fmtGold(breakdown.netOnFail)}</div>`);
         rows.push(`<div><strong>Max single-action loss:</strong> ${fmtGold(maxSinglePossibleLoss)}</div>`);
         rows.push(this._riskFormulaLine(startingBalance, maxSinglePossibleLoss, minActions));
 
-        // dropRevenues' own revenuePerAttempt is already scaled by successRate (the overall
-        // per-attempt expected revenue); divide back out to the "given success" value so each
-        // row - and its sum - lines up with outputValueGivenSuccess shown above.
-        let totalGivenSuccess = 0;
-        const dropRows = breakdown.dropRevenues
-            .map((drop) => {
-                const evGivenSuccess = drop.revenuePerAttempt / breakdown.successRate;
-                totalGivenSuccess += evGivenSuccess;
-                return `<tr>
-                        <td style="padding:2px 6px;">${dataManager.getItemDetails(drop.itemHrid)?.name || drop.itemHrid}${drop.isSelfReturn ? ' (self-return)' : ''}</td>
-                        <td style="padding:2px 6px; text-align:right;">${formatPercentage(drop.dropRate, 2)}</td>
-                        <td style="padding:2px 6px; text-align:right;">${fmtGold(drop.price)}</td>
-                        <td style="padding:2px 6px; text-align:right;">${fmtGold(evGivenSuccess)}</td>
-                    </tr>`;
-            })
+        const mainRows = breakdown.mainBranches
+            .map(
+                (branch) =>
+                    `<tr>
+                        <td style="padding:2px 6px;">${dataManager.getItemDetails(branch.itemHrid)?.name || branch.itemHrid}${branch.isSelfReturn ? ' (self-return)' : ''}</td>
+                        <td style="padding:2px 6px; text-align:right;">${formatPercentage(breakdown.successRate * branch.dropRate, 2)}</td>
+                        <td style="padding:2px 6px; text-align:right;">${fmtGold(branch.payout)}</td>
+                    </tr>`
+            )
             .join('');
+        const mainCoverage = breakdown.mainBranches.reduce((sum, b) => sum + b.dropRate, 0);
+        const failRow = `<tr>
+                        <td style="padding:2px 6px;">(failure)</td>
+                        <td style="padding:2px 6px; text-align:right;">${formatPercentage(1 - breakdown.successRate, 2)}</td>
+                        <td style="padding:2px 6px; text-align:right;">${fmtGold(0)}</td>
+                    </tr>`;
+        const gapNote =
+            mainCoverage < 0.999
+                ? `<div style="color:#c98; margin-top:4px; font-size:11px;">${formatPercentage(1 - mainCoverage, 1)} of the success-branch probability has no market price data and is treated as a 0-payout outcome (never inflated with a guess).</div>`
+                : '';
+
+        const bonusRows = breakdown.bonusDrops
+            .map(
+                (bonus) =>
+                    `<tr>
+                        <td style="padding:2px 6px;">${dataManager.getItemDetails(bonus.itemHrid)?.name || bonus.itemHrid}</td>
+                        <td style="padding:2px 6px; text-align:right;">${formatPercentage(bonus.dropRate, 2)}</td>
+                        <td style="padding:2px 6px; text-align:right;">${fmtGold(bonus.payout)}</td>
+                    </tr>`
+            )
+            .join('');
+        const bonusSection = breakdown.bonusDrops.length
+            ? this._wrapDetails(
+                  `Bonus drops (${breakdown.bonusDrops.length}, independent of success/fail)`,
+                  `<table style="width:100%; border-collapse:collapse; font-size:11px;">
+                        <tr style="color:#888;"><th style="text-align:left;">Item</th><th>Chance per attempt</th><th>Payout if hit</th></tr>
+                        ${bonusRows}
+                    </table>`,
+                  true
+              )
+            : '';
 
         return this._wrapDetails(
             'Cost & risk details',
             rows.join('') +
                 this._wrapDetails(
-                    `Output drops (${breakdown.dropRevenues.length} items)`,
+                    `Output drop table (${breakdown.mainBranches.length} branches, one roll given success)`,
                     `<table style="width:100%; border-collapse:collapse; font-size:11px;">
-                        <tr style="color:#888;"><th style="text-align:left;">Item</th><th>Drop rate</th><th>Price</th><th>EV given success</th></tr>
-                        ${dropRows}
-                        <tr style="border-top:1px solid #444; font-weight:600;">
-                            <td style="padding:2px 6px;" colspan="3">Total EV given success</td>
-                            <td style="padding:2px 6px; text-align:right;">${fmtGold(totalGivenSuccess)}</td>
-                        </tr>
-                    </table>`,
+                        <tr style="color:#888;"><th style="text-align:left;">Outcome</th><th>Chance per attempt</th><th>Payout if hit</th></tr>
+                        ${failRow}
+                        ${mainRows}
+                    </table>
+                    ${gapNote}`,
                     true
-                )
+                ) +
+                bonusSection
         );
     }
 

--- a/src/features/risk-of-ruin/risk-of-ruin-ui.js
+++ b/src/features/risk-of-ruin/risk-of-ruin-ui.js
@@ -69,6 +69,20 @@ class RiskOfRuinUI {
         this.dragOffset = { x: 0, y: 0 };
     }
 
+    /**
+     * Setup setting change listener (always active, even when feature is disabled) so toggling
+     * "Enable Risk of Ruin calculator" in Settings takes effect immediately, with no refresh.
+     */
+    setupSettingListener() {
+        config.onSettingChange('riskOfRuin', (enabled) => {
+            if (enabled) {
+                this.initialize();
+            } else {
+                this.disable();
+            }
+        });
+    }
+
     initialize() {
         if (this.isInitialized) return;
         if (!config.getSetting('riskOfRuin')) return;
@@ -745,4 +759,5 @@ class RiskOfRuinUI {
 }
 
 const riskOfRuinUI = new RiskOfRuinUI();
+riskOfRuinUI.setupSettingListener();
 export default riskOfRuinUI;

--- a/src/features/risk-of-ruin/risk-of-ruin-ui.test.js
+++ b/src/features/risk-of-ruin/risk-of-ruin-ui.test.js
@@ -1,0 +1,90 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    riskOfRuinEnabled: true,
+    settingChangeHandlers: {},
+}));
+
+vi.mock('../../core/config.js', () => ({
+    default: {
+        Z_FLOATING_PANEL: 1000,
+        getSetting: vi.fn((key) => (key === 'riskOfRuin' ? mocks.riskOfRuinEnabled : false)),
+        getSettingValue: vi.fn((_key, fallback) => fallback),
+        onSettingChange: vi.fn((key, callback) => {
+            mocks.settingChangeHandlers[key] = callback;
+        }),
+    },
+}));
+
+vi.mock('../../core/data-manager.js', () => ({
+    default: {
+        getInitClientData: vi.fn(() => ({ itemDetailMap: {} })),
+        getItemDetails: vi.fn(() => null),
+        getInventory: vi.fn(() => []),
+    },
+}));
+
+const { PANEL_ID, LAUNCHER_ID } = vi.hoisted(() => ({
+    PANEL_ID: 'mwi-risk-of-ruin-panel',
+    LAUNCHER_ID: 'mwi-risk-of-ruin-launcher',
+}));
+
+import config from '../../core/config.js';
+import riskOfRuinUI from './risk-of-ruin-ui.js';
+
+describe('RiskOfRuinUI feature toggle', () => {
+    beforeEach(() => {
+        mocks.riskOfRuinEnabled = true;
+        document.body.innerHTML = '';
+        riskOfRuinUI.disable();
+    });
+
+    afterEach(() => {
+        riskOfRuinUI.disable();
+    });
+
+    test('registers a live setting listener for the riskOfRuin toggle at module load', () => {
+        // setupSettingListener() runs once at module load (see the bottom of
+        // risk-of-ruin-ui.js), before any test body executes, so by the time this test runs
+        // the handler must already be registered - proving the toggle is wired up live, not
+        // just read once at startup (which previously required a page refresh to take effect).
+        expect(config.onSettingChange).toHaveBeenCalledWith('riskOfRuin', expect.any(Function));
+        expect(mocks.settingChangeHandlers.riskOfRuin).toBeTypeOf('function');
+    });
+
+    test('initialize() is a no-op when the riskOfRuin setting is disabled', () => {
+        mocks.riskOfRuinEnabled = false;
+        riskOfRuinUI.initialize();
+
+        expect(document.getElementById(PANEL_ID)).toBeNull();
+        expect(document.getElementById(LAUNCHER_ID)).toBeNull();
+    });
+
+    test('toggling the riskOfRuin setting off removes the panel and launcher with no refresh', () => {
+        riskOfRuinUI.initialize();
+        expect(document.getElementById(PANEL_ID)).not.toBeNull();
+        expect(document.getElementById(LAUNCHER_ID)).not.toBeNull();
+
+        // Simulate the settings panel checkbox being unchecked.
+        mocks.settingChangeHandlers.riskOfRuin(false);
+
+        expect(document.getElementById(PANEL_ID)).toBeNull();
+        expect(document.getElementById(LAUNCHER_ID)).toBeNull();
+    });
+
+    test('toggling the riskOfRuin setting back on rebuilds the panel and launcher', () => {
+        riskOfRuinUI.initialize();
+        mocks.settingChangeHandlers.riskOfRuin(false);
+        expect(document.getElementById(LAUNCHER_ID)).toBeNull();
+
+        // Simulate the checkbox being re-checked - this is the live listener's other branch,
+        // not feature-registry's own startup pass, which never re-runs mid-session.
+        mocks.riskOfRuinEnabled = true;
+        mocks.settingChangeHandlers.riskOfRuin(true);
+
+        expect(document.getElementById(PANEL_ID)).not.toBeNull();
+        expect(document.getElementById(LAUNCHER_ID)).not.toBeNull();
+    });
+});

--- a/src/utils/risk-of-ruin-adapters/alchemy-adapter.js
+++ b/src/utils/risk-of-ruin-adapters/alchemy-adapter.js
@@ -1,30 +1,118 @@
 /**
  * Alchemy Transmute Risk-of-Ruin Adapter
  *
- * Builds a two-outcome-per-attempt cost/payout model for a Transmute action, from
+ * Builds the exact per-attempt cost/payout model for a Transmute action, from
  * alchemyProfitCalculator.calculateTransmuteProfit() — the same per-attempt economics
  * (material cost net of self-return, catalyst cost, output drop-table EV, success rate) the
  * live action panel and best-item ranking already use, not a re-derived approximation.
  *
- * Catalyst is consumed only on success (per alchemy-profit-display.js's own label: "consumed
- * only on success"), so it is charged only in the success branch. Materials — including any
- * direct coin cost — are consumed on every attempt regardless of outcome.
+ * A real transmute's output drop table (itemDetails.alchemyDetail.transmuteDropTable) is a
+ * MUTUALLY EXCLUSIVE categorical roll GIVEN success — its dropRates sum to exactly 1.0 (e.g.
+ * Sunstone: 25% star fragment, 30% moonstone, 44.9% self-return, 0.1% philosopher's stone,
+ * confirmed against the live game reference data). Collapsing that into one blended "average
+ * success value" would discard exactly the variance a risk calculator needs — a 0.1% chance of
+ * a huge hit is a very different risk shape than its smoothed mean — so every branch is kept as
+ * its own separate outcome. Every transmutable item's drop table has at most a few (2-10 in
+ * practice) branches, so the exact cross product with the independent essence/rare bonus-drop
+ * layer (below) is always small; no sampling is needed here, unlike the chest adapter.
  *
- * calculateTransmuteProfit() itself blends the success/fail split together into hourly EVs
- * (e.g. catalystCostPerHour, selfReturnValue are already scaled by successRate). This adapter
- * un-blends those back into the two discrete branches a single attempt can land in, using only
- * the function's public return fields — no private internals are touched.
+ * Alongside that categorical roll, calculateTransmuteProfit() also reports two bonus drops
+ * (Alchemy Essence, an Artisan's Crate) that are independent per-attempt Bernoulli events
+ * occurring regardless of whether the transmute itself succeeds or fails ("not affected by
+ * success rate" — see alchemy-profit-display.js and calculateAlchemyBonusDrops()'s own
+ * actionsPerHour-based, successRate-independent rate calculation).
+ *
+ * Catalyst is consumed only on success (per alchemy-profit-display.js's own label: "consumed
+ * only on success"), so it is charged on every success branch, never on failure. Materials —
+ * including any direct coin cost — are consumed on every attempt regardless of outcome.
  */
 
 import alchemyProfitCalculator from '../../features/market/alchemy-profit-calculator.js';
 import { drawFromDistribution } from '../risk-of-ruin-engine.js';
 
 /**
- * Build the two-outcome risk-of-ruin model for repeatedly Transmuting one item.
+ * Recover the per-occurrence payout for one categorical drop-table branch (excluding the
+ * essence/rare bonus layer, handled separately), un-scaling calculateTransmuteProfit()'s
+ * successRate-blended revenuePerAttempt/selfReturnValue fields back to "value if this branch
+ * is the one that happens".
+ */
+function mainBranchPayout(drop, profit) {
+    if (drop.dropRate <= 0) return 0;
+    if (drop.isSelfReturn) {
+        // selfReturnValue = inputPrice * selfReturnRate(=drop.dropRate) * successRate * selfReturnCount
+        return profit.selfReturnValue / (profit.successRate * drop.dropRate);
+    }
+    // revenuePerAttempt = (afterTaxPrice * avgCount * bulkMultiplier) * dropRate * successRate
+    return drop.revenuePerAttempt / (profit.successRate * drop.dropRate);
+}
+
+/**
+ * Build the exact per-attempt outcome distribution: failure, plus one branch per categorical
+ * drop-table entry (each independently crossed with the essence/rare bonus-drop Bernoulli
+ * layer, since that layer applies regardless of success/failure).
+ * @returns {Array<{prob: number, net: number}>}
+ */
+function buildOutcomeDistribution(profit, attemptCost, catalystCostOnSuccess) {
+    const dropRevenues = profit.dropRevenues || [];
+    const mainDrops = dropRevenues.filter((d) => !d.isEssence && !d.isRare);
+    const bonusDrops = dropRevenues.filter((d) => d.isEssence || d.isRare);
+
+    const mainBranches = [{ prob: 1 - profit.successRate, payout: 0, isSuccess: false }];
+    let coveredDropRate = 0;
+    for (const drop of mainDrops) {
+        if (!(drop.dropRate > 0)) continue;
+        coveredDropRate += drop.dropRate;
+        mainBranches.push({
+            prob: profit.successRate * drop.dropRate,
+            payout: mainBranchPayout(drop, profit),
+            isSuccess: true,
+        });
+    }
+    // A drop-table entry the calculator couldn't price (getItemPrice returned null) is silently
+    // dropped upstream, leaving a gap in dropRate coverage. Fold that residual probability mass
+    // into a zero-payout branch rather than losing it — conservative (never invents a value),
+    // and keeps probabilities summing to exactly 1.
+    const residualDropRate = Math.max(0, 1 - coveredDropRate);
+    if (residualDropRate > 0) {
+        mainBranches.push({ prob: profit.successRate * residualDropRate, payout: 0, isSuccess: true });
+    }
+
+    // Essence/rare bonus drops are independent per-attempt Bernoulli events, unaffected by
+    // success/failure - cross every combination of them into its own outcome.
+    let bonusOutcomes = [{ prob: 1, payout: 0 }];
+    for (const bonus of bonusDrops) {
+        if (!(bonus.dropRate > 0)) continue;
+        const hitPayout = bonus.revenuePerAttempt / bonus.dropRate;
+        const next = [];
+        for (const outcome of bonusOutcomes) {
+            next.push({ prob: outcome.prob * (1 - bonus.dropRate), payout: outcome.payout });
+            next.push({ prob: outcome.prob * bonus.dropRate, payout: outcome.payout + hitPayout });
+        }
+        bonusOutcomes = next;
+    }
+
+    const outcomeDistribution = [];
+    for (const main of mainBranches) {
+        const cost = attemptCost + (main.isSuccess ? catalystCostOnSuccess : 0);
+        for (const bonus of bonusOutcomes) {
+            const prob = main.prob * bonus.prob;
+            if (prob <= 0) continue;
+            outcomeDistribution.push({ prob, net: -cost + main.payout + bonus.payout });
+        }
+    }
+
+    return outcomeDistribution;
+}
+
+/**
+ * Build the exact per-attempt risk-of-ruin model for repeatedly Transmuting one item.
  * @param {string} itemHrid - Item being transmuted.
  * @param {Object} [options]
  * @param {boolean} [options.useLiveSetup] - Use the currently-open action panel's live
- *   catalyst/tea selection instead of the automatically-best combination.
+ *   catalyst/tea selection instead of the automatically-best combination. Ignored when
+ *   catalystChoice is given.
+ * @param {'none'|'typeSpecific'|'prime'|null} [options.catalystChoice] - Force a specific
+ *   catalyst instead of searching for the best one or reading the live panel.
  * @returns {{
  *   cost: number,
  *   maxSinglePossibleLoss: number,
@@ -36,35 +124,40 @@ import { drawFromDistribution } from '../risk-of-ruin-engine.js';
  *     coinCost: number,
  *     catalystHrid: string|null,
  *     catalystCostOnSuccess: number,
- *     outputValueGivenSuccess: number,
- *     selfReturnGivenSuccess: number,
- *     netOnSuccess: number,
  *     netOnFail: number,
- *     dropRevenues: Array,
+ *     mainBranches: Array<{itemHrid: string, dropRate: number, payout: number, isSelfReturn: boolean}>,
+ *     bonusDrops: Array<{itemHrid: string, dropRate: number, payout: number}>,
  *   },
  * }|null} null if the item isn't transmutable or has no usable market/success-rate data.
  */
-export function buildAlchemyTransmuteModel(itemHrid, { useLiveSetup = false } = {}) {
-    const profit = alchemyProfitCalculator.calculateTransmuteProfit(itemHrid, useLiveSetup);
+export function buildAlchemyTransmuteModel(itemHrid, { useLiveSetup = false, catalystChoice = null } = {}) {
+    const profit = alchemyProfitCalculator.calculateTransmuteProfit(itemHrid, useLiveSetup, null, catalystChoice);
     if (!profit || !(profit.successRate > 0)) return null;
 
     const coinCost = profit.requirementCosts.find((r) => r.itemHrid === '/items/coin')?.costPerAction ?? 0;
     const attemptCost = profit.grossMaterialCost + coinCost;
     const catalystCostOnSuccess = profit.catalystPrice || 0;
-    const outputValueGivenSuccess = profit.incomePerAttempt / profit.successRate;
-    const selfReturnGivenSuccess = profit.selfReturnValue / profit.successRate;
-
-    const netOnSuccess = -attemptCost - catalystCostOnSuccess + outputValueGivenSuccess + selfReturnGivenSuccess;
     const netOnFail = -attemptCost;
 
-    const outcomeDistribution = [
-        { prob: profit.successRate, net: netOnSuccess },
-        { prob: 1 - profit.successRate, net: netOnFail },
-    ];
+    const outcomeDistribution = buildOutcomeDistribution(profit, attemptCost, catalystCostOnSuccess);
+    const maxSinglePossibleLoss = Math.max(0, ...outcomeDistribution.map((o) => -o.net));
+
+    const dropRevenues = profit.dropRevenues || [];
+    const mainBranches = dropRevenues
+        .filter((d) => !d.isEssence && !d.isRare && d.dropRate > 0)
+        .map((d) => ({
+            itemHrid: d.itemHrid,
+            dropRate: d.dropRate,
+            payout: mainBranchPayout(d, profit),
+            isSelfReturn: d.isSelfReturn || false,
+        }));
+    const bonusDrops = dropRevenues
+        .filter((d) => (d.isEssence || d.isRare) && d.dropRate > 0)
+        .map((d) => ({ itemHrid: d.itemHrid, dropRate: d.dropRate, payout: d.revenuePerAttempt / d.dropRate }));
 
     return {
         cost: attemptCost,
-        maxSinglePossibleLoss: Math.max(0, -netOnSuccess, -netOnFail),
+        maxSinglePossibleLoss,
         outcomeDistribution,
         stepFn: (state, rng) => ({ balance: state.balance + drawFromDistribution(outcomeDistribution, rng).net }),
         breakdown: {
@@ -73,11 +166,9 @@ export function buildAlchemyTransmuteModel(itemHrid, { useLiveSetup = false } = 
             coinCost,
             catalystHrid: profit.catalystPrice ? profit.catalystCost?.itemHrid || null : null,
             catalystCostOnSuccess,
-            outputValueGivenSuccess,
-            selfReturnGivenSuccess,
-            netOnSuccess,
             netOnFail,
-            dropRevenues: profit.dropRevenues || [],
+            mainBranches,
+            bonusDrops,
         },
     };
 }

--- a/src/utils/risk-of-ruin-adapters/alchemy-adapter.test.js
+++ b/src/utils/risk-of-ruin-adapters/alchemy-adapter.test.js
@@ -1,9 +1,10 @@
 import { describe, expect, test, vi } from 'vitest';
 
 let mockProfit = null;
+const calculateTransmuteProfit = vi.fn(() => mockProfit);
 
 vi.mock('../../features/market/alchemy-profit-calculator.js', () => ({
-    default: { calculateTransmuteProfit: () => mockProfit },
+    default: { calculateTransmuteProfit: (...args) => calculateTransmuteProfit(...args) },
 }));
 
 const { buildAlchemyTransmuteModel } = await import('./alchemy-adapter.js');
@@ -14,10 +15,13 @@ function baseProfit(overrides = {}) {
         grossMaterialCost: 1000,
         requirementCosts: [],
         catalystPrice: 0,
-        incomePerAttempt: 300, // expectedOutputValue(600) * successRate(0.5)
-        selfReturnValue: 0,
+        dropRevenues: [],
         ...overrides,
     };
+}
+
+function sortByNet(outcomes) {
+    return [...outcomes].sort((a, b) => a.net - b.net);
 }
 
 describe('buildAlchemyTransmuteModel', () => {
@@ -31,84 +35,210 @@ describe('buildAlchemyTransmuteModel', () => {
         expect(buildAlchemyTransmuteModel('/items/impossible')).toBeNull();
     });
 
-    test('splits into a success/fail two-outcome distribution with materials lost on both', () => {
-        mockProfit = baseProfit();
+    test('keeps each categorical drop-table branch as its own outcome instead of averaging them', () => {
+        // Mirrors the real Sunstone shape: two mutually-exclusive success branches (a priced
+        // output and a self-return), not a single blended "success value".
+        mockProfit = baseProfit({
+            successRate: 0.5,
+            dropRevenues: [
+                // payout = revenuePerAttempt / (successRate * dropRate) = 150 / (0.5*0.6) = 500
+                { itemHrid: '/items/output_a', dropRate: 0.6, revenuePerAttempt: 150, isEssence: false, isRare: false },
+            ],
+        });
+        // Add the self-return branch via a second call shape below instead (selfReturnValue is
+        // a top-level profit field, not part of dropRevenues' revenuePerAttempt for that entry).
+        mockProfit.dropRevenues.push({
+            itemHrid: '/items/widget',
+            dropRate: 0.4,
+            revenuePerAttempt: 0,
+            isEssence: false,
+            isRare: false,
+            isSelfReturn: true,
+        });
+        mockProfit.selfReturnValue = 40; // payout = 40 / (0.5*0.4) = 200
+
         const model = buildAlchemyTransmuteModel('/items/widget');
 
         expect(model.cost).toBe(1000);
-        expect(model.outcomeDistribution).toEqual([
-            { prob: 0.5, net: -1000 + 600 }, // success: -materials + output value given success
-            { prob: 0.5, net: -1000 }, // failure: -materials only
+        const outcomes = sortByNet(model.outcomeDistribution);
+        expect(outcomes).toEqual([
+            { prob: 0.5, net: -1000 }, // failure
+            { prob: 0.2, net: -1000 + 200 }, // success -> self-return (0.5 * 0.4)
+            { prob: 0.3, net: -1000 + 500 }, // success -> output_a (0.5 * 0.6)
+        ]);
+        const totalProb = model.outcomeDistribution.reduce((sum, o) => sum + o.prob, 0);
+        expect(totalProb).toBeCloseTo(1, 10);
+    });
+
+    test('folds unpriced drop-table coverage gaps into a zero-payout branch rather than dropping probability mass', () => {
+        // Only 70% of the categorical space is priced/represented; the other 30% must still
+        // sum to 1 overall, contributing 0 extra payout (never invents a value for it).
+        mockProfit = baseProfit({
+            successRate: 0.5,
+            dropRevenues: [
+                { itemHrid: '/items/output_a', dropRate: 0.7, revenuePerAttempt: 175, isEssence: false, isRare: false },
+            ],
+        });
+
+        const model = buildAlchemyTransmuteModel('/items/widget');
+        const totalProb = model.outcomeDistribution.reduce((sum, o) => sum + o.prob, 0);
+        expect(totalProb).toBeCloseTo(1, 10);
+
+        const residual = model.outcomeDistribution.find((o) => Math.abs(o.prob - 0.5 * 0.3) < 1e-9);
+        expect(residual).toBeDefined();
+        expect(residual.net).toBe(-1000); // 0 extra payout for the unpriced residual
+    });
+
+    test('crosses independent essence/rare bonus drops with every main branch (unaffected by success/fail)', () => {
+        mockProfit = baseProfit({
+            successRate: 0.5,
+            dropRevenues: [
+                { itemHrid: '/items/output_a', dropRate: 1, revenuePerAttempt: 250, isEssence: false, isRare: false },
+                {
+                    itemHrid: '/items/alchemy_essence',
+                    dropRate: 0.5,
+                    revenuePerAttempt: 100,
+                    isEssence: true,
+                    isRare: false,
+                },
+            ],
+        });
+
+        const model = buildAlchemyTransmuteModel('/items/widget');
+        const outcomes = sortByNet(model.outcomeDistribution);
+
+        expect(outcomes).toEqual([
+            { prob: 0.25, net: -1000 }, // fail, no essence
+            { prob: 0.25, net: -1000 + 200 }, // fail, essence hit (payout 100/0.5=200)
+            { prob: 0.25, net: -1000 + 500 }, // success, no essence
+            { prob: 0.25, net: -1000 + 500 + 200 }, // success, essence hit
         ]);
     });
 
-    test('includes a direct coin line item in the per-attempt cost charged on both branches', () => {
-        mockProfit = baseProfit({ requirementCosts: [{ itemHrid: '/items/coin', costPerAction: 50 }] });
-        const model = buildAlchemyTransmuteModel('/items/widget');
+    test('charges catalyst cost only on success branches, never on failure', () => {
+        mockProfit = baseProfit({
+            successRate: 0.5,
+            catalystPrice: 300,
+            catalystCost: { itemHrid: '/items/prime_catalyst' },
+            dropRevenues: [
+                { itemHrid: '/items/output_a', dropRate: 1, revenuePerAttempt: 250, isEssence: false, isRare: false },
+            ],
+        });
 
+        const model = buildAlchemyTransmuteModel('/items/widget');
+        const [failOutcome, successOutcome] = sortByNet(model.outcomeDistribution);
+
+        expect(failOutcome.net).toBe(-1000); // no catalyst
+        expect(successOutcome.net).toBe(-1000 - 300 + 500); // catalyst charged
+    });
+
+    test('includes a direct coin line item in the per-attempt cost charged on every branch', () => {
+        mockProfit = baseProfit({
+            successRate: 0.5,
+            requirementCosts: [{ itemHrid: '/items/coin', costPerAction: 50 }],
+            dropRevenues: [
+                { itemHrid: '/items/output_a', dropRate: 1, revenuePerAttempt: 250, isEssence: false, isRare: false },
+            ],
+        });
+
+        const model = buildAlchemyTransmuteModel('/items/widget');
         expect(model.cost).toBe(1050);
-        expect(model.outcomeDistribution[0].net).toBe(-1050 + 600);
-        expect(model.outcomeDistribution[1].net).toBe(-1050);
+        const [failOutcome, successOutcome] = sortByNet(model.outcomeDistribution);
+        expect(failOutcome.net).toBe(-1050);
+        expect(successOutcome.net).toBe(-1050 + 500);
     });
 
-    test('charges catalyst cost only on the success branch', () => {
-        mockProfit = baseProfit({ catalystPrice: 200 });
+    test('maxSinglePossibleLoss is the worst branch across the full distribution, not just fail', () => {
+        // An expensive catalyst with a tiny output can make a success branch worse than failure.
+        mockProfit = baseProfit({
+            successRate: 0.5,
+            catalystPrice: 5000,
+            dropRevenues: [
+                { itemHrid: '/items/output_a', dropRate: 1, revenuePerAttempt: 5, isEssence: false, isRare: false },
+            ],
+        });
+
         const model = buildAlchemyTransmuteModel('/items/widget');
-
-        expect(model.outcomeDistribution[0].net).toBe(-1000 - 200 + 600); // success pays catalyst
-        expect(model.outcomeDistribution[1].net).toBe(-1000); // failure does not
-    });
-
-    test('un-blends the hourly-scaled self-return value back to a given-success amount', () => {
-        // selfReturnValue is already successRate-scaled by the real calculator: 0.4 * 100 = 40
-        mockProfit = baseProfit({ successRate: 0.4, incomePerAttempt: 240, selfReturnValue: 40 });
-        const model = buildAlchemyTransmuteModel('/items/widget');
-
-        // outputValueGivenSuccess = 240 / 0.4 = 600; selfReturnGivenSuccess = 40 / 0.4 = 100
-        expect(model.outcomeDistribution[0].net).toBeCloseTo(-1000 + 600 + 100, 6);
-    });
-
-    test('maxSinglePossibleLoss is the worst-case branch even when the success branch is the bigger loss', () => {
-        // Expensive catalyst with a tiny output value makes success worse than failure.
-        mockProfit = baseProfit({ catalystPrice: 5000, incomePerAttempt: 5 });
-        const model = buildAlchemyTransmuteModel('/items/widget');
-
-        const [successOutcome, failOutcome] = model.outcomeDistribution;
-        expect(-successOutcome.net).toBeGreaterThan(-failOutcome.net);
+        const successOutcome = model.outcomeDistribution.find((o) => o.net < -1000);
+        expect(-successOutcome.net).toBeGreaterThan(1000);
         expect(model.maxSinglePossibleLoss).toBeCloseTo(-successOutcome.net, 6);
     });
 
-    test('stepFn resolves via the outcome distribution using the supplied rng', () => {
-        mockProfit = baseProfit();
+    test('stepFn resolves via drawFromDistribution using the supplied rng', () => {
+        mockProfit = baseProfit({
+            successRate: 0.5,
+            dropRevenues: [
+                { itemHrid: '/items/output_a', dropRate: 1, revenuePerAttempt: 250, isEssence: false, isRare: false },
+            ],
+        });
         const model = buildAlchemyTransmuteModel('/items/widget');
 
-        const successState = model.stepFn({ balance: 10000 }, () => 0);
-        expect(successState.balance).toBe(10000 - 1000 + 600);
-
-        const failState = model.stepFn({ balance: 10000 }, () => 0.99);
+        const failState = model.stepFn({ balance: 10000 }, () => 0);
         expect(failState.balance).toBe(10000 - 1000);
+
+        const successState = model.stepFn({ balance: 10000 }, () => 0.99);
+        expect(successState.balance).toBe(10000 - 1000 + 500);
     });
 
-    test('exposes a breakdown with the individual cost/payout components for a details UI', () => {
+    test('breakdown exposes per-branch payouts for a details UI, excluding zero-drop-rate rows', () => {
         mockProfit = baseProfit({
-            catalystPrice: 200,
+            successRate: 0.5,
+            catalystPrice: 300,
             catalystCost: { itemHrid: '/items/prime_catalyst' },
             requirementCosts: [{ itemHrid: '/items/coin', costPerAction: 50 }],
-            dropRevenues: [{ itemHrid: '/items/output_item', revenuePerAttempt: 600 }],
+            dropRevenues: [
+                { itemHrid: '/items/output_a', dropRate: 0.6, revenuePerAttempt: 150, isEssence: false, isRare: false },
+                {
+                    itemHrid: '/items/widget',
+                    dropRate: 0.4,
+                    revenuePerAttempt: 0,
+                    isEssence: false,
+                    isRare: false,
+                    isSelfReturn: true,
+                },
+                {
+                    itemHrid: '/items/alchemy_essence',
+                    dropRate: 0.5,
+                    revenuePerAttempt: 100,
+                    isEssence: true,
+                    isRare: false,
+                },
+                {
+                    itemHrid: '/items/large_artisans_crate',
+                    dropRate: 0,
+                    revenuePerAttempt: 0,
+                    isEssence: false,
+                    isRare: true,
+                },
+            ],
+            selfReturnValue: 40,
         });
+
         const model = buildAlchemyTransmuteModel('/items/widget');
 
-        expect(model.breakdown).toEqual({
-            successRate: 0.5,
-            materialCost: 1000,
-            coinCost: 50,
-            catalystHrid: '/items/prime_catalyst',
-            catalystCostOnSuccess: 200,
-            outputValueGivenSuccess: 600,
-            selfReturnGivenSuccess: 0,
-            netOnSuccess: -1000 - 50 - 200 + 600,
-            netOnFail: -1050,
-            dropRevenues: [{ itemHrid: '/items/output_item', revenuePerAttempt: 600 }],
-        });
+        expect(model.breakdown.successRate).toBe(0.5);
+        expect(model.breakdown.materialCost).toBe(1000);
+        expect(model.breakdown.coinCost).toBe(50);
+        expect(model.breakdown.catalystHrid).toBe('/items/prime_catalyst');
+        expect(model.breakdown.catalystCostOnSuccess).toBe(300);
+        expect(model.breakdown.netOnFail).toBe(-1050);
+
+        expect(model.breakdown.mainBranches).toEqual([
+            { itemHrid: '/items/output_a', dropRate: 0.6, payout: 500, isSelfReturn: false },
+            { itemHrid: '/items/widget', dropRate: 0.4, payout: 200, isSelfReturn: true },
+        ]);
+        // The 0-drop-rate crate row is excluded, not shown as a misleading "0% chance" line.
+        expect(model.breakdown.bonusDrops).toEqual([
+            { itemHrid: '/items/alchemy_essence', dropRate: 0.5, payout: 200 },
+        ]);
+    });
+
+    test('forwards catalystChoice through to calculateTransmuteProfit', () => {
+        mockProfit = baseProfit({ dropRevenues: [] });
+        calculateTransmuteProfit.mockClear();
+
+        buildAlchemyTransmuteModel('/items/widget', { catalystChoice: 'prime' });
+
+        expect(calculateTransmuteProfit).toHaveBeenCalledWith('/items/widget', false, null, 'prime');
     });
 });


### PR DESCRIPTION
## Summary

Three fixes bundled here to keep this to a single PR/merge:

* fix: model each Transmute output branch separately, add catalyst selector, drop Lundberg bound

  The alchemy transmute output drop table is a mutually-exclusive categorical roll given
  success (dropRates sum to 1.0), not independent per-item drops. Averaging it into one blended
  value erased exactly the tail risk a risk-of-ruin tool needs (e.g. Sunstone's 0.1% chance of
  a 9.8M-gold philosopher's stone hit). Rebuilt the alchemy adapter to enumerate every branch
  exactly, crossed with the independent essence/rare bonus-drop layer.

  Also adds a catalyst selector (best / none / type-specific / prime) to the alchemy mode, and
  removes the Lundberg upper-bound display (kept the underlying engine function) since it read
  as confusing added text without clear value.

* fix: turning off Risk of Ruin required a page refresh to take effect

  Registers a live `config.onSettingChange('riskOfRuin', ...)` listener at module load, matching
  the pattern used by other toggleable features (drink-timer, queue-monitor), so unchecking the
  setting removes the panel/launcher immediately instead of requiring a reload.

  (The two fixes above were approved and tested during the same session as PR #641, but got
  pushed to that branch after it had already been merged - GitHub doesn't fold post-merge
  commits into a closed PR, so they never actually shipped. This PR lands them properly.)

* fix: auto-click-max scoped only to the price row, not quantity, in Sell dialogs

  The recent marketplace update added a tradable-range price row (Min/-/+/Max) ahead of the
  quantity row (1/Max) in the Sell Listing dialog's DOM order. The feature's modal-wide "first
  button matching Max/All" search grabbed the price row's Max instead, setting price to the top
  of the tradable range (non-competitive, confirmed against a live DOM/React snapshot) and
  leaving the quantity row's Max unclicked - which is why quantity wasn't ending up at the
  player's full inventory count. Scoped the search to the quantity row's container, matching
  auto-fill-price.js's own container-scoping for the price row.

## Test plan

- [x] `npm test` - 740 tests passed (69 files)
- [x] `npm run lint` - clean
- [x] `npm run format -- --check` - clean
- [x] `npm run build:dev` / `npm run build` - both succeed, all bundles under the 2MB CI limit
- [ ] Manual in-game verification of the auto-click-max fix on a live Sell Listing dialog

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>