### PR TITLE
fix: correct Combat Stats runway and Loot Luck sampling

### DIFF
--- a/src/core/settings-schema.js
+++ b/src/core/settings-schema.js
@@ -1761,7 +1761,7 @@ export const settingsGroups = {
                 label: 'Combat Statistics: consumable runway warning threshold (hours)',
                 type: 'number',
                 default: 12,
-                help: 'Send a browser notification when a combat consumable is projected to run out within this many hours. Set to 0 to disable.',
+                help: 'Highlight combat consumables projected to run out within this many hours. Set to 0 to disable warnings.',
             },
             combatStatsChatMessage: {
                 id: 'combatStatsChatMessage',

--- a/src/features/combat-stats/combat-stats-calculator.js
+++ b/src/features/combat-stats/combat-stats-calculator.js
@@ -437,9 +437,17 @@ export function calculatePlayerStats(playerData, durationSeconds = null, expecte
             : null;
 
     // Actual vs Expected loot / RNG Delta - current player only, and only once at least one
-    // encounter has completed (never fabricated from zero completed samples)
+    // encounter has completed (never fabricated from zero completed samples). Dungeons are
+    // excluded: the current player's totalLootMap (the only Actual-loot source Combat Stats
+    // observes) never reflects a dungeon's completion reward - that reward is delivered via a
+    // different field entirely, so an "Actual" baseline for dungeons cannot be proven correct.
     let actualVsExpected = null;
-    if (expectedLootData && expectedLootData.sampleSize > 0 && expectedLootData.elapsedSeconds > 0) {
+    if (
+        expectedLootData &&
+        !expectedLootData.isDungeon &&
+        expectedLootData.sampleSize > 0 &&
+        expectedLootData.elapsedSeconds > 0
+    ) {
         // Both sides must cover the exact same window. Reusing the session-wide totalLootMap for
         // "Actual" would compare a short Expected sample against a much longer Actual window
         // (e.g. the script attaching mid-fight), silently mis-scaling the result - so Actual here

--- a/src/features/combat-stats/combat-stats-calculator.test.js
+++ b/src/features/combat-stats/combat-stats-calculator.test.js
@@ -291,6 +291,18 @@ describe('calculatePlayerStats - actualVsExpected (RNG Delta)', () => {
         expect(stats.actualVsExpected).toBeNull();
     });
 
+    test('is null for dungeons even with a full sample - the current player totalLootMap Combat Stats observes never reflects a dungeon completion reward, so Actual cannot be proven correct there', () => {
+        const stats = calculatePlayerStats(basePlayerData(), 3600, {
+            expectedDropsMap: new Map([['/items/dungeon_reward', 2]]),
+            sampleSize: 3,
+            elapsedSeconds: 3600,
+            actualLootSinceTracking: [],
+            isDungeon: true,
+        });
+
+        expect(stats.actualVsExpected).toBeNull();
+    });
+
     test('computes a positive RNG delta when actual loot outvalues expected loot over the same window', () => {
         const stats = calculatePlayerStats(basePlayerData(), 3600, {
             expectedDropsMap: new Map([['/items/log', 10]]),

--- a/src/features/combat-stats/combat-stats-data-collector.js
+++ b/src/features/combat-stats/combat-stats-data-collector.js
@@ -6,8 +6,6 @@
 import webSocketHook from '../../core/websocket.js';
 import storage from '../../core/storage.js';
 import dataManager from '../../core/data-manager.js';
-import config from '../../core/config.js';
-import { createTimerRegistry } from '../../utils/timer-registry.js';
 import { calculateLevelGapDebuff } from '../combat-sim/combat-sim-adapter.js';
 import dungeonTracker from '../combat/dungeon-tracker.js';
 import ExpectedLootTracker from './expected-loot-tracker.js';
@@ -47,9 +45,6 @@ class CombatStatsDataCollector {
         this.currentBattleId = null;
         this.characterId = null;
         this.lifecycleGeneration = 0;
-        this.wasBelowRunwayThreshold = {};
-        this.runwayNotificationPermissionGranted = false;
-        this.timerRegistry = createTimerRegistry();
         this.pendingEncounter = null;
         this.latestSelfCombatDropQuantity = 0;
         this.actualLootSnapshot = null;
@@ -115,9 +110,6 @@ class CombatStatsDataCollector {
         await this.loadConsumableTracking(this.characterId);
         if (generation !== this.lifecycleGeneration || !this.isInitialized) return;
 
-        await this.requestRunwayNotificationPermission();
-        if (generation !== this.lifecycleGeneration || !this.isInitialized) return;
-
         // Store handler references for cleanup
         this.newBattleHandler = (data) => this.onNewBattle(data, generation);
         this.consumableEventHandler = (data) => this.onConsumableUsed(data, generation);
@@ -141,90 +133,6 @@ class CombatStatsDataCollector {
             }
         };
         dungeonTracker.onUpdate(this.dungeonCompletionHandler);
-    }
-
-    /**
-     * Request browser notification permission for the consumable runway warning
-     */
-    async requestRunwayNotificationPermission() {
-        if (typeof Notification === 'undefined') {
-            return;
-        }
-
-        if (Notification.permission === 'granted') {
-            this.runwayNotificationPermissionGranted = true;
-            return;
-        }
-
-        if (Notification.permission !== 'denied') {
-            try {
-                const permission = await Notification.requestPermission();
-                this.runwayNotificationPermissionGranted = permission === 'granted';
-            } catch (error) {
-                console.warn('[Combat Stats] Runway notification permission request failed:', error);
-            }
-        }
-    }
-
-    /**
-     * Check the current player's runway against the configured warning threshold and fire a
-     * one-shot browser notification on a threshold crossing (never for party members).
-     * @param {string} itemHrid - Item HRID
-     * @param {number} timeToZeroSeconds - Seconds until this item's inventory reaches zero
-     */
-    checkRunwayWarning(itemHrid, timeToZeroSeconds) {
-        const thresholdHours = config.getSettingValue('combatStats_runwayWarningThreshold', 12);
-        if (!thresholdHours || thresholdHours <= 0) {
-            this.wasBelowRunwayThreshold[itemHrid] = false;
-            return;
-        }
-
-        const thresholdSeconds = thresholdHours * 3600;
-        const isBelow = timeToZeroSeconds < thresholdSeconds;
-
-        if (isBelow && !this.wasBelowRunwayThreshold[itemHrid]) {
-            this.sendRunwayWarning(itemHrid, timeToZeroSeconds);
-        }
-
-        this.wasBelowRunwayThreshold[itemHrid] = isBelow;
-    }
-
-    /**
-     * Send the low-supply browser notification for a single consumable
-     * @param {string} itemHrid - Item HRID
-     * @param {number} timeToZeroSeconds - Seconds until this item's inventory reaches zero
-     */
-    sendRunwayWarning(itemHrid, timeToZeroSeconds) {
-        try {
-            if (!this.runwayNotificationPermissionGranted || typeof Notification === 'undefined') {
-                return;
-            }
-
-            const itemName = dataManager.getItemDetails(itemHrid)?.name || itemHrid;
-            const hours = Math.max(0, timeToZeroSeconds) / 3600;
-            const hoursLabel = hours < 1 ? `${Math.round(hours * 60)}m` : `${hours.toFixed(1)}h`;
-
-            const notification = new Notification('Milky Way Idle', {
-                body: `${itemName} is running low: ~${hoursLabel} remaining`,
-                icon: 'https://www.milkywayidle.com/favicon.ico',
-                tag: `combat-consumable-runway-${itemHrid}`,
-                requireInteraction: false,
-            });
-
-            notification.onclick = () => {
-                window.focus();
-                notification.close();
-            };
-
-            notification.onerror = (error) => {
-                console.error('[Combat Stats] Runway notification error:', error);
-            };
-
-            const closeTimeout = setTimeout(() => notification.close(), 5000);
-            this.timerRegistry.registerTimeout(closeTimeout);
-        } catch (error) {
-            console.error('[Combat Stats] Failed to send runway notification:', error);
-        }
     }
 
     /**
@@ -585,6 +493,7 @@ class CombatStatsDataCollector {
 
         if (this.actualLootSnapshot === null) {
             this.actualLootSnapshot = sumLootByItemHrid(selfPlayer?.totalLootMap);
+            this.expectedLootTracker.markSampleStart(zoneInfo.zoneHrid, false);
         }
 
         if (this.pendingEncounter) {
@@ -901,10 +810,6 @@ class CombatStatsDataCollector {
                             const timeToZeroSeconds =
                                 consumptionRate > 0 ? inventoryAmount / consumptionRate : Infinity;
 
-                            if (isCurrentPlayer) {
-                                this.checkRunwayWarning(consumable.itemHrid, timeToZeroSeconds);
-                            }
-
                             const consumableData = {
                                 itemHrid: consumable.itemHrid,
                                 currentCount: consumable.count,
@@ -1000,9 +905,6 @@ class CombatStatsDataCollector {
         this.isInitialized = false;
         this.latestCombatData = null;
         this.currentBattleId = null;
-        this.wasBelowRunwayThreshold = {};
-        this.runwayNotificationPermissionGranted = false;
-        this.timerRegistry.clearAll();
         this.pendingEncounter = null;
         this.latestSelfCombatDropQuantity = 0;
         this.actualLootSnapshot = null;

--- a/src/features/combat-stats/combat-stats-data-collector.test.js
+++ b/src/features/combat-stats/combat-stats-data-collector.test.js
@@ -205,66 +205,44 @@ describe('CombatStatsDataCollector character-scoped persistence', () => {
     });
 });
 
-describe('CombatStatsDataCollector runway warning', () => {
-    test('fires once when crossing from above to below the threshold', async () => {
+describe('CombatStatsDataCollector consumable runway - no browser notification path', () => {
+    test('initialize never touches Notification.requestPermission', async () => {
         const collector = new CombatStatsDataCollector();
-        await collector.requestRunwayNotificationPermission();
+        await collector.initialize();
 
-        collector.checkRunwayWarning('/items/coffee', 20 * 3600); // above 12h threshold
-        collector.checkRunwayWarning('/items/coffee', 5 * 3600); // crosses below
-
-        expect(globalThis.Notification).toHaveBeenCalledTimes(1);
-        expect(globalThis.Notification.mock.calls[0][1].tag).toBe('combat-consumable-runway-/items/coffee');
+        expect(globalThis.Notification.requestPermission).not.toHaveBeenCalled();
+        collector.cleanup();
     });
 
-    test('does not spam on repeated calls while still below the threshold', async () => {
+    test('a low-runway current-player consumable never creates a browser Notification', async () => {
         const collector = new CombatStatsDataCollector();
-        await collector.requestRunwayNotificationPermission();
+        collector.isInitialized = true;
+        collector.characterId = 'character-a';
+        mocks.currentCharacterId = 'character-a';
 
-        collector.checkRunwayWarning('/items/coffee', 5 * 3600);
-        collector.checkRunwayWarning('/items/coffee', 4 * 3600);
-        collector.checkRunwayWarning('/items/coffee', 3 * 3600);
-
-        expect(globalThis.Notification).toHaveBeenCalledTimes(1);
-    });
-
-    test('re-arms after inventory is replenished back above the threshold', async () => {
-        const collector = new CombatStatsDataCollector();
-        await collector.requestRunwayNotificationPermission();
-
-        collector.checkRunwayWarning('/items/coffee', 5 * 3600); // fires
-        collector.checkRunwayWarning('/items/coffee', 30 * 3600); // replenished, re-arm
-        collector.checkRunwayWarning('/items/coffee', 5 * 3600); // fires again
-
-        expect(globalThis.Notification).toHaveBeenCalledTimes(2);
-    });
-
-    test('threshold of 0 disables the warning entirely', async () => {
-        mocks.settingValues.combatStats_runwayWarningThreshold = 0;
-        const collector = new CombatStatsDataCollector();
-        await collector.requestRunwayNotificationPermission();
-
-        collector.checkRunwayWarning('/items/coffee', 0);
+        await collector.onNewBattle(
+            {
+                battleId: 1,
+                combatStartTime: new Date().toISOString(),
+                players: [
+                    {
+                        character: { id: 'character-a', name: 'Self' },
+                        combatConsumables: [{ itemHrid: '/items/coffee', count: 0 }],
+                        totalLootMap: {},
+                        totalSkillExperienceMap: {},
+                    },
+                ],
+            },
+            collector.lifecycleGeneration
+        );
 
         expect(globalThis.Notification).not.toHaveBeenCalled();
     });
 
-    test('cleanup resets warning-crossed state so a new character starts unarmed, not pre-tripped', async () => {
-        const collector = new CombatStatsDataCollector();
-        await collector.requestRunwayNotificationPermission();
-        collector.checkRunwayWarning('/items/coffee', 5 * 3600);
-        expect(collector.wasBelowRunwayThreshold['/items/coffee']).toBe(true);
-
-        collector.cleanup();
-
-        expect(collector.wasBelowRunwayThreshold).toEqual({});
-    });
-
-    test('a party member consumable running low never triggers a notification', async () => {
+    test('a party member consumable running low never creates a browser Notification', async () => {
         const collector = new CombatStatsDataCollector();
         collector.isInitialized = true;
         collector.characterId = 'character-a';
-        collector.runwayNotificationPermissionGranted = true;
         mocks.currentCharacterId = 'character-a';
 
         await collector.onNewBattle(
@@ -290,6 +268,15 @@ describe('CombatStatsDataCollector runway warning', () => {
         );
 
         expect(globalThis.Notification).not.toHaveBeenCalled();
+    });
+
+    test('cleanup does not throw and leaves no notification-permission bookkeeping behind', async () => {
+        const collector = new CombatStatsDataCollector();
+        await collector.initialize();
+
+        expect(() => collector.cleanup()).not.toThrow();
+        expect(collector.runwayNotificationPermissionGranted).toBeUndefined();
+        expect(collector.wasBelowRunwayThreshold).toBeUndefined();
     });
 });
 
@@ -580,5 +567,166 @@ describe('CombatStatsDataCollector expected-loot integration', () => {
 
         expect(collector.actualLootSnapshot).toBeNull();
         expect(collector.getActualLootSinceTrackingStarted()).toEqual([]);
+    });
+});
+
+describe('CombatStatsDataCollector Loot Luck sample window (exact start/end boundaries)', () => {
+    function regularZoneAction(zoneHrid = '/actions/combat/rat', difficultyTier = 0) {
+        return { actionHrid: zoneHrid, isDone: false, difficultyTier };
+    }
+
+    function battlePayload({ battleId, monsterHrids }) {
+        return {
+            battleId,
+            combatStartTime: new Date().toISOString(),
+            monsters: monsterHrids.map((hrid) => ({ hrid })),
+            players: [
+                {
+                    character: { id: 'character-a', name: 'Self' },
+                    combatConsumables: [],
+                    totalLootMap: {},
+                    totalSkillExperienceMap: {},
+                    combatDetails: { combatLevel: 100, combatStats: {} },
+                },
+            ],
+        };
+    }
+
+    async function makeInitializedCollector() {
+        const collector = new CombatStatsDataCollector();
+        collector.isInitialized = true;
+        collector.characterId = 'character-a';
+        mocks.currentCharacterId = 'character-a';
+        return collector;
+    }
+
+    beforeEach(() => {
+        dataManager.getCurrentActions.mockReturnValue([regularZoneAction()]);
+        dataManager.getActionDetails.mockReturnValue({ combatZoneInfo: { isDungeon: false } });
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test('the first observed battle establishes the baseline; elapsed stays 0 until the next battle confirms it completed', async () => {
+        const collector = await makeInitializedCollector();
+
+        await collector.onNewBattle(
+            battlePayload({ battleId: 1, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+
+        expect(collector.expectedLootTracker.getSampleSize()).toBe(0);
+        expect(collector.expectedLootTracker.getElapsedSeconds()).toBe(0);
+    });
+
+    test('next battle at t=60s confirms one completed encounter with a real 60s duration, not ~0s', async () => {
+        const collector = await makeInitializedCollector();
+
+        await collector.onNewBattle(
+            battlePayload({ battleId: 1, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+
+        vi.setSystemTime(60_000);
+        await collector.onNewBattle(
+            battlePayload({ battleId: 2, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+
+        expect(collector.expectedLootTracker.getSampleSize()).toBe(1);
+        expect(collector.expectedLootTracker.getElapsedSeconds()).toBe(60);
+    });
+
+    test('elapsed sample does not drift merely because time passes with no new completed encounter', async () => {
+        const collector = await makeInitializedCollector();
+
+        await collector.onNewBattle(
+            battlePayload({ battleId: 1, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+        vi.setSystemTime(60_000);
+        await collector.onNewBattle(
+            battlePayload({ battleId: 2, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+
+        // 30s pass with no new new_battle message at all (e.g. user just left the stats popup
+        // open) - the denominator must not silently keep growing off Date.now().
+        vi.setSystemTime(90_000);
+
+        expect(collector.expectedLootTracker.getSampleSize()).toBe(1);
+        expect(collector.expectedLootTracker.getElapsedSeconds()).toBe(60);
+    });
+
+    test('a third battle at t=120s confirms a second completed encounter, extending the sample end to 120s', async () => {
+        const collector = await makeInitializedCollector();
+
+        await collector.onNewBattle(
+            battlePayload({ battleId: 1, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+        vi.setSystemTime(60_000);
+        await collector.onNewBattle(
+            battlePayload({ battleId: 2, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+        vi.setSystemTime(120_000);
+        await collector.onNewBattle(
+            battlePayload({ battleId: 3, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+
+        expect(collector.expectedLootTracker.getSampleSize()).toBe(2);
+        expect(collector.expectedLootTracker.getElapsedSeconds()).toBe(120);
+    });
+
+    test('the currently-active encounter never extends the sample end before it completes', async () => {
+        const collector = await makeInitializedCollector();
+
+        await collector.onNewBattle(
+            battlePayload({ battleId: 1, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+        vi.setSystemTime(60_000);
+        await collector.onNewBattle(
+            battlePayload({ battleId: 2, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+        const elapsedBeforeThirdBattle = collector.expectedLootTracker.getElapsedSeconds();
+
+        // Battle 2 is still active (no battle 3 yet) - time passing must not move the boundary.
+        vi.setSystemTime(100_000);
+
+        expect(collector.expectedLootTracker.getElapsedSeconds()).toBe(elapsedBeforeThirdBattle);
+    });
+
+    test('a zone change resets the sample start/end boundaries in lockstep with the Actual baseline', async () => {
+        const collector = await makeInitializedCollector();
+
+        await collector.onNewBattle(
+            battlePayload({ battleId: 1, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+        vi.setSystemTime(60_000);
+        await collector.onNewBattle(
+            battlePayload({ battleId: 2, monsterHrids: ['/monsters/rat'] }),
+            collector.lifecycleGeneration
+        );
+        expect(collector.expectedLootTracker.getSampleSize()).toBe(1);
+
+        dataManager.getCurrentActions.mockReturnValue([regularZoneAction('/actions/combat/alligator')]);
+        vi.setSystemTime(90_000);
+        await collector.onNewBattle(
+            battlePayload({ battleId: 3, monsterHrids: ['/monsters/alligator'] }),
+            collector.lifecycleGeneration
+        );
+
+        // New zone, no completion yet - sample must restart clean, not inherit the old window.
+        expect(collector.expectedLootTracker.getSampleSize()).toBe(0);
+        expect(collector.expectedLootTracker.getElapsedSeconds()).toBe(0);
     });
 });

--- a/src/features/combat-stats/combat-stats-ui.js
+++ b/src/features/combat-stats/combat-stats-ui.js
@@ -384,6 +384,7 @@ class CombatStatsUI {
                   sampleSize: expectedLootTracker.getSampleSize(),
                   elapsedSeconds: expectedLootTracker.getElapsedSeconds(),
                   actualLootSinceTracking: combatStatsDataCollector.getActualLootSinceTrackingStarted(),
+                  isDungeon: expectedLootTracker.isDungeon,
               }
             : null;
         const playerStats = calculateAllPlayerStats(combatData, durationSeconds, expectedLootData);
@@ -714,7 +715,7 @@ class CombatStatsUI {
             },
             ...(stats.actualVsExpected
                 ? (() => {
-                      const sampleHeading = `Loot RNG sample · ${formatNum(stats.actualVsExpected.sampleSize)} encounters · ${formatRunway(stats.actualVsExpected.elapsedSeconds)}`;
+                      const sampleHeading = `Loot Luck sample · ${formatNum(stats.actualVsExpected.sampleSize)} encounters · ${formatRunway(stats.actualVsExpected.elapsedSeconds)}`;
                       return [
                           {
                               label: 'Actual Rate',

--- a/src/features/combat-stats/combat-stats-ui.test.js
+++ b/src/features/combat-stats/combat-stats-ui.test.js
@@ -69,6 +69,12 @@ describe('getRunwayColor', () => {
         expect(getRunwayColor(6 * 3600)).toBe('#f0a830');
     });
 
+    test('threshold 0 disables the visual warning - never amber regardless of runway', () => {
+        mocks.threshold = 0;
+        expect(getRunwayColor(6 * 3600)).toBe('#888');
+        expect(getRunwayColor(1)).toBe('#888');
+    });
+
     test('is muted gray when comfortably above the warning threshold', () => {
         mocks.threshold = 12;
         expect(getRunwayColor(30 * 3600)).toBe('#888');

--- a/src/features/combat-stats/expected-loot-tracker.js
+++ b/src/features/combat-stats/expected-loot-tracker.js
@@ -4,9 +4,29 @@
  * completions for the current zone, then feeds the exact same canonical drop-math helper
  * Combat Sim uses (`calculateExpectedDrops`) so Actual and Expected never disagree because of
  * duplicated formulas.
+ *
+ * Encounters/runs are bucketed by their exact modifier signature (difficulty, party size, Combat
+ * Drop Rate/Rare Find/Drop Quantity, level-gap debuff) and each bucket is run through the
+ * canonical helper independently, then summed - a modifier change mid-sample (gear swap, party
+ * change, difficulty change) must never retroactively reprice encounters that already completed
+ * under the old modifiers.
  */
 
 import { calculateExpectedDrops } from '../combat-sim/combat-sim-adapter.js';
+
+const REGULAR_MODIFIER_KEYS = [
+    'difficultyTier',
+    'numberOfPlayers',
+    'dropRateMultiplier',
+    'rareFindMultiplier',
+    'combatDropQuantity',
+    'debuffOnLevelGap',
+];
+const DUNGEON_MODIFIER_KEYS = ['difficultyTier', 'numberOfPlayers', 'combatDropQuantity'];
+
+function bucketKey(modifiers, keys) {
+    return keys.map((key) => modifiers[key]).join('|');
+}
 
 class ExpectedLootTracker {
     constructor() {
@@ -19,18 +39,11 @@ class ExpectedLootTracker {
     reset() {
         this.zoneHrid = null;
         this.isDungeon = false;
-        this.deaths = {};
-        this.dungeonsCompleted = 0;
+        /** @type {Map<string, {modifiers: Object, deaths: Object, dungeonsCompleted: number}>} */
+        this.buckets = new Map();
         this.completedEncounterCount = 0;
-        this.trackingStartTime = null;
-        this.latest = {
-            difficultyTier: 0,
-            numberOfPlayers: 1,
-            dropRateMultiplier: 1,
-            rareFindMultiplier: 1,
-            combatDropQuantity: 0,
-            debuffOnLevelGap: 0,
-        };
+        this.sampleStartTime = null;
+        this.sampleEndTime = null;
     }
 
     /**
@@ -45,6 +58,36 @@ class ExpectedLootTracker {
         }
         this.zoneHrid = zoneHrid;
         this.isDungeon = isDungeon;
+    }
+
+    /**
+     * Establish the sample's start boundary the instant the Actual-loot baseline is captured,
+     * decoupled from the first *completed* encounter - the first encounter can legitimately take
+     * a long time to finish, and that whole duration must still count toward the sample window
+     * (otherwise the denominator excludes it while the numerator includes it once it completes).
+     * @param {string} zoneHrid - Current action HRID
+     * @param {boolean} isDungeon - Whether the current zone is a dungeon
+     */
+    markSampleStart(zoneHrid, isDungeon) {
+        this._syncZone(zoneHrid, isDungeon);
+        if (this.sampleStartTime === null) {
+            this.sampleStartTime = Date.now();
+        }
+    }
+
+    /**
+     * @param {Object} modifiers - Modifier signature for this bucket
+     * @param {Array<string>} keys - Which modifier fields identify this bucket's signature
+     * @returns {{modifiers: Object, deaths: Object, dungeonsCompleted: number}}
+     */
+    _bucketFor(modifiers, keys) {
+        const key = bucketKey(modifiers, keys);
+        let bucket = this.buckets.get(key);
+        if (!bucket) {
+            bucket = { modifiers, deaths: {}, dungeonsCompleted: 0 };
+            this.buckets.set(key, bucket);
+        }
+        return bucket;
     }
 
     /**
@@ -70,23 +113,27 @@ class ExpectedLootTracker {
         debuffOnLevelGap,
     }) {
         this._syncZone(zoneHrid, false);
-        if (this.trackingStartTime === null) {
-            this.trackingStartTime = Date.now();
+        if (this.sampleStartTime === null) {
+            this.sampleStartTime = Date.now();
         }
 
+        const bucket = this._bucketFor(
+            {
+                difficultyTier,
+                numberOfPlayers,
+                dropRateMultiplier,
+                rareFindMultiplier,
+                combatDropQuantity,
+                debuffOnLevelGap,
+            },
+            REGULAR_MODIFIER_KEYS
+        );
         for (const monsterHrid of monsterHrids) {
-            this.deaths[monsterHrid] = (this.deaths[monsterHrid] || 0) + 1;
+            bucket.deaths[monsterHrid] = (bucket.deaths[monsterHrid] || 0) + 1;
         }
-        this.completedEncounterCount += 1;
 
-        this.latest = {
-            difficultyTier,
-            numberOfPlayers,
-            dropRateMultiplier,
-            rareFindMultiplier,
-            combatDropQuantity,
-            debuffOnLevelGap,
-        };
+        this.completedEncounterCount += 1;
+        this.sampleEndTime = Date.now();
     }
 
     /**
@@ -99,13 +146,15 @@ class ExpectedLootTracker {
      */
     recordDungeonCompletion({ zoneHrid, difficultyTier, numberOfPlayers, combatDropQuantity }) {
         this._syncZone(zoneHrid, true);
-        if (this.trackingStartTime === null) {
-            this.trackingStartTime = Date.now();
+        if (this.sampleStartTime === null) {
+            this.sampleStartTime = Date.now();
         }
 
-        this.dungeonsCompleted += 1;
+        const bucket = this._bucketFor({ difficultyTier, numberOfPlayers, combatDropQuantity }, DUNGEON_MODIFIER_KEYS);
+        bucket.dungeonsCompleted += 1;
+
         this.completedEncounterCount += 1;
-        this.latest = { ...this.latest, difficultyTier, numberOfPlayers, combatDropQuantity };
+        this.sampleEndTime = Date.now();
     }
 
     /**
@@ -123,44 +172,91 @@ class ExpectedLootTracker {
     }
 
     /**
-     * Real wall-clock time actually covered by the accumulated sample - NOT the whole combat
-     * session's duration, which may have started long before this tracker began observing
-     * (e.g. the script attached mid-fight). Using the session duration here would silently
-     * understate the expected daily rate by whatever ratio the two windows differ by.
-     * @returns {number} Seconds since the first completed encounter/dungeon run in this sample
+     * Merged kill-count view across every modifier bucket - read-only introspection only;
+     * `getExpectedDrops()` always computes per-bucket so a modifier change never retroactively
+     * reprices encounters that completed under different modifiers.
+     * @returns {Object} monsterHrid -> total kill count across all buckets
+     */
+    get deaths() {
+        const merged = {};
+        for (const bucket of this.buckets.values()) {
+            for (const [hrid, count] of Object.entries(bucket.deaths)) {
+                merged[hrid] = (merged[hrid] || 0) + count;
+            }
+        }
+        return merged;
+    }
+
+    /**
+     * @returns {number} Total completed dungeon runs across all modifier buckets
+     */
+    get dungeonsCompleted() {
+        let total = 0;
+        for (const bucket of this.buckets.values()) {
+            total += bucket.dungeonsCompleted;
+        }
+        return total;
+    }
+
+    /**
+     * Real wall-clock time actually covered by the accumulated sample: from the moment the
+     * Actual-loot baseline was captured to the moment the most recently included encounter/run
+     * was confirmed completed. Deliberately NOT `Date.now() - sampleStartTime` - Expected only
+     * advances at a completed-encounter boundary, so using the current instant as the end would
+     * let the denominator keep growing after the last included sample, silently deflating the
+     * displayed rate the longer the user waits before checking.
+     * @returns {number} Seconds between the sample's start and last-completed boundary
      */
     getElapsedSeconds() {
-        if (this.trackingStartTime === null) {
+        if (this.sampleStartTime === null || this.sampleEndTime === null) {
             return 0;
         }
-        return Math.max(0, (Date.now() - this.trackingStartTime) / 1000);
+        return Math.max(0, (this.sampleEndTime - this.sampleStartTime) / 1000);
     }
 
     /**
      * Compute expected drops for everything accumulated so far, using the exact same helper
-     * Combat Sim uses for simulated runs.
+     * Combat Sim uses for simulated runs - once per modifier bucket, then summed, so a modifier
+     * change mid-sample never retroactively recalculates already-completed encounters.
      * @param {Object} gameData - `dataManager.getInitClientData()` result (combatMonsterDetailMap/actionDetailMap)
      * @returns {Map<string, number>} itemHrid -> expected total drop count
      */
     getExpectedDrops(gameData) {
+        const totals = new Map();
         if (!this.hasData()) {
-            return new Map();
+            return totals;
         }
 
-        const simResult = {
-            isDungeon: this.isDungeon,
-            zoneName: this.zoneHrid,
-            deaths: this.deaths,
-            dungeonsCompleted: this.dungeonsCompleted,
-            numberOfPlayers: this.latest.numberOfPlayers || 1,
-            difficultyTier: this.latest.difficultyTier || 0,
-            dropRateMultiplier: { player1: this.latest.dropRateMultiplier || 1 },
-            rareFindMultiplier: { player1: this.latest.rareFindMultiplier || 1 },
-            combatDropQuantity: { player1: this.latest.combatDropQuantity || 0 },
-            debuffOnLevelGap: { player1: this.latest.debuffOnLevelGap || 0 },
-        };
+        for (const bucket of this.buckets.values()) {
+            const simResult = this.isDungeon
+                ? {
+                      isDungeon: true,
+                      zoneName: this.zoneHrid,
+                      dungeonsCompleted: bucket.dungeonsCompleted,
+                      numberOfPlayers: bucket.modifiers.numberOfPlayers || 1,
+                      difficultyTier: bucket.modifiers.difficultyTier || 0,
+                      dropRateMultiplier: { player1: 1 },
+                      combatDropQuantity: { player1: bucket.modifiers.combatDropQuantity || 0 },
+                  }
+                : {
+                      isDungeon: false,
+                      zoneName: this.zoneHrid,
+                      deaths: bucket.deaths,
+                      numberOfPlayers: bucket.modifiers.numberOfPlayers || 1,
+                      difficultyTier: bucket.modifiers.difficultyTier || 0,
+                      dropRateMultiplier: { player1: bucket.modifiers.dropRateMultiplier || 1 },
+                      rareFindMultiplier: { player1: bucket.modifiers.rareFindMultiplier || 1 },
+                      combatDropQuantity: { player1: bucket.modifiers.combatDropQuantity || 0 },
+                      debuffOnLevelGap: { player1: bucket.modifiers.debuffOnLevelGap || 0 },
+                  };
 
-        return calculateExpectedDrops(simResult, gameData, 'player1');
+            const bucketDrops = calculateExpectedDrops(simResult, gameData, 'player1');
+            for (const [itemHrid, count] of bucketDrops) {
+                totals.set(itemHrid, (totals.get(itemHrid) || 0) + count);
+            }
+        }
+
+        return totals;
     }
 }
 

--- a/src/features/combat-stats/expected-loot-tracker.parity.test.js
+++ b/src/features/combat-stats/expected-loot-tracker.parity.test.js
@@ -74,4 +74,87 @@ describe('ExpectedLootTracker parity with the real Combat Sim helper (no duplica
 
         expect(rareFindResult).toBeCloseTo(baselineResult * 3, 10);
     });
+
+    test('a modifier change mid-sample never retroactively reprices already-completed encounters', () => {
+        const tracker = new ExpectedLootTracker();
+
+        // Encounter 1 completes under one modifier signature (e.g. before a gear/party change).
+        tracker.recordCompletedEncounter({
+            zoneHrid: '/actions/combat/rat',
+            monsterHrids: ['/monsters/rat', '/monsters/rat'],
+            difficultyTier: 0,
+            numberOfPlayers: 1,
+            dropRateMultiplier: 1,
+            rareFindMultiplier: 1,
+            combatDropQuantity: 0,
+            debuffOnLevelGap: 0,
+        });
+
+        // Encounter 2 completes under a different modifier signature (Combat Drop Rate changed
+        // mid-sample, e.g. a gear swap). A recalculation-with-newest-modifiers bug would run BOTH
+        // encounters' deaths through this new modifier instead of only encounter 2's.
+        tracker.recordCompletedEncounter({
+            zoneHrid: '/actions/combat/rat',
+            monsterHrids: ['/monsters/rat', '/monsters/rat', '/monsters/rat'],
+            difficultyTier: 0,
+            numberOfPlayers: 1,
+            dropRateMultiplier: 1.5,
+            rareFindMultiplier: 1,
+            combatDropQuantity: 0,
+            debuffOnLevelGap: 0,
+        });
+
+        const combined = tracker.getExpectedDrops(GAME_DATA);
+
+        const encounter1Alone = calculateExpectedDrops(
+            {
+                isDungeon: false,
+                deaths: { '/monsters/rat': 2 },
+                numberOfPlayers: 1,
+                difficultyTier: 0,
+                dropRateMultiplier: { player1: 1 },
+                rareFindMultiplier: { player1: 1 },
+                combatDropQuantity: { player1: 0 },
+                debuffOnLevelGap: { player1: 0 },
+            },
+            GAME_DATA,
+            'player1'
+        );
+        const encounter2Alone = calculateExpectedDrops(
+            {
+                isDungeon: false,
+                deaths: { '/monsters/rat': 3 },
+                numberOfPlayers: 1,
+                difficultyTier: 0,
+                dropRateMultiplier: { player1: 1.5 },
+                rareFindMultiplier: { player1: 1 },
+                combatDropQuantity: { player1: 0 },
+                debuffOnLevelGap: { player1: 0 },
+            },
+            GAME_DATA,
+            'player1'
+        );
+        const expectedSum =
+            (encounter1Alone.get('/items/rat_tail') || 0) + (encounter2Alone.get('/items/rat_tail') || 0);
+
+        expect(combined.get('/items/rat_tail')).toBeCloseTo(expectedSum, 10);
+
+        // The bug this guards against: running all 5 combined deaths through only encounter 2's
+        // modifier would NOT equal the correct per-bucket sum computed above.
+        const buggyRecalculation = calculateExpectedDrops(
+            {
+                isDungeon: false,
+                deaths: { '/monsters/rat': 5 },
+                numberOfPlayers: 1,
+                difficultyTier: 0,
+                dropRateMultiplier: { player1: 1.5 },
+                rareFindMultiplier: { player1: 1 },
+                combatDropQuantity: { player1: 0 },
+                debuffOnLevelGap: { player1: 0 },
+            },
+            GAME_DATA,
+            'player1'
+        );
+        expect(combined.get('/items/rat_tail')).not.toBeCloseTo(buggyRecalculation.get('/items/rat_tail'), 5);
+    });
 });


### PR DESCRIPTION
## Summary

Focused correctness follow-up on top of the already-shipped Combat Stats Expansion
(Consumable Runway + Actual vs Expected Loot / Loot Luck), per the supplied
`REPORT_FOR_CLAUDE_CODE.md`.

- **Consumable Runway**: removed `Notification.requestPermission()` / `new Notification(...)`
  entirely - having Combat Statistics enabled (its default) no longer triggers a browser
  permission prompt. The in-panel warning threshold/urgency coloring is untouched.
- **Loot Luck sample window**: `sampleStartTime` is now captured the instant the Actual-loot
  baseline is taken (not delayed until the first encounter completes), and `sampleEndTime` only
  advances at a confirmed completed-encounter boundary instead of drifting with `Date.now()`.
- **Historical modifier bucketing**: expected drops are computed per modifier-signature bucket
  and summed, so a mid-sample gear/party/difficulty change never retroactively reprices
  encounters that already completed under different modifiers.
- **Dungeon Loot Luck hidden**: independently verified (background research against the MWI
  client bundle) that the current player's `totalLootMap` never reflects a dungeon's completion
  reward - it travels via `endCharacterItems` on `action_completed`, a field Combat Stats never
  reads. Rather than guess at a new architecture, the Actual-vs-Expected comparison is now
  suppressed for dungeons instead of showing a false `Actual=0` result.
- Small polish: `Loot RNG sample` → `Loot Luck sample`.

The separate Combat Level / Level Malus fix (#660) is intentionally not folded into this PR
and was already merged to `main` before this branch was cut, so no rebase-and-rerun step is
needed.

## Test plan

- [x] Focused regression tests added, each confirmed to fail on unmodified `main` for the
      correct reason (confound-checked via `git stash` before/after)
- [x] Full suite: 1062/1062 passing
- [x] Lint clean, Prettier clean
- [x] `build:dev`, production `build`, `build:enhancement` all succeed
- [x] Exact CI bundle-size gate replica passes for every `dist/` artifact
- [x] Built dev artifact verified: fix markers present, all dead runway-notification code
      absent, the 2 remaining `Notification` references are the separate opt-in Empty Queue
      Notification feature (untouched, out of scope)