### PR TITLE
fix: correct decimal combat level and level malus

### DIFF
--- a/src/core/settings-schema.js
+++ b/src/core/settings-schema.js
@@ -2043,10 +2043,10 @@ export const settingsGroups = {
             },
             combatLevelProgress: {
                 id: 'combatLevelProgress',
-                label: 'Left sidebar: Show precise Combat Level progress',
+                label: 'Left sidebar: Show decimal Combat Level',
                 type: 'checkbox',
                 default: true,
-                help: 'Shows weighted progress toward the next Combat Level (e.g. 94.80) next to the native Combat Level. Display-only - never changes the native integer level shown by the game.',
+                help: "Shows the unrounded Combat Level formula value from current whole skill levels (e.g. 133.2). MWI's native sidebar floors it to an integer for display.",
             },
             itemIconLevel: {
                 id: 'itemIconLevel',

--- a/src/features/combat-sim/combat-sim-adapter.js
+++ b/src/features/combat-sim/combat-sim-adapter.js
@@ -12,6 +12,7 @@ import loadoutSnapshot from '../combat/loadout-snapshot.js';
 import config from '../../core/config.js';
 import marketAPI from '../../api/marketplace.js';
 import expectedValueCalculator from '../market/expected-value-calculator.js';
+import { calculateRawCombatLevel } from '../../utils/combat-level-progress-calculator.js';
 
 /**
  * Extract all required game data maps from initClientData for the sim engine.
@@ -543,14 +544,21 @@ function buildPartyMemberDTO(profile, clientData, battleData) {
 /**
  * Calculate the level-gap debuff for one party member given their combat level and the party's
  * highest combat level. Shared by Combat Sim (simulated party loadouts) and Combat Stats
- * (real live encounters) so both agree on the exact same 1.2-ratio rule.
+ * (real live encounters) so both agree on the exact same eligibility rule.
+ *
+ * Per the official MWI Game Guide, both conditions are required: the player must be more than
+ * 20% lower AND at least 10 Combat Levels below the party's highest combat level. `combatLevel`
+ * and `maxCombatLevel` must be the raw (unfloored) whole-skill Combat Level formula value - see
+ * `calculateRawCombatLevel()` - never a floored/integer approximation, since flooring before
+ * this check can flip eligibility right at the boundary.
  * @param {number} combatLevel - This player's combat level
  * @param {number} maxCombatLevel - The party's highest combat level
  * @returns {number} Debuff as a negative decimal (0 = no debuff, e.g. -0.3 = -30%)
  */
 export function calculateLevelGapDebuff(combatLevel, maxCombatLevel) {
     const ratio = maxCombatLevel / combatLevel;
-    if (ratio <= 1.2) {
+    const gap = maxCombatLevel - combatLevel;
+    if (ratio <= 1.2 || gap < 10) {
         return 0;
     }
     const maxDebuff = 0.9;
@@ -559,20 +567,24 @@ export function calculateLevelGapDebuff(combatLevel, maxCombatLevel) {
 }
 
 /**
- * Calculate combat level for level gap debuff.
- * @param {Object} dto - Player DTO
+ * Calculate the raw (unfloored) combat level from any object exposing the game's own
+ * combatDetails-shaped whole-skill-level fields (staminaLevel, intelligenceLevel, attackLevel,
+ * defenseLevel, meleeLevel, rangedLevel, magicLevel) - the same shape as a player DTO here in
+ * Combat Sim and as a live `new_battle` player's `combatDetails` in Combat Stats, so both derive
+ * Level Malus input from one canonical formula instead of two.
+ * @param {{staminaLevel: number, intelligenceLevel: number, attackLevel: number, defenseLevel: number, meleeLevel: number, rangedLevel: number, magicLevel: number}} levelFields
  * @returns {number} Combat level
  */
-function calcCombatLevel(dto) {
-    return Math.floor(
-        0.1 *
-            (dto.staminaLevel +
-                dto.intelligenceLevel +
-                dto.attackLevel +
-                dto.defenseLevel +
-                Math.max(dto.meleeLevel, dto.rangedLevel, dto.magicLevel)) +
-            0.5 * Math.max(dto.attackLevel, dto.defenseLevel, dto.meleeLevel, dto.rangedLevel, dto.magicLevel)
-    );
+export function calculateCombatLevelFromLevelFields(levelFields) {
+    return calculateRawCombatLevel({
+        stamina: levelFields.staminaLevel,
+        intelligence: levelFields.intelligenceLevel,
+        attack: levelFields.attackLevel,
+        defense: levelFields.defenseLevel,
+        melee: levelFields.meleeLevel,
+        ranged: levelFields.rangedLevel,
+        magic: levelFields.magicLevel,
+    });
 }
 
 /**
@@ -649,7 +661,7 @@ export async function buildAllPlayerDTOs() {
 
     // Calculate level gap debuff
     if (players.length > 1) {
-        const levels = players.map((p) => calcCombatLevel(p));
+        const levels = players.map((p) => calculateCombatLevelFromLevelFields(p));
         const maxCombatLevel = Math.max(...levels);
 
         for (let i = 0; i < players.length; i++) {

--- a/src/features/combat-sim/combat-sim-adapter.test.js
+++ b/src/features/combat-sim/combat-sim-adapter.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { calculateLevelGapDebuff } from './combat-sim-adapter.js';
+import { calculateLevelGapDebuff, calculateCombatLevelFromLevelFields } from './combat-sim-adapter.js';
 
 describe('calculateLevelGapDebuff', () => {
     test('no debuff when ratio is exactly at the 1.2 threshold', () => {
@@ -33,5 +33,45 @@ describe('calculateLevelGapDebuff', () => {
         ]) {
             expect(calculateLevelGapDebuff(level, maxLevel)).toBeLessThanOrEqual(0);
         }
+    });
+
+    describe('the official 10-level-gap requirement (both ratio > 1.2 AND gap >= 10 are required)', () => {
+        test('ratio above 1.2 but gap under 10 -> no malus', () => {
+            // 49.9/40 = 1.2475 > 1.2, but the gap is only 9.9 levels
+            expect(calculateLevelGapDebuff(40.0, 49.9)).toBe(0);
+        });
+
+        test('gap exactly 10 and ratio above 1.2 -> malus applies', () => {
+            // 50/40 = 1.25 > 1.2, gap = 10.0 -> levelPercent = floor((1.25-1.2)*100)/100 = 0.05
+            expect(calculateLevelGapDebuff(40.0, 50.0)).toBeCloseTo(-0.15, 5);
+        });
+
+        test('ratio exactly 1.2 -> no malus regardless of the absolute gap', () => {
+            expect(calculateLevelGapDebuff(100.0, 120.0)).toBe(0);
+        });
+
+        test('decimal (raw, unfloored) combat level inputs are not floored before the ratio/gap check', () => {
+            // Flooring 133.2 -> 149.9 to 133/149 would change both the ratio and the gap outcome;
+            // the function must use the exact decimal values it is given.
+            expect(calculateLevelGapDebuff(133.2, 149.9)).toBe(0); // gap 16.7 >= 10, ratio 1.125 <= 1.2 -> no malus
+            expect(calculateLevelGapDebuff(133.2, 165.0)).not.toBe(0); // ratio ~1.238 > 1.2, gap 31.8 >= 10
+        });
+    });
+});
+
+describe('calculateCombatLevelFromLevelFields', () => {
+    test('computes the raw (unfloored) combat level from combatDetails-shaped whole-skill-level fields', () => {
+        // Player report example: Stamina 125, Intelligence 124, Attack 130, Defense 125,
+        // Melee 105, Ranged 138, Magic 77 -> raw CL = 133.2, not floored to 133.
+        const result = calculateCombatLevelFromLevelFields({
+            staminaLevel: 125,
+            intelligenceLevel: 124,
+            attackLevel: 130,
+            defenseLevel: 125,
+            meleeLevel: 105,
+            rangedLevel: 138,
+            magicLevel: 77,
+        });
+        expect(result).toBe(133.2);
     });
 });

--- a/src/features/combat-stats/combat-stats-data-collector.js
+++ b/src/features/combat-stats/combat-stats-data-collector.js
@@ -8,7 +8,7 @@ import storage from '../../core/storage.js';
 import dataManager from '../../core/data-manager.js';
 import config from '../../core/config.js';
 import { createTimerRegistry } from '../../utils/timer-registry.js';
-import { calculateLevelGapDebuff } from '../combat-sim/combat-sim-adapter.js';
+import { calculateLevelGapDebuff, calculateCombatLevelFromLevelFields } from '../combat-sim/combat-sim-adapter.js';
 import dungeonTracker from '../combat/dungeon-tracker.js';
 import ExpectedLootTracker from './expected-loot-tracker.js';
 
@@ -591,11 +591,20 @@ class CombatStatsDataCollector {
             this.expectedLootTracker.recordCompletedEncounter(this.pendingEncounter);
         }
 
+        // Level Malus eligibility needs the raw (unfloored) whole-skill Combat Level formula
+        // value, not the floored combatDetails.combatLevel the game computes for display - see
+        // calculateCombatLevelFromLevelFields(). Both this and Combat Sim's party-mode debuff
+        // derive from the same combatDetails-shaped level fields, so they stay in parity.
         const levels = data.players
-            .map((player) => player?.combatDetails?.combatLevel)
-            .filter((level) => typeof level === 'number');
+            .map((player) => player?.combatDetails)
+            .filter((combatDetails) => combatDetails && typeof combatDetails.staminaLevel === 'number')
+            .map((combatDetails) => calculateCombatLevelFromLevelFields(combatDetails));
         const maxCombatLevel = levels.length > 0 ? Math.max(...levels) : 0;
-        const selfCombatLevel = selfPlayer?.combatDetails?.combatLevel;
+        const selfCombatDetails = selfPlayer?.combatDetails;
+        const selfCombatLevel =
+            selfCombatDetails && typeof selfCombatDetails.staminaLevel === 'number'
+                ? calculateCombatLevelFromLevelFields(selfCombatDetails)
+                : undefined;
         const debuffOnLevelGap =
             typeof selfCombatLevel === 'number' && maxCombatLevel > 0
                 ? calculateLevelGapDebuff(selfCombatLevel, maxCombatLevel)

--- a/src/features/combat-stats/combat-stats-data-collector.test.js
+++ b/src/features/combat-stats/combat-stats-data-collector.test.js
@@ -48,6 +48,25 @@ vi.mock('../../core/config.js', () => ({
 
 vi.mock('../combat-sim/combat-sim-adapter.js', () => ({
     calculateLevelGapDebuff: vi.fn(() => 0),
+    calculateCombatLevelFromLevelFields: vi.fn((levelFields) => {
+        const combatStyleMax = Math.max(levelFields.meleeLevel, levelFields.rangedLevel, levelFields.magicLevel);
+        const primaryMax = Math.max(
+            levelFields.attackLevel,
+            levelFields.defenseLevel,
+            levelFields.meleeLevel,
+            levelFields.rangedLevel,
+            levelFields.magicLevel
+        );
+        const raw =
+            0.1 *
+                (levelFields.staminaLevel +
+                    levelFields.intelligenceLevel +
+                    levelFields.attackLevel +
+                    levelFields.defenseLevel +
+                    combatStyleMax) +
+            0.5 * primaryMax;
+        return Math.round(raw * 10) / 10;
+    }),
 }));
 
 vi.mock('../combat/dungeon-tracker.js', () => ({
@@ -60,6 +79,7 @@ vi.mock('../combat/dungeon-tracker.js', () => ({
 import storage from '../../core/storage.js';
 import dataManager from '../../core/data-manager.js';
 import dungeonTracker from '../combat/dungeon-tracker.js';
+import { calculateLevelGapDebuff } from '../combat-sim/combat-sim-adapter.js';
 import { CombatStatsDataCollector } from './combat-stats-data-collector.js';
 
 beforeEach(() => {
@@ -417,6 +437,62 @@ describe('CombatStatsDataCollector expected-loot integration', () => {
 
         expect(collector.expectedLootTracker.hasData()).toBe(false);
         expect(collector.pendingEncounter).not.toBeNull(); // this battle's own snapshot for the next completion
+    });
+
+    test('derives Level Malus input from the same raw whole-skill Combat Level formula as Combat Sim, not the floored combatDetails.combatLevel', async () => {
+        dataManager.getCurrentActions.mockReturnValue([regularZoneAction()]);
+        dataManager.getActionDetails.mockReturnValue({ combatZoneInfo: { isDungeon: false } });
+        const collector = await makeInitializedCollector();
+        calculateLevelGapDebuff.mockClear();
+
+        // Player report example: raw CL = 133.2, but the game's own floored combatLevel is 133.
+        const selfLevelFields = {
+            staminaLevel: 125,
+            intelligenceLevel: 124,
+            attackLevel: 130,
+            defenseLevel: 125,
+            meleeLevel: 105,
+            rangedLevel: 138,
+            magicLevel: 77,
+        };
+        // All 300s -> raw CL = 300 exactly, well above self.
+        const allyLevelFields = {
+            staminaLevel: 300,
+            intelligenceLevel: 300,
+            attackLevel: 300,
+            defenseLevel: 300,
+            meleeLevel: 300,
+            rangedLevel: 300,
+            magicLevel: 300,
+        };
+
+        await collector.onNewBattle(
+            {
+                battleId: 1,
+                combatStartTime: new Date().toISOString(),
+                monsters: [{ hrid: '/monsters/rat' }],
+                players: [
+                    {
+                        character: { id: 'character-a', name: 'Self' },
+                        combatConsumables: [],
+                        totalLootMap: {},
+                        totalSkillExperienceMap: {},
+                        combatDetails: { combatLevel: 133, combatStats: {}, ...selfLevelFields },
+                    },
+                    {
+                        character: { id: 'character-b', name: 'Ally' },
+                        combatConsumables: [],
+                        totalLootMap: {},
+                        totalSkillExperienceMap: {},
+                        combatDetails: { combatLevel: 300, combatStats: {}, ...allyLevelFields },
+                    },
+                ],
+            },
+            collector.lifecycleGeneration
+        );
+
+        // Called with the raw 133.2/300, never with the floored 133/300.
+        expect(calculateLevelGapDebuff).toHaveBeenCalledWith(133.2, 300);
     });
 
     test('cleanup resets the expected-loot tracker and pending encounter (no cross-character leakage)', async () => {

--- a/src/features/ui/combat-level-progress.js
+++ b/src/features/ui/combat-level-progress.js
@@ -1,16 +1,17 @@
 /**
- * Combat Level Progress Display
- * Shows a continuous "weighted progress toward the next level" number next to the
- * persistent Combat entry in the left sidebar, e.g. 94.80 next to the native 94.
+ * Decimal Combat Level Display
+ * Shows the unfloored Combat Level formula value, computed from current whole skill levels,
+ * next to the persistent Combat entry in the left sidebar (e.g. 133.2 next to the native 133).
  *
- * Display-only: never replaces or feeds into combatDetails.combatLevel or any
- * gameplay-affecting calculation (Combat Sim, Labyrinth, party requirements, etc.).
+ * Display-only in the sense that it never overwrites the native integer node - but unlike the
+ * native sidebar's floored integer, this value is the same raw formula relevant to Level Malus,
+ * so it must never be XP-interpolated (no fractional skill levels from XP progress).
  */
 
 import config from '../../core/config.js';
 import dataManager from '../../core/data-manager.js';
 import domObserver from '../../core/dom-observer.js';
-import { calculatePreciseCombatLevel } from '../../utils/combat-level-progress-calculator.js';
+import { calculateCombatLevelFromSkills } from '../../utils/combat-level-progress-calculator.js';
 
 const CSS_CLASS = 'mwi-combat-level-precise';
 
@@ -72,7 +73,7 @@ class CombatLevelProgress {
     }
 
     /**
-     * Recompute and render (or clear) the precise Combat Level companion span
+     * Recompute and render (or clear) the decimal Combat Level companion span
      */
     update() {
         const navRow = this.findCombatNavRow();
@@ -86,10 +87,9 @@ class CombatLevelProgress {
         }
 
         const skills = dataManager.getSkills();
-        const levelExperienceTable = dataManager.getInitClientData()?.levelExperienceTable;
-        const result = calculatePreciseCombatLevel(skills, levelExperienceTable);
+        const rawCombatLevel = calculateCombatLevelFromSkills(skills);
 
-        if (!result) {
+        if (rawCombatLevel === null) {
             textContainer.querySelector(`.${CSS_CLASS}`)?.remove();
             return;
         }
@@ -100,7 +100,7 @@ class CombatLevelProgress {
         }
 
         // Appended as a child of the native level span (never overwriting its own "150" text
-        // node) rather than a flex sibling, so it reads flush as one number ("150.49") instead
+        // node) rather than a flex sibling, so it reads flush as one number ("150.2") instead
         // of picking up the textContainer's flex gap between label/level as visible whitespace.
         let span = levelSpan.querySelector(`.${CSS_CLASS}`);
         if (!span) {
@@ -109,9 +109,9 @@ class CombatLevelProgress {
             levelSpan.appendChild(span);
         }
 
-        const decimalText = result.preciseValue.toFixed(2).split('.')[1];
+        const decimalText = rawCombatLevel.toFixed(1).split('.')[1];
         span.textContent = `.${decimalText}`;
-        span.title = `Native Combat Level: ${result.nativeCombatLevel} · weighted progress toward the next level`;
+        span.title = `Combat Level from current whole skill levels · native display: ${Math.floor(rawCombatLevel)}`;
     }
 
     /**

--- a/src/features/ui/combat-level-progress.test.js
+++ b/src/features/ui/combat-level-progress.test.js
@@ -27,28 +27,27 @@ vi.mock('../../core/data-manager.js', () => ({
         on: vi.fn((event, handler) => dataManagerHandlers.set(event, handler)),
         off: vi.fn((event) => dataManagerHandlers.delete(event)),
         getSkills: vi.fn(),
-        getInitClientData: vi.fn(),
     },
 }));
 
 const { CombatLevelProgress } = await import('./combat-level-progress.js');
 const dataManager = (await import('../../core/data-manager.js')).default;
 
-const TABLE = [0, 0, 33, 76, 132, 202, 286, 386, 503, 637, 791, 964, 1159];
-
-function skill(hrid, level, experience) {
-    return { skillHrid: hrid, level, experience };
+function skill(hrid, level) {
+    return { skillHrid: hrid, level };
 }
 
+// Stamina 5, Intelligence 5, Attack 6, Defense 5, Melee 5, Ranged 3, Magic 3 ->
+// combatStyleMax=5, primaryMax=6 -> raw = 0.1*(5+5+6+5+5) + 0.5*6 = 2.6 + 3.0 = 5.6
 function makeFullSkillSet() {
     return [
-        skill('/skills/stamina', 5, TABLE[5]),
-        skill('/skills/intelligence', 5, TABLE[5]),
-        skill('/skills/attack', 6, TABLE[6]),
-        skill('/skills/defense', 5, TABLE[5]),
-        skill('/skills/melee', 5, TABLE[5]),
-        skill('/skills/ranged', 3, TABLE[3]),
-        skill('/skills/magic', 3, TABLE[3]),
+        skill('/skills/stamina', 5),
+        skill('/skills/intelligence', 5),
+        skill('/skills/attack', 6),
+        skill('/skills/defense', 5),
+        skill('/skills/melee', 5),
+        skill('/skills/ranged', 3),
+        skill('/skills/magic', 3),
     ];
 }
 
@@ -61,7 +60,7 @@ function buildNavBarFixture() {
                     <div class="NavigationBar_contentContainer__1x6WS">
                         <div class="NavigationBar_textContainer__7TdaI">
                             <span class="NavigationBar_label__1uH-y">Combat</span>
-                            <span class="NavigationBar_level__3C7eR">6</span>
+                            <span class="NavigationBar_level__3C7eR">5</span>
                         </div>
                     </div>
                 </div>
@@ -89,7 +88,6 @@ describe('CombatLevelProgress', () => {
         mockOnClass.mockClear();
         dataManagerHandlers.clear();
         dataManager.getSkills.mockReset();
-        dataManager.getInitClientData.mockReset().mockReturnValue({ levelExperienceTable: TABLE });
         buildNavBarFixture();
         feature = new CombatLevelProgress();
     });
@@ -104,12 +102,30 @@ describe('CombatLevelProgress', () => {
         feature.initialize();
 
         const levelSpan = document.querySelector('[class*="NavigationBar_level"]');
-        expect(levelSpan.firstChild.nodeValue).toBe('6'); // native text node untouched
+        expect(levelSpan.firstChild.nodeValue).toBe('5'); // native text node untouched
 
         const companion = document.querySelector('.mwi-combat-level-precise');
         expect(companion).not.toBeNull();
         expect(companion.parentElement).toBe(levelSpan);
-        expect(companion.textContent).toMatch(/^\.\d{2}$/);
+        expect(companion.textContent).toBe('.6');
+    });
+
+    test('renders an exact-integer raw value with one decimal (N.0), never as a bare integer', () => {
+        // stamina+intelligence+attack+defense+max(melee,ranged,magic) with all levels at 1 except
+        // attack -> raw = 0.1*(1+1+1+1+1) + 0.5*1 = 0.5 + 0.5 = 1.0 exactly
+        dataManager.getSkills.mockReturnValue([
+            skill('/skills/stamina', 1),
+            skill('/skills/intelligence', 1),
+            skill('/skills/attack', 1),
+            skill('/skills/defense', 1),
+            skill('/skills/melee', 1),
+            skill('/skills/ranged', 1),
+            skill('/skills/magic', 1),
+        ]);
+        feature.initialize();
+
+        const companion = document.querySelector('.mwi-combat-level-precise');
+        expect(companion.textContent).toBe('.0');
     });
 
     test('finds the Combat row via the stable aria-label icon anchor, not the sub-skill rows', () => {
@@ -138,6 +154,14 @@ describe('CombatLevelProgress', () => {
         expect(document.querySelector('.mwi-combat-level-precise')).toBeNull();
     });
 
+    test('a missing level/XP table no longer prevents display - only whole skill levels are needed', () => {
+        // No getInitClientData mock at all - the calculation must not depend on it.
+        dataManager.getSkills.mockReturnValue(makeFullSkillSet());
+        feature.initialize();
+
+        expect(document.querySelector('.mwi-combat-level-precise')).not.toBeNull();
+    });
+
     test('recomputes when dataManager reports a skill/XP update, not on a timer', () => {
         const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
         dataManager.getSkills.mockReturnValue(makeFullSkillSet());
@@ -145,20 +169,20 @@ describe('CombatLevelProgress', () => {
 
         expect(setIntervalSpy).not.toHaveBeenCalled();
 
-        // Simulate a combat XP gain: attack levels up further
+        // Simulate a real whole-skill level-up on attack (not XP progress within a level).
         dataManager.getSkills.mockReturnValue([
-            skill('/skills/stamina', 5, TABLE[5]),
-            skill('/skills/intelligence', 5, TABLE[5]),
-            skill('/skills/attack', 8, TABLE[8]),
-            skill('/skills/defense', 5, TABLE[5]),
-            skill('/skills/melee', 5, TABLE[5]),
-            skill('/skills/ranged', 3, TABLE[3]),
-            skill('/skills/magic', 3, TABLE[3]),
+            skill('/skills/stamina', 5),
+            skill('/skills/intelligence', 5),
+            skill('/skills/attack', 8),
+            skill('/skills/defense', 5),
+            skill('/skills/melee', 5),
+            skill('/skills/ranged', 3),
+            skill('/skills/magic', 3),
         ]);
         dataManagerHandlers.get('action_completed')();
 
         const levelSpan = document.querySelector('[class*="NavigationBar_level"]');
-        expect(levelSpan.firstChild.nodeValue).toBe('6'); // untouched by re-render, only re-read
+        expect(levelSpan.firstChild.nodeValue).toBe('5'); // untouched by re-render, only re-read
 
         setIntervalSpy.mockRestore();
     });

--- a/src/utils/combat-level-progress-calculator.js
+++ b/src/utils/combat-level-progress-calculator.js
@@ -1,16 +1,19 @@
 /**
- * Combat Level Progress Calculator
- * Derives a continuous (fractional) Combat Level for display purposes only.
+ * Combat Level formula helpers.
  *
- * MWI's native player Combat Level is an integer, computed as:
+ * MWI's official Combat Level formula (per the in-game Game Guide) is:
  *   raw = 0.1 * (Stamina + Intelligence + Attack + Defense + max(Melee, Ranged, Magic))
  *       + 0.5 * max(Attack, Defense, Melee, Ranged, Magic)
- *   nativeCombatLevel = floor(raw)
  *
- * This module applies the same weighting to fractional skill levels (integer level + XP
- * progress toward the next level) to produce a "weighted progress toward the next level"
- * score, e.g. 94.80. This value must never replace or contradict the native integer level -
- * see clampDisplayCombatLevel().
+ * Applied to current whole skill levels, `raw` naturally has at most one meaningful decimal
+ * digit (the 0.1/0.5 coefficients on integer inputs cannot produce more). MWI's native sidebar
+ * floors this to an integer for display; this module exposes the unfloored value so features can
+ * show it (e.g. 133.2 next to a native 133) or use it for Level Malus math that must not lose
+ * that fractional part.
+ *
+ * This must never be confused with XP-within-level interpolation: inventing a fractional skill
+ * level from XP progress toward the next level is a different, invalid metric for this mechanic
+ * and must not feed into this formula.
  */
 
 export const COMBAT_SKILL_HRIDS = {
@@ -24,82 +27,41 @@ export const COMBAT_SKILL_HRIDS = {
 };
 
 /**
- * Fractional skill level: integer level + XP progress toward the next level, clamped to
- * [level, level + 1). Falls back to the plain integer level if the table has no next-level
- * entry (max level) or the table is unavailable.
- * @param {number} level - Native integer skill level
- * @param {number} experience - Current skill XP
- * @param {Array<number>|undefined} levelExperienceTable - Native level -> XP table
- * @returns {number}
- */
-export function calculateFractionalSkillLevel(level, experience, levelExperienceTable) {
-    const currentThreshold = levelExperienceTable?.[level];
-    const nextThreshold = levelExperienceTable?.[level + 1];
-
-    if (
-        typeof currentThreshold !== 'number' ||
-        typeof nextThreshold !== 'number' ||
-        nextThreshold <= currentThreshold
-    ) {
-        return level;
-    }
-
-    const progress = (experience - currentThreshold) / (nextThreshold - currentThreshold);
-    return level + Math.min(Math.max(progress, 0), 0.999999999);
-}
-
-/**
- * Apply MWI's native Combat Level weighting to a set of skill levels (integer or fractional -
- * the formula is identical either way).
+ * Apply MWI's official Combat Level formula to a set of whole skill levels, rounded to one
+ * decimal place. The rounding only clears IEEE-754 float noise from the 0.1/0.5 coefficients
+ * (e.g. 0.1 * 3 === 0.30000000000000004 in JS) - it never discards real precision, since integer
+ * inputs cannot produce more than one meaningful decimal digit.
  * @param {{stamina: number, intelligence: number, attack: number, defense: number, melee: number, ranged: number, magic: number}} levels
  * @returns {number}
  */
-export function calculateWeightedCombatScore(levels) {
+export function calculateRawCombatLevel(levels) {
     const { stamina, intelligence, attack, defense, melee, ranged, magic } = levels;
     const combatStyleMax = Math.max(melee, ranged, magic);
     const primaryMax = Math.max(attack, defense, melee, ranged, magic);
-    return 0.1 * (stamina + intelligence + attack + defense + combatStyleMax) + 0.5 * primaryMax;
+    const raw = 0.1 * (stamina + intelligence + attack + defense + combatStyleMax) + 0.5 * primaryMax;
+    return Math.round(raw * 10) / 10;
 }
 
 /**
- * Clamp a continuous combat score for display so it never contradicts the native integer
- * Combat Level: bounded to [nativeLevel, nativeLevel + 0.99], truncated (never rounded) to
- * two decimals so a value like N.995 displays as N.99, not N+1.00.
- * @param {number} continuousScore
- * @param {number} nativeCombatLevel
- * @returns {number}
+ * Compute the raw (unfloored) Combat Level from a live skills list, using only whole skill
+ * levels - no XP-within-level interpolation and no dependency on the level/XP table.
+ * @param {Array<{skillHrid: string, level: number}>|null} skills - dataManager.getSkills() shape
+ * @returns {number|null} null if required combat skill data is missing
  */
-export function clampDisplayCombatLevel(continuousScore, nativeCombatLevel) {
-    const clamped = Math.min(Math.max(continuousScore, nativeCombatLevel), nativeCombatLevel + 0.99);
-    return Math.floor(clamped * 100) / 100;
-}
-
-/**
- * Compute the precise (continuous, display-only) Combat Level for a set of live skills.
- * @param {Array<{skillHrid: string, level: number, experience: number}>|null} skills - dataManager.getSkills() shape
- * @param {Array<number>|undefined} levelExperienceTable - Native level -> XP table
- * @returns {{nativeCombatLevel: number, preciseValue: number}|null} null if required skill/table data is missing
- */
-export function calculatePreciseCombatLevel(skills, levelExperienceTable) {
-    if (!skills || !levelExperienceTable) return null;
+export function calculateCombatLevelFromSkills(skills) {
+    if (!skills) return null;
 
     const skillByHrid = {};
     for (const skill of skills) {
         skillByHrid[skill.skillHrid] = skill;
     }
 
-    const integerLevels = {};
-    const fractionalLevels = {};
+    const levels = {};
     for (const [key, hrid] of Object.entries(COMBAT_SKILL_HRIDS)) {
         const skill = skillByHrid[hrid];
         if (!skill || typeof skill.level !== 'number') return null;
-        integerLevels[key] = skill.level;
-        fractionalLevels[key] = calculateFractionalSkillLevel(skill.level, skill.experience, levelExperienceTable);
+        levels[key] = skill.level;
     }
 
-    const nativeCombatLevel = Math.floor(calculateWeightedCombatScore(integerLevels));
-    const continuousScore = calculateWeightedCombatScore(fractionalLevels);
-    const preciseValue = clampDisplayCombatLevel(continuousScore, nativeCombatLevel);
-
-    return { nativeCombatLevel, preciseValue };
+    return calculateRawCombatLevel(levels);
 }

--- a/src/utils/combat-level-progress-calculator.test.js
+++ b/src/utils/combat-level-progress-calculator.test.js
@@ -1,45 +1,37 @@
 import { describe, expect, test } from 'vitest';
-import {
-    calculateFractionalSkillLevel,
-    calculateWeightedCombatScore,
-    clampDisplayCombatLevel,
-    calculatePreciseCombatLevel,
-} from './combat-level-progress-calculator.js';
+import { calculateRawCombatLevel, calculateCombatLevelFromSkills } from './combat-level-progress-calculator.js';
 
-const TABLE = [0, 0, 33, 76, 132, 202, 286, 386, 503, 637, 791];
-
-describe('calculateFractionalSkillLevel', () => {
-    test('computes exact fractional progress from the native XP table', () => {
-        // Level 3 threshold is 76, level 4 threshold is 132. Halfway through: 76 + (132-76)/2 = 104
-        const result = calculateFractionalSkillLevel(3, 104, TABLE);
-        expect(result).toBeCloseTo(3.5, 5);
+describe('calculateRawCombatLevel', () => {
+    test('matches the player-reported example: whole skill levels -> 133.2, not 133.39', () => {
+        // Stamina 125, Intelligence 124, Attack 130, Defense 125, Melee 105, Ranged 138, Magic 77
+        const result = calculateRawCombatLevel({
+            stamina: 125,
+            intelligence: 124,
+            attack: 130,
+            defense: 125,
+            melee: 105,
+            ranged: 138,
+            magic: 77,
+        });
+        expect(result).toBe(133.2);
     });
 
-    test('is zero progress exactly at a level threshold', () => {
-        const result = calculateFractionalSkillLevel(3, 76, TABLE);
-        expect(result).toBe(3);
+    test('an exact result has no float noise (e.g. 0.1 * 3 !== 0.30000000000000004)', () => {
+        // stamina+intelligence+attack+defense+max(melee,ranged,magic) = 3, primaryMax = attack = 1
+        const result = calculateRawCombatLevel({
+            stamina: 1,
+            intelligence: 1,
+            attack: 1,
+            defense: 0,
+            melee: 0,
+            ranged: 0,
+            magic: 0,
+        });
+        expect(result).toBe(0.8);
     });
 
-    test('approaches but never reaches the next integer level just below the next threshold', () => {
-        const result = calculateFractionalSkillLevel(3, 131, TABLE);
-        expect(result).toBeGreaterThan(3.9);
-        expect(result).toBeLessThan(4);
-    });
-
-    test('falls back to the plain integer level at max level (no next-level entry)', () => {
-        const shortTable = [0, 0, 33];
-        const result = calculateFractionalSkillLevel(2, 40, shortTable);
-        expect(result).toBe(2);
-    });
-
-    test('falls back to the plain integer level when no table is supplied', () => {
-        expect(calculateFractionalSkillLevel(5, 999, undefined)).toBe(5);
-    });
-});
-
-describe('calculateWeightedCombatScore', () => {
-    function levels(overrides = {}) {
-        return {
+    test('the combat-style max is max(melee, ranged, magic)', () => {
+        const base = calculateRawCombatLevel({
             stamina: 50,
             intelligence: 50,
             attack: 50,
@@ -47,59 +39,58 @@ describe('calculateWeightedCombatScore', () => {
             melee: 50,
             ranged: 30,
             magic: 30,
-            ...overrides,
-        };
-    }
-
-    test('the combat-style max (melee/ranged/magic) changes when fractional levels cross', () => {
-        const base = calculateWeightedCombatScore(levels({ melee: 50.2, ranged: 50.1, magic: 30 }));
-        const crossed = calculateWeightedCombatScore(levels({ melee: 50.2, ranged: 50.3, magic: 30 }));
-        // Once ranged's fractional level overtakes melee's, it becomes the combat-style max,
-        // strictly increasing the weighted score even though melee did not change.
-        expect(crossed).toBeGreaterThan(base);
+        });
+        const higherRanged = calculateRawCombatLevel({
+            stamina: 50,
+            intelligence: 50,
+            attack: 50,
+            defense: 50,
+            melee: 50,
+            ranged: 90,
+            magic: 30,
+        });
+        expect(higherRanged).toBeGreaterThan(base);
     });
 
-    test('the primary max (attack/defense/combat-style) changes when a fractional level crosses it', () => {
-        const base = calculateWeightedCombatScore(levels({ attack: 60, defense: 59.9 }));
-        const crossed = calculateWeightedCombatScore(levels({ attack: 60, defense: 60.5 }));
-        expect(crossed).toBeGreaterThan(base);
+    test('the primary max is max(attack, defense, melee, ranged, magic)', () => {
+        const base = calculateRawCombatLevel({
+            stamina: 40,
+            intelligence: 35,
+            attack: 60,
+            defense: 55,
+            melee: 20,
+            ranged: 20,
+            magic: 15,
+        });
+        const higherDefense = calculateRawCombatLevel({
+            stamina: 40,
+            intelligence: 35,
+            attack: 60,
+            defense: 90,
+            melee: 20,
+            ranged: 20,
+            magic: 15,
+        });
+        expect(higherDefense).toBeGreaterThan(base);
     });
 
-    test('matches the plain native raw-score formula when given integer levels', () => {
-        const intLevels = { stamina: 40, intelligence: 35, attack: 60, defense: 55, melee: 70, ranged: 20, magic: 15 };
-        const expected = 0.1 * (40 + 35 + 60 + 55 + Math.max(70, 20, 15)) + 0.5 * Math.max(60, 55, 70, 20, 15);
-        expect(calculateWeightedCombatScore(intLevels)).toBeCloseTo(expected, 10);
+    test('matches the plain formula for a fresh/low character', () => {
+        const result = calculateRawCombatLevel({
+            stamina: 1,
+            intelligence: 1,
+            attack: 1,
+            defense: 1,
+            melee: 1,
+            ranged: 1,
+            magic: 1,
+        });
+        const expected = 0.1 * (1 + 1 + 1 + 1 + 1) + 0.5 * 1;
+        expect(result).toBeCloseTo(expected, 10);
     });
 });
 
-describe('clampDisplayCombatLevel', () => {
-    test('a continuous score below the native integer level cannot occur after clamping', () => {
-        expect(clampDisplayCombatLevel(93.5, 94)).toBe(94);
-    });
-
-    test('a continuous score at or above the next native integer displays at most N.99', () => {
-        expect(clampDisplayCombatLevel(96, 94)).toBe(94.99);
-        expect(clampDisplayCombatLevel(95, 94)).toBe(94.99);
-    });
-
-    test('truncates rather than rounds, so N.995 never displays as N+1.00', () => {
-        expect(clampDisplayCombatLevel(94.995, 94)).toBe(94.99);
-    });
-
-    test('truncates an in-range value down instead of rounding to the nearest cent', () => {
-        // 94.986 would round to 94.99 with toFixed(2); truncation must give 94.98.
-        expect(clampDisplayCombatLevel(94.986, 94)).toBe(94.98);
-    });
-
-    test('passes through an exact value with no truncation drift', () => {
-        expect(clampDisplayCombatLevel(94.0, 94)).toBe(94);
-    });
-});
-
-describe('calculatePreciseCombatLevel', () => {
-    const table = [0, 0, 33, 76, 132, 202, 286, 386, 503, 637, 791, 964, 1159];
-
-    function skill(hrid, level, experience) {
+describe('calculateCombatLevelFromSkills', () => {
+    function skill(hrid, level, experience = 0) {
         return { skillHrid: hrid, level, experience };
     }
 
@@ -113,48 +104,63 @@ describe('calculatePreciseCombatLevel', () => {
         magic = 3,
     } = {}) {
         return [
-            skill('/skills/stamina', stamina, table[stamina] || 0),
-            skill('/skills/intelligence', intelligence, table[intelligence] || 0),
-            skill('/skills/attack', attack, table[attack] || 0),
-            skill('/skills/defense', defense, table[defense] || 0),
-            skill('/skills/melee', melee, table[melee] || 0),
-            skill('/skills/ranged', ranged, table[ranged] || 0),
-            skill('/skills/magic', magic, table[magic] || 0),
+            skill('/skills/stamina', stamina),
+            skill('/skills/intelligence', intelligence),
+            skill('/skills/attack', attack),
+            skill('/skills/defense', defense),
+            skill('/skills/melee', melee),
+            skill('/skills/ranged', ranged),
+            skill('/skills/magic', magic),
         ];
     }
 
-    test('native level increasing (via higher integer skill levels) advances the displayed whole number', () => {
-        const lower = calculatePreciseCombatLevel(makeSkills({ attack: 5 }), table);
-        const higher = calculatePreciseCombatLevel(makeSkills({ attack: 10 }), table);
-        expect(higher.nativeCombatLevel).toBeGreaterThan(lower.nativeCombatLevel);
-        expect(higher.preciseValue).toBeGreaterThanOrEqual(higher.nativeCombatLevel);
+    test('computes the raw CL from whole skill levels only', () => {
+        const result = calculateCombatLevelFromSkills(
+            makeSkills({
+                stamina: 125,
+                intelligence: 124,
+                attack: 130,
+                defense: 125,
+                melee: 105,
+                ranged: 138,
+                magic: 77,
+            })
+        );
+        expect(result).toBe(133.2);
+    });
+
+    test('changing XP while all whole skill levels remain unchanged does not change the result', () => {
+        const skills = makeSkills();
+        const withXpProgress = skills.map((s) => ({ ...s, experience: s.experience + 999 }));
+
+        expect(calculateCombatLevelFromSkills(skills)).toBe(calculateCombatLevelFromSkills(withXpProgress));
+    });
+
+    test('a real whole-skill level-up changes the result according to the formula', () => {
+        const before = calculateCombatLevelFromSkills(makeSkills({ attack: 5 }));
+        const after = calculateCombatLevelFromSkills(makeSkills({ attack: 10 }));
+        expect(after).toBeGreaterThan(before);
+    });
+
+    test('does not require a level/XP table - works from levels alone', () => {
+        expect(calculateCombatLevelFromSkills(makeSkills())).not.toBeNull();
+    });
+
+    test('returns null when a required combat skill is missing from the live skills list', () => {
+        const incomplete = makeSkills().filter((s) => s.skillHrid !== '/skills/magic');
+        expect(calculateCombatLevelFromSkills(incomplete)).toBeNull();
+    });
+
+    test('returns null when no skills are supplied', () => {
+        expect(calculateCombatLevelFromSkills(null)).toBeNull();
     });
 
     test('is display-only: never mutates the skills array or its entries', () => {
         const skills = makeSkills();
         const snapshot = JSON.parse(JSON.stringify(skills));
 
-        calculatePreciseCombatLevel(skills, table);
+        calculateCombatLevelFromSkills(skills);
 
         expect(skills).toEqual(snapshot);
-    });
-
-    test('returns null when a required combat skill is missing from the live skills list', () => {
-        const incomplete = makeSkills().filter((s) => s.skillHrid !== '/skills/magic');
-        expect(calculatePreciseCombatLevel(incomplete, table)).toBeNull();
-    });
-
-    test('returns null when no skills are supplied', () => {
-        expect(calculatePreciseCombatLevel(null, table)).toBeNull();
-    });
-
-    test('returns null when no level experience table is supplied', () => {
-        expect(calculatePreciseCombatLevel(makeSkills(), undefined)).toBeNull();
-    });
-
-    test('the precise value never falls below the native integer level it is paired with', () => {
-        const result = calculatePreciseCombatLevel(makeSkills({ attack: 8, defense: 7 }), table);
-        expect(result.preciseValue).toBeGreaterThanOrEqual(result.nativeCombatLevel);
-        expect(result.preciseValue).toBeLessThanOrEqual(result.nativeCombatLevel + 0.99);
     });
 });


### PR DESCRIPTION
## Summary

Fixes a player-reported correctness bug in the decimal Combat Level display, plus two directly
related pre-existing Level Malus bugs uncovered during the investigation. Package/evidence:
`Toolasha_Combat_Level_and_Level_Malus_Fix_for_Claude_Code_2026-08-21/REPORT_FOR_CLAUDE_CODE.md`.

### Root causes

1. The decimal Combat Level display (`src/features/ui/combat-level-progress.js` +
   `src/utils/combat-level-progress-calculator.js`) fractionalized each skill into
   integer-level-plus-XP-progress before applying the CL weighting formula, then clamped the
   result into the native integer bucket. For the reported example (Stamina 125, Intelligence
   124, Attack 130, Defense 125, Melee 105, Ranged 138, Magic 77) this produced 133.39, while the
   official formula evaluated on whole skill levels only gives 133.2.
2. `combat-sim-adapter.js`'s `calcCombatLevel()` wrapped the raw CL formula in `Math.floor()`
   before feeding it into the Level Malus ratio check, discarding exactly the fractional part the
   penalty mechanic needs.
3. The shared `calculateLevelGapDebuff()` helper checked only the official ">20% lower" ratio
   condition and omitted the official ">= 10 Combat Levels below" absolute-gap condition, so a
   player just over the ratio threshold but under the level-gap threshold was incorrectly
   penalized.

### Changed behavior

- The decimal CL display now shows only the unfloored whole-skill formula value (e.g. `.2`
  appended to the native `133`), with no XP-within-level interpolation, and no dependency on
  `levelExperienceTable` (removed `calculateFractionalSkillLevel`/`clampDisplayCombatLevel`/
  `calculatePreciseCombatLevel` — replaced by canonical `calculateRawCombatLevel()` /
  `calculateCombatLevelFromSkills()`). Setting key (`combatLevelProgress`) is unchanged; only the
  label/help/tooltip wording was updated to drop "progress" framing.
- `calculateLevelGapDebuff()` now requires both the ratio AND the >= 10 level gap.
- Combat Sim's `calcCombatLevel` and Combat Stats' Level Malus input (previously
  `combatDetails.combatLevel`, which the game always floors before sending) now derive the raw CL
  from the same `combatDetails`-shaped whole-skill-level fields via a new shared
  `calculateCombatLevelFromLevelFields()`, so both consumers stay in parity.

### Verification

- MWI Client Code bundle (`build df72a1bc617d97e8`) confirms `initializeCombatDetails()` always
  computes `combatLevel` via `Math.floor(...)` from the same whole-skill-level fields
  (`staminaLevel`, `intelligenceLevel`, etc.) that are present as siblings on the same object -
  used here to derive the raw CL for Combat Stats without needing a live `new_battle` capture.
- MWI Game Reference confirms the official formula (no floor) and the official Level Malus
  wording: "more than 20% lower **and** at least 10 levels below".
- 22/54 new/changed tests independently confirmed to fail against pre-fix source for the expected
  reasons (git-stash isolation), then pass after the fix.
- Full suite: 1033/1033 passing. Lint clean. Format clean. `build:dev` + `build` +
  `build:enhancement` all succeed. CI bundle-size gate reproduced locally - all files under the
  2 MiB limit. Built artifacts checked directly: no occurrence of the retired "weighted progress
  toward the next level" string remains in any bundle.

### Scope

No changes to Labyrinth Combat Level, party join/filter requirements, release/version/publication
behavior, or unrelated Combat Stats runway/RNG work - none of the report's findings implicated
those paths.

## Test plan

- [x] `npm test` - 1033/1033 passing
- [x] `npm run lint` - clean
- [x] `npm run format:check` - clean
- [x] `npm run build:dev`, `npm run build`, `npm run build:enhancement` - all succeed
- [x] CI bundle-size gate reproduced locally - all files under 2 MiB
- [x] Built artifacts inspected for absence of the retired display string