### PR TITLE
fix: refresh queue-aware production panel displays on actions_updated

### DIFF
--- a/src/features/actions/cost-summary.js
+++ b/src/features/actions/cost-summary.js
@@ -8,7 +8,12 @@
 import config from '../../core/config.js';
 import dataManager from '../../core/data-manager.js';
 import domObserver from '../../core/dom-observer.js';
-import { findActionInput, attachInputListeners, performInitialUpdate } from '../../utils/action-panel-helper.js';
+import {
+    findActionInput,
+    attachInputListeners,
+    performInitialUpdate,
+    refreshActionPanels,
+} from '../../utils/action-panel-helper.js';
 import { calculateMaterialRequirements } from '../../utils/material-calculator.js';
 import { getItemPrice, formatPrice } from '../../utils/market-data.js';
 import { computeBestCraftingPlan } from '../../features/crafting-plan/crafting-plan-calculator.js';
@@ -27,11 +32,22 @@ const PRODUCTION_TYPES = [
 
 let domObserverUnregister = null;
 let processedPanels = new WeakSet();
+let actionsUpdatedHandler = null;
 
 export function initialize() {
     domObserverUnregister = domObserver.onClass('CostSummary-ActionPanel', 'SkillActionDetail_skillActionDetail', () =>
         processActionPanels()
     );
+
+    // Refresh Missing direct mats when the finite action queue changes (add/remove), since the
+    // calculation reads dataManager.getCurrentActions() but nothing else invalidates an
+    // already-rendered panel.
+    if (actionsUpdatedHandler) {
+        dataManager.off('actions_updated', actionsUpdatedHandler);
+    }
+    actionsUpdatedHandler = () => refreshActionPanels((panel, value) => updatePanel(panel, value));
+    dataManager.on('actions_updated', actionsUpdatedHandler);
+
     processActionPanels();
 }
 
@@ -39,6 +55,10 @@ export function cleanup() {
     if (domObserverUnregister) {
         domObserverUnregister();
         domObserverUnregister = null;
+    }
+    if (actionsUpdatedHandler) {
+        dataManager.off('actions_updated', actionsUpdatedHandler);
+        actionsUpdatedHandler = null;
     }
     document.querySelectorAll(`#${UI_ID}`).forEach((el) => el.remove());
     processedPanels = new WeakSet();

--- a/src/features/actions/cost-summary.test.js
+++ b/src/features/actions/cost-summary.test.js
@@ -1,30 +1,45 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-const { mockGetItemPrice, mockComputeBestCraftingPlan, mockCalculateMaterialRequirements } = vi.hoisted(() => ({
-    mockGetItemPrice: vi.fn(),
-    mockComputeBestCraftingPlan: vi.fn(),
-    mockCalculateMaterialRequirements: vi.fn(),
-}));
+const { mockGetItemPrice, mockComputeBestCraftingPlan, mockCalculateMaterialRequirements, fakeDataManager } =
+    vi.hoisted(() => {
+        const listeners = new Map();
+        return {
+            mockGetItemPrice: vi.fn(),
+            mockComputeBestCraftingPlan: vi.fn(),
+            mockCalculateMaterialRequirements: vi.fn(),
+            fakeDataManager: {
+                on: (event, handler) => {
+                    if (!listeners.has(event)) listeners.set(event, new Set());
+                    listeners.get(event).add(handler);
+                },
+                off: (event, handler) => {
+                    listeners.get(event)?.delete(handler);
+                },
+                emit: (event, data) => {
+                    for (const handler of Array.from(listeners.get(event) || [])) handler(data);
+                },
+                listenerCount: (event) => listeners.get(event)?.size || 0,
+                getInitClientData: vi.fn(() => null),
+            },
+        };
+    });
 
 vi.mock('../../core/config.js', () => ({
     default: { getSetting: vi.fn(() => true) },
 }));
 
-vi.mock('../../core/data-manager.js', () => ({
-    default: { getInitClientData: vi.fn(() => null) },
-}));
+vi.mock('../../core/data-manager.js', () => ({ default: fakeDataManager }));
 
 vi.mock('../../core/dom-observer.js', () => ({
     default: { onClass: vi.fn(() => vi.fn()) },
 }));
 
-vi.mock('../../utils/action-panel-helper.js', () => ({
-    findActionInput: vi.fn(),
-    attachInputListeners: vi.fn(),
-    performInitialUpdate: vi.fn(),
-}));
+vi.mock('../../utils/action-panel-helper.js', async () => {
+    const actual = await vi.importActual('../../utils/action-panel-helper.js');
+    return actual;
+});
 
 vi.mock('../../utils/material-calculator.js', () => ({
     calculateMaterialRequirements: mockCalculateMaterialRequirements,
@@ -40,10 +55,10 @@ vi.mock('../../features/crafting-plan/crafting-plan-calculator.js', () => ({
 }));
 
 vi.mock('../../utils/game-lookups.js', () => ({
-    getActionHridFromName: vi.fn(),
+    getActionHridFromName: vi.fn(() => '/actions/crafting/sword'),
 }));
 
-import { buildBlock, renderBlock } from './cost-summary.js';
+import costSummary, { buildBlock, renderBlock } from './cost-summary.js';
 
 function readRows(block) {
     return Array.from(block.children)
@@ -145,5 +160,73 @@ describe('cost-summary', () => {
         expect(rows[1]).toEqual(['Missing direct mats', '—']);
         expect(mockGetItemPrice).toHaveBeenCalledWith('/items/unpriced', { mode: 'ask', side: 'buy' });
         expect(mockGetItemPrice).toHaveBeenCalledWith('/items/output', { mode: 'ask', side: 'buy' });
+    });
+});
+
+function buildPanel(inputValue) {
+    document.body.innerHTML = `
+        <div class="SkillActionDetail_skillActionDetail_abc">
+            <div class="SkillActionDetail_name_xyz">Craft Sword</div>
+            <div class="maxActionCountInput_123"><input value="${inputValue}" /></div>
+        </div>
+    `;
+    return document.querySelector('.SkillActionDetail_skillActionDetail_abc');
+}
+
+describe('cost-summary — queue-change refresh', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        mockGetItemPrice.mockReset();
+        mockComputeBestCraftingPlan.mockReset();
+        mockCalculateMaterialRequirements.mockReset();
+        mockGetItemPrice.mockReturnValue(5);
+        fakeDataManager.getInitClientData.mockReturnValue({
+            actionDetailMap: {
+                '/actions/crafting/sword': {
+                    type: '/action_types/crafting',
+                    inputItems: [{ itemHrid: '/items/log', count: 1 }],
+                    outputItems: [],
+                },
+            },
+        });
+    });
+
+    afterEach(() => {
+        costSummary.cleanup();
+        document.body.innerHTML = '';
+    });
+
+    test('Missing direct mats refreshes when the finite action queue changes', () => {
+        mockCalculateMaterialRequirements.mockReturnValue([
+            { itemHrid: '/items/log', required: 10, missing: 0, isTradeable: true },
+        ]);
+
+        buildPanel('5');
+        costSummary.initialize();
+
+        let rows = readRows(document.querySelector('#mwi-cost-summary'));
+        expect(rows[1]).toEqual(['Missing direct mats', '0']);
+
+        mockCalculateMaterialRequirements.mockReturnValue([
+            { itemHrid: '/items/log', required: 10, missing: 4, isTradeable: true },
+        ]);
+        fakeDataManager.emit('actions_updated', { endCharacterActions: [] });
+
+        rows = readRows(document.querySelector('#mwi-cost-summary'));
+        expect(rows[1]).toEqual(['Missing direct mats', '20']);
+    });
+
+    test('initialize -> cleanup -> initialize registers exactly one actions_updated listener', () => {
+        mockCalculateMaterialRequirements.mockReturnValue([
+            { itemHrid: '/items/log', required: 10, missing: 0, isTradeable: true },
+        ]);
+
+        buildPanel('5');
+        costSummary.initialize();
+        costSummary.cleanup();
+        buildPanel('5');
+        costSummary.initialize();
+
+        expect(fakeDataManager.listenerCount('actions_updated')).toBe(1);
     });
 });

--- a/src/features/actions/missing-materials-button.js
+++ b/src/features/actions/missing-materials-button.js
@@ -7,7 +7,12 @@ import dataManager from '../../core/data-manager.js';
 import config from '../../core/config.js';
 import domObserver from '../../core/dom-observer.js';
 import { marketplaceSession, MARKETPLACE_OWNER } from '../../core/marketplace-session.js';
-import { findActionInput, attachInputListeners, performInitialUpdate } from '../../utils/action-panel-helper.js';
+import {
+    findActionInput,
+    attachInputListeners,
+    performInitialUpdate,
+    refreshActionPanels,
+} from '../../utils/action-panel-helper.js';
 import {
     calculateMaterialRequirements,
     calculateEnhancementMaterialRequirements,
@@ -50,6 +55,7 @@ let inventoryUpdateHandler = null;
 let activeWorkflowModel = null;
 let actionsSessionId = null;
 let enhancingReturnGeneration = 0;
+let actionsUpdatedHandler = null;
 const timerRegistry = createTimerRegistry();
 const autofillManager = createAutofillManager('MissingMats-Actions');
 
@@ -89,6 +95,15 @@ export function initialize() {
         (panel) => processEnhancingPanel(panel)
     );
 
+    // Refresh the queue-aware button state when the finite action queue changes (add/remove),
+    // since the calculation reads dataManager.getCurrentActions() but nothing else invalidates
+    // an already-rendered panel.
+    if (actionsUpdatedHandler) {
+        dataManager.off('actions_updated', actionsUpdatedHandler);
+    }
+    actionsUpdatedHandler = () => refreshActionPanels((panel, value) => updateButtonForPanel(panel, value));
+    dataManager.on('actions_updated', actionsUpdatedHandler);
+
     // Process existing panels
     processActionPanels();
     processExistingEnhancingPanels();
@@ -114,6 +129,11 @@ export function cleanup() {
     if (enhancementDomObserverUnregister) {
         enhancementDomObserverUnregister();
         enhancementDomObserverUnregister = null;
+    }
+
+    if (actionsUpdatedHandler) {
+        dataManager.off('actions_updated', actionsUpdatedHandler);
+        actionsUpdatedHandler = null;
     }
 
     // Disconnect marketplace cleanup observer

--- a/src/features/actions/missing-materials-button.test.js
+++ b/src/features/actions/missing-materials-button.test.js
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { fakeDataManager, mockCalculateMaterialRequirements } = vi.hoisted(() => {
+    const listeners = new Map();
+    return {
+        mockCalculateMaterialRequirements: vi.fn(),
+        fakeDataManager: {
+            on: (event, handler) => {
+                if (!listeners.has(event)) listeners.set(event, new Set());
+                listeners.get(event).add(handler);
+            },
+            off: (event, handler) => {
+                listeners.get(event)?.delete(handler);
+            },
+            emit: (event, data) => {
+                for (const handler of Array.from(listeners.get(event) || [])) handler(data);
+            },
+            listenerCount: (event) => listeners.get(event)?.size || 0,
+            getInitClientData: vi.fn(),
+            getCurrentActions: vi.fn(() => []),
+            getInventory: vi.fn(() => []),
+            getActionDetails: vi.fn(),
+            getCurrentCharacterId: vi.fn(() => 'char-1'),
+        },
+    };
+});
+
+vi.mock('../../core/data-manager.js', () => ({ default: fakeDataManager }));
+vi.mock('../../core/config.js', () => ({
+    default: { getSetting: vi.fn((key) => key !== 'actions_missingMaterialsButton_ignoreQueue') },
+}));
+vi.mock('../../core/dom-observer.js', () => ({ default: { onClass: vi.fn(() => vi.fn()) } }));
+vi.mock('../../core/marketplace-session.js', () => ({
+    marketplaceSession: { isActive: vi.fn(() => false), getActive: vi.fn(() => null), start: vi.fn(), end: vi.fn() },
+    MARKETPLACE_OWNER: { ACTIONS: 'actions', ENHANCEMENT: 'enhancement' },
+}));
+vi.mock('../../utils/material-calculator.js', () => ({
+    calculateMaterialRequirements: mockCalculateMaterialRequirements,
+    calculateEnhancementMaterialRequirements: vi.fn(() => []),
+}));
+vi.mock('../../utils/formatters.js', () => ({ formatWithSeparator: vi.fn((n) => String(n)) }));
+vi.mock('../../utils/timer-registry.js', () => ({
+    createTimerRegistry: () => ({ registerTimeout: vi.fn(), clearAll: vi.fn() }),
+}));
+vi.mock('../../utils/marketplace-autofill.js', () => ({
+    createAutofillManager: () => ({
+        initialize: vi.fn(),
+        cleanup: vi.fn(),
+        startSession: vi.fn(),
+        arm: vi.fn(),
+        exitSession: vi.fn(),
+    }),
+    getReactFiberFromElement: vi.fn(() => null),
+}));
+vi.mock('../../utils/marketplace-tabs.js', () => ({
+    createMaterialTab: vi.fn(),
+    removeMaterialTabsForOwner: vi.fn(),
+    getVisibleMarketplaceTabContainer: vi.fn(() => null),
+    setupMarketplaceCleanupObserver: vi.fn(() => vi.fn()),
+    navigateToMarketplace: vi.fn(),
+    watchNativeTabExit: vi.fn(() => vi.fn()),
+    isElementActuallyVisible: vi.fn(() => true),
+    clickMarketplaceNavigationButton: vi.fn(() => false),
+    updateTabBadge: vi.fn(),
+    MARKETPLACE_REMOUNT_GRACE_MS: 350,
+    isMarketplaceMarketListingsSelected: vi.fn(() => false),
+}));
+vi.mock('./enhancement-display.js', () => ({
+    getProtectionItemFromUI: vi.fn(() => null),
+    getProtectFromLevelFromUI: vi.fn(() => 0),
+}));
+vi.mock('../enhancement/tooltip-enhancement.js', () => ({ calculateEnhancementPath: vi.fn(() => null) }));
+vi.mock('../../utils/enhancement-config.js', () => ({ getEnhancingParams: vi.fn(() => ({})) }));
+vi.mock('../../utils/dom-observer-helpers.js', () => ({ createMutationWatcher: vi.fn(() => vi.fn()) }));
+vi.mock('../../utils/game-lookups.js', () => ({ getActionHridFromName: vi.fn(() => '/actions/crafting/sword') }));
+vi.mock('./production-tools-layout.js', () => ({
+    getOrCreateProductionToolsBlock: vi.fn(() => null),
+    normalizeProductionToolsBlock: vi.fn(),
+}));
+
+import missingMaterialsButton from './missing-materials-button.js';
+
+function buildPanel(inputValue) {
+    document.body.innerHTML = `
+        <div class="SkillActionDetail_skillActionDetail_abc">
+            <div class="SkillActionDetail_name_xyz">Craft Sword</div>
+            <div class="maxActionCountInput_123"><input value="${inputValue}" /></div>
+        </div>
+    `;
+    return document.querySelector('.SkillActionDetail_skillActionDetail_abc');
+}
+
+describe('missing-materials-button — queue-change refresh', () => {
+    beforeEach(() => {
+        mockCalculateMaterialRequirements.mockReset();
+        fakeDataManager.getInitClientData.mockReturnValue({
+            actionDetailMap: {
+                '/actions/crafting/sword': {
+                    type: '/action_types/crafting',
+                    inputItems: [{ itemHrid: '/items/log', count: 1 }],
+                },
+            },
+        });
+    });
+
+    afterEach(() => {
+        missingMaterialsButton.cleanup();
+        document.body.innerHTML = '';
+    });
+
+    test('button becomes enabled when a finite queue change adds missing materials', () => {
+        mockCalculateMaterialRequirements.mockReturnValue([{ itemHrid: '/items/log', isTradeable: true, missing: 0 }]);
+
+        buildPanel('5');
+        missingMaterialsButton.initialize();
+
+        const button = document.querySelector('#mwi-missing-mats-button');
+        expect(button.disabled).toBe(true);
+
+        // Simulate a finite queue change: the fresh calculation now has missing materials.
+        mockCalculateMaterialRequirements.mockReturnValue([{ itemHrid: '/items/log', isTradeable: true, missing: 10 }]);
+        fakeDataManager.emit('actions_updated', { endCharacterActions: [] });
+
+        const refreshedButton = document.querySelector('#mwi-missing-mats-button');
+        expect(refreshedButton.disabled).toBe(false);
+    });
+
+    test('button becomes disabled when a finite queue change removes the missing-material reservation', () => {
+        mockCalculateMaterialRequirements.mockReturnValue([{ itemHrid: '/items/log', isTradeable: true, missing: 10 }]);
+
+        buildPanel('5');
+        missingMaterialsButton.initialize();
+
+        const button = document.querySelector('#mwi-missing-mats-button');
+        expect(button.disabled).toBe(false);
+
+        mockCalculateMaterialRequirements.mockReturnValue([{ itemHrid: '/items/log', isTradeable: true, missing: 0 }]);
+        fakeDataManager.emit('actions_updated', { endCharacterActions: [] });
+
+        const refreshedButton = document.querySelector('#mwi-missing-mats-button');
+        expect(refreshedButton.disabled).toBe(true);
+    });
+
+    test('initialize -> cleanup -> initialize registers exactly one actions_updated listener', () => {
+        mockCalculateMaterialRequirements.mockReturnValue([{ itemHrid: '/items/log', isTradeable: true, missing: 0 }]);
+
+        buildPanel('5');
+        missingMaterialsButton.initialize();
+        missingMaterialsButton.cleanup();
+        buildPanel('5');
+        missingMaterialsButton.initialize();
+
+        expect(fakeDataManager.listenerCount('actions_updated')).toBe(1);
+    });
+});

--- a/src/features/actions/required-materials.js
+++ b/src/features/actions/required-materials.js
@@ -4,10 +4,16 @@
  */
 
 import config from '../../core/config.js';
+import dataManager from '../../core/data-manager.js';
 import domObserver from '../../core/dom-observer.js';
 import { numberFormatter } from '../../utils/formatters.js';
 import { calculateMaterialRequirements, isArtisanTeaOutOfStock } from '../../utils/material-calculator.js';
-import { findActionInput, attachInputListeners, performInitialUpdate } from '../../utils/action-panel-helper.js';
+import {
+    findActionInput,
+    attachInputListeners,
+    performInitialUpdate,
+    refreshActionPanels,
+} from '../../utils/action-panel-helper.js';
 import { getActionHridFromName } from '../../utils/game-lookups.js';
 
 /**
@@ -31,6 +37,7 @@ class RequiredMaterials {
         this.initialized = false;
         this.observers = [];
         this.processedPanels = new WeakSet();
+        this.actionsUpdatedHandler = null;
     }
 
     initialize() {
@@ -43,6 +50,13 @@ class RequiredMaterials {
             () => this.processActionPanels()
         );
         this.observers.push(unregister);
+
+        // Refresh the queue-aware Q'd/Missing text when the finite action queue changes
+        // (add/remove), since the calculation reads dataManager.getCurrentActions() but nothing
+        // else invalidates an already-rendered panel.
+        this.actionsUpdatedHandler = () =>
+            refreshActionPanels((panel, value) => this.updateRequiredMaterials(panel, value));
+        dataManager.on('actions_updated', this.actionsUpdatedHandler);
 
         // Process existing panels
         this.processActionPanels();
@@ -255,6 +269,11 @@ class RequiredMaterials {
         this.observers.forEach((unregister) => unregister());
         this.observers = [];
         this.processedPanels = new WeakSet();
+
+        if (this.actionsUpdatedHandler) {
+            dataManager.off('actions_updated', this.actionsUpdatedHandler);
+            this.actionsUpdatedHandler = null;
+        }
 
         document.querySelectorAll('.mwi-required-materials').forEach((el) => el.remove());
 

--- a/src/features/actions/required-materials.test.js
+++ b/src/features/actions/required-materials.test.js
@@ -1,7 +1,28 @@
 // @vitest-environment jsdom
 
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+const { fakeDataManager, mockCalculateMaterialRequirements } = vi.hoisted(() => {
+    const listeners = new Map();
+    return {
+        mockCalculateMaterialRequirements: vi.fn(),
+        fakeDataManager: {
+            on: (event, handler) => {
+                if (!listeners.has(event)) listeners.set(event, new Set());
+                listeners.get(event).add(handler);
+            },
+            off: (event, handler) => {
+                listeners.get(event)?.delete(handler);
+            },
+            emit: (event, data) => {
+                for (const handler of Array.from(listeners.get(event) || [])) handler(data);
+            },
+            listenerCount: (event) => listeners.get(event)?.size || 0,
+        },
+    };
+});
+
+vi.mock('../../core/data-manager.js', () => ({ default: fakeDataManager }));
 vi.mock('../../core/config.js', () => ({
     default: {
         COLOR_LOSS: '#f00',
@@ -9,22 +30,21 @@ vi.mock('../../core/config.js', () => ({
     },
 }));
 
-vi.mock('../../core/dom-observer.js', () => ({ default: {} }));
+vi.mock('../../core/dom-observer.js', () => ({ default: { onClass: vi.fn(() => vi.fn()) } }));
 vi.mock('../../utils/material-calculator.js', () => ({
-    calculateMaterialRequirements: vi.fn(),
-    isArtisanTeaOutOfStock: vi.fn(),
+    calculateMaterialRequirements: mockCalculateMaterialRequirements,
+    isArtisanTeaOutOfStock: vi.fn(() => false),
 }));
-vi.mock('../../utils/action-panel-helper.js', () => ({
-    findActionInput: vi.fn(),
-    attachInputListeners: vi.fn(),
-    performInitialUpdate: vi.fn(),
-}));
-vi.mock('../../utils/game-lookups.js', () => ({ getActionHridFromName: vi.fn() }));
+vi.mock('../../utils/action-panel-helper.js', async () => {
+    const actual = await vi.importActual('../../utils/action-panel-helper.js');
+    return actual;
+});
+vi.mock('../../utils/game-lookups.js', () => ({ getActionHridFromName: vi.fn(() => '/actions/crafting/sword') }));
 vi.mock('../../utils/formatters.js', () => ({
     numberFormatter: vi.fn((value) => new Intl.NumberFormat('en-US').format(value)),
 }));
 
-import { formatRequiredMaterialStatus } from './required-materials.js';
+import requiredMaterials, { formatRequiredMaterialStatus } from './required-materials.js';
 
 describe('formatRequiredMaterialStatus', () => {
     test('shows the queued reservation once and keeps Missing compact', () => {
@@ -39,5 +59,64 @@ describe('formatRequiredMaterialStatus', () => {
 
     test('omits queue and Missing parts when they are not applicable', () => {
         expect(formatRequiredMaterialStatus({ required: 900, queued: 0, missing: 0 })).toBe('Required: 900');
+    });
+});
+
+function buildPanel(inputValue) {
+    document.body.innerHTML = `
+        <div class="SkillActionDetail_skillActionDetail_abc">
+            <div class="SkillActionDetail_name_xyz">Craft Sword</div>
+            <div class="maxActionCountInput_123"><input value="${inputValue}" /></div>
+            <div class="SkillActionDetail_itemRequirements_1">
+                <span class="inputCount_1"></span>
+                <div class="target-1"></div>
+            </div>
+        </div>
+    `;
+    return document.querySelector('.SkillActionDetail_skillActionDetail_abc');
+}
+
+describe('required-materials — queue-change refresh', () => {
+    beforeEach(() => {
+        mockCalculateMaterialRequirements.mockReset();
+    });
+
+    afterEach(() => {
+        requiredMaterials.cleanup();
+        document.body.innerHTML = '';
+    });
+
+    test("Q'd / Missing text refreshes when the finite action queue changes", () => {
+        mockCalculateMaterialRequirements.mockReturnValue([
+            { itemHrid: '/items/log', required: 100, queued: 0, missing: 0 },
+        ]);
+
+        buildPanel('5');
+        requiredMaterials.initialize();
+
+        let display = document.querySelector('.mwi-required-materials');
+        expect(display.textContent).toBe('Required: 100');
+
+        mockCalculateMaterialRequirements.mockReturnValue([
+            { itemHrid: '/items/log', required: 100, queued: 60, missing: 40 },
+        ]);
+        fakeDataManager.emit('actions_updated', { endCharacterActions: [] });
+
+        display = document.querySelector('.mwi-required-materials');
+        expect(display.textContent).toBe("Required: 100 (60 Q'd) | Missing: 40");
+    });
+
+    test('initialize -> cleanup -> initialize registers exactly one actions_updated listener', () => {
+        mockCalculateMaterialRequirements.mockReturnValue([
+            { itemHrid: '/items/log', required: 100, queued: 0, missing: 0 },
+        ]);
+
+        buildPanel('5');
+        requiredMaterials.initialize();
+        requiredMaterials.cleanup();
+        buildPanel('5');
+        requiredMaterials.initialize();
+
+        expect(fakeDataManager.listenerCount('actions_updated')).toBe(1);
     });
 });

--- a/src/utils/action-panel-helper.js
+++ b/src/utils/action-panel-helper.js
@@ -77,3 +77,19 @@ export function performInitialUpdate(input, updateCallback) {
     }
     return false;
 }
+
+/**
+ * Re-run updateCallback for every currently-mounted action panel using its existing input
+ * value. For data events (e.g. dataManager's 'actions_updated') that invalidate a panel's
+ * queue-aware calculation without the input itself changing, so the visible display doesn't
+ * wait for an incidental click/edit/remount to catch up.
+ * @param {Function} updateCallback - (panel, value) => void, same shape passed to attachInputListeners
+ */
+export function refreshActionPanels(updateCallback) {
+    const panels = document.querySelectorAll('[class*="SkillActionDetail_skillActionDetail"]');
+    panels.forEach((panel) => {
+        const inputField = findActionInput(panel);
+        if (!inputField) return;
+        updateCallback(panel, inputField.value);
+    });
+}


### PR DESCRIPTION
## Summary

Confirms and fixes the reported defect: Missing Mats, Required Materials (Q'd), and Cost
Summary compute against `dataManager.getCurrentActions()` (queue-aware, via
`calculateMaterialRequirements(..., accountForQueue=true)`), but none of the three
subscribed to `dataManager`'s `actions_updated` event. An already-rendered panel kept
showing values computed against the previous action queue until an incidental input edit,
panel click, or remount happened to re-trigger the calculation. `actions_updated` alone is
sufficient — it's the event `dataManager` emits whenever `characterActions` changes
membership (queue add/remove).

- Added `refreshActionPanels()` to `action-panel-helper.js`: re-runs a panel's existing
  update callback with its current input value for every mounted production panel.
- `missing-materials-button.js`, `required-materials.js`, `cost-summary.js` each subscribe
  this on `actions_updated` in `initialize()` and unsubscribe in `cleanup()`.
- Infinite queued actions are unaffected — still intentionally skipped by
  `calculateQueuedMaterialsForAction()`, out of scope per the report.

## Root cause

`processActionPanels()` in each of the three modules only wires `attachInputListeners`
(typing/clicking) and `performInitialUpdate` (first render) to the update callback. Nothing
called that callback again when the queue itself changed underneath an already-rendered
panel.

## Regression coverage

- `src/features/actions/missing-materials-button.test.js` (new): button enable/disable on
  finite queue add/remove, plus init→cleanup→init listener-count check.
- `src/features/actions/required-materials.test.js`: `Q'd`/Missing text refresh, plus
  lifecycle check.
- `src/features/actions/cost-summary.test.js`: `Missing direct mats` refresh, plus
  lifecycle check.

All new tests were run against the pre-fix source first and failed for the stated reason
(stale value / 0 listeners registered) before the fix was applied.

## Out of scope / additional findings

- `action_completed` also mutates `characterActions[i].currentCount` for the actively
  progressing action on every tick, which technically shifts other queued actions' `maxCount
  - currentCount` reservation over time too. This is a much smaller, monotonically-favorable
  drift (reservations only shrink) rather than a "stuck stale" bug, and the report's test
  scenarios are scoped to `actions_updated` (queue membership changes), so no listener was
  added for it here.
- Enhancement Missing Mats, House Missing Mats, and infinite-action accounting were left
  untouched per explicit scope instructions.

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` (792 passed, up from 785)
- [x] `npm run build:dev`
- [x] `npm run build`
- [x] `npm run build:enhancement`
- [x] Exact CI bundle-size gate (2MB limit) run locally against all `dist/` artifacts — all pass
- [x] Verified `refreshActionPanels` string present in built `dist/Toolasha-dev.user.js` and `dist/libraries/toolasha-actions.js`