### PR TITLE
fix: keep Guild level-slot details inside the native card

### DIFF
--- a/src/features/guild/guild-xp-display.exp-card.test.js
+++ b/src/features/guild/guild-xp-display.exp-card.test.js
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('../../core/dom-observer.js', () => ({
+    default: { onClass: vi.fn(() => () => {}) },
+}));
+
+vi.mock('../../core/websocket.js', () => ({
+    default: { on: vi.fn(), off: vi.fn() },
+}));
+
+vi.mock('../../core/config.js', () => ({
+    default: {
+        getSetting: vi.fn((_key, def) => def),
+        getSettingValue: vi.fn((_key, def) => def),
+    },
+}));
+
+vi.mock('../../core/data-manager.js', () => ({
+    default: { getCurrentCharacterName: vi.fn(() => null) },
+}));
+
+vi.mock('./guild-xp-tracker.js', () => ({
+    guildXPTracker: {
+        getOwnGuildName: vi.fn(() => 'My Guild'),
+        getGuildStats: vi.fn(() => ({ lastHourXPH: 0, lastXPH: 0, lastDayXPH: 0, chart: [] })),
+        getMemberList: vi.fn(() => []),
+        lastMembersUpdateTime: null,
+        getTimeToLevel: vi.fn(() => null),
+        getNextMemberSlotETA: vi.fn(() => null),
+    },
+}));
+
+import { guildXPTracker } from './guild-xp-tracker.js';
+import { GuildXPDisplay } from './guild-xp-display.js';
+
+/**
+ * Build a fixture matching the native Guild Overview data grid: an "Exp to Level Up" block
+ * (the one Toolasha expands/appends into) and one unrelated sibling block, using the same
+ * class names `_renderOverview()` selects on.
+ * @returns {{dataGridEl: HTMLElement, expBlock: HTMLElement, siblingBlock: HTMLElement}}
+ */
+function buildDataGridFixture() {
+    const dataGridEl = document.createElement('div');
+    dataGridEl.className = 'GuildPanel_dataGrid';
+
+    const makeBlock = (labelText) => {
+        const block = document.createElement('div');
+        block.className = 'GuildPanel_dataBlock__3qVhK';
+        const label = document.createElement('div');
+        label.className = 'GuildPanel_label__-A63g';
+        label.textContent = labelText;
+        block.appendChild(label);
+        const value = document.createElement('div');
+        value.className = 'GuildPanel_value__Hm2I9';
+        value.textContent = '1,234';
+        block.appendChild(value);
+        return block;
+    };
+
+    const expBlock = makeBlock('Exp to Level Up');
+    const siblingBlock = makeBlock('Guild Level');
+    dataGridEl.appendChild(expBlock);
+    dataGridEl.appendChild(siblingBlock);
+    return { dataGridEl, expBlock, siblingBlock };
+}
+
+describe('GuildXPDisplay - Next Guild Level Slot card layout', () => {
+    let display;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(window, 'getComputedStyle').mockReturnValue({ height: '64px' });
+        display = new GuildXPDisplay();
+        guildXPTracker.getOwnGuildName.mockReturnValue('My Guild');
+        guildXPTracker.getGuildStats.mockReturnValue({ lastHourXPH: 0, lastXPH: 0, lastDayXPH: 0, chart: [] });
+        guildXPTracker.getMemberList.mockReturnValue([]);
+        guildXPTracker.getTimeToLevel.mockReturnValue(null);
+    });
+
+    test('renders the compact three-line slot block and never the old "XP remaining" phrasing', () => {
+        guildXPTracker.getNextMemberSlotETA.mockReturnValue({
+            targetLevel: 114,
+            xpRemaining: 5679629,
+            status: 'ok',
+            etaMs: 7 * 86400000 + 86400000,
+            rateBasis: '24h',
+            rateValue: 26602,
+        });
+
+        const { dataGridEl, expBlock } = buildDataGridFixture();
+        display._renderOverview(dataGridEl);
+
+        const slotBlock = expBlock.querySelector(`.mwi-guild-xp`);
+        expect(slotBlock).not.toBeNull();
+        expect(slotBlock.textContent).not.toContain('XP remaining');
+
+        const lines = Array.from(slotBlock.children).map((el) => el.textContent);
+        expect(lines).toEqual(['Next Guild Level Slot (+1)', 'To Lv 114 · 5,679,629 XP', 'ETA: 1 week 1 day']);
+    });
+
+    test('preserves the existing ETA tooltip/rate basis for the ok state', () => {
+        guildXPTracker.getNextMemberSlotETA.mockReturnValue({
+            targetLevel: 114,
+            xpRemaining: 5679629,
+            status: 'ok',
+            etaMs: 3600000,
+            rateBasis: '24h',
+            rateValue: 26602,
+        });
+
+        const { dataGridEl, expBlock } = buildDataGridFixture();
+        display._renderOverview(dataGridEl);
+
+        const slotBlock = expBlock.querySelector(`.mwi-guild-xp[title]`);
+        expect(slotBlock.title).toBe('ETA based on 24h average: 26,602 XP/h');
+    });
+
+    test('renders "collecting data" when the tracker reports insufficient sample', () => {
+        guildXPTracker.getNextMemberSlotETA.mockReturnValue({
+            targetLevel: 114,
+            xpRemaining: 5679629,
+            status: 'collecting-data',
+        });
+
+        const { dataGridEl, expBlock } = buildDataGridFixture();
+        display._renderOverview(dataGridEl);
+
+        expect(expBlock.textContent).toContain('ETA: collecting data');
+    });
+
+    test('renders "no recent gains" when the tracker reports a zero recent rate', () => {
+        guildXPTracker.getNextMemberSlotETA.mockReturnValue({
+            targetLevel: 114,
+            xpRemaining: 5679629,
+            status: 'zero-rate',
+            rateBasis: '24h',
+        });
+
+        const { dataGridEl, expBlock } = buildDataGridFixture();
+        display._renderOverview(dataGridEl);
+
+        expect(expBlock.textContent).toContain('ETA: no recent gains');
+    });
+
+    test('only the native "Exp to Level Up" card receives the expansion marker/style', () => {
+        guildXPTracker.getNextMemberSlotETA.mockReturnValue({
+            targetLevel: 114,
+            xpRemaining: 5679629,
+            status: 'ok',
+            etaMs: 86400000,
+            rateBasis: '24h',
+            rateValue: 26602,
+        });
+
+        const { dataGridEl, expBlock, siblingBlock } = buildDataGridFixture();
+        display._renderOverview(dataGridEl);
+
+        expect(expBlock.classList.contains('mwi-guild-xp__exp-card')).toBe(true);
+        expect(expBlock.style.height).toBe('auto');
+        expect(expBlock.style.minHeight).toBe('64px');
+
+        expect(siblingBlock.classList.contains('mwi-guild-xp__exp-card')).toBe(false);
+        expect(siblingBlock.style.height).toBe('');
+        expect(siblingBlock.style.minHeight).toBe('');
+    });
+
+    test('rerender is idempotent - no duplicate slot content and no style/class accumulation', () => {
+        guildXPTracker.getNextMemberSlotETA.mockReturnValue({
+            targetLevel: 114,
+            xpRemaining: 5679629,
+            status: 'ok',
+            etaMs: 86400000,
+            rateBasis: '24h',
+            rateValue: 26602,
+        });
+
+        const { dataGridEl, expBlock } = buildDataGridFixture();
+        display._renderOverview(dataGridEl);
+        display._renderOverview(dataGridEl);
+        display._renderOverview(dataGridEl);
+
+        expect(expBlock.querySelectorAll('.mwi-guild-xp').length).toBe(1);
+        expect(expBlock.classList.contains('mwi-guild-xp__exp-card')).toBe(true);
+        // getComputedStyle is only consulted the first time the block is marked, never re-measured.
+        expect(window.getComputedStyle).toHaveBeenCalledTimes(1);
+    });
+
+    test('cleanup removes injected content and restores the native card class/style', () => {
+        guildXPTracker.getNextMemberSlotETA.mockReturnValue({
+            targetLevel: 114,
+            xpRemaining: 5679629,
+            status: 'ok',
+            etaMs: 86400000,
+            rateBasis: '24h',
+            rateValue: 26602,
+        });
+
+        const { dataGridEl, expBlock } = buildDataGridFixture();
+        document.body.appendChild(dataGridEl);
+        display._renderOverview(dataGridEl);
+        expect(expBlock.classList.contains('mwi-guild-xp__exp-card')).toBe(true);
+
+        display.disable();
+
+        expect(expBlock.classList.contains('mwi-guild-xp__exp-card')).toBe(false);
+        expect(expBlock.style.height).toBe('');
+        expect(expBlock.style.minHeight).toBe('');
+        expect(expBlock.querySelector('.mwi-guild-xp')).toBeNull();
+
+        document.body.removeChild(dataGridEl);
+    });
+
+    test('a remounted (fresh) card is measured again rather than leaking stale styling', () => {
+        guildXPTracker.getNextMemberSlotETA.mockReturnValue({
+            targetLevel: 114,
+            xpRemaining: 5679629,
+            status: 'ok',
+            etaMs: 86400000,
+            rateBasis: '24h',
+            rateValue: 26602,
+        });
+
+        const first = buildDataGridFixture();
+        display._renderOverview(first.dataGridEl);
+        expect(window.getComputedStyle).toHaveBeenCalledTimes(1);
+
+        // Simulate leaving/remounting Guild: a brand-new native card element, no marker class yet.
+        const second = buildDataGridFixture();
+        display._renderOverview(second.dataGridEl);
+
+        expect(window.getComputedStyle).toHaveBeenCalledTimes(2);
+        expect(second.expBlock.classList.contains('mwi-guild-xp__exp-card')).toBe(true);
+    });
+});

--- a/src/features/guild/guild-xp-display.js
+++ b/src/features/guild/guild-xp-display.js
@@ -14,6 +14,10 @@ import { createTimerRegistry } from '../../utils/timer-registry.js';
 import { fNum, rankBadge, addColumn, makeColumnSortable } from '../../utils/table-columns.js';
 
 const CSS_PREFIX = 'mwi-guild-xp';
+// Marker on the native "Exp to Level Up" data block itself (never the `mwi-guild-xp` class used
+// by removable injected content) so its one-time min-height/height expansion is idempotent
+// across re-renders and cleanly revertible on disable().
+const EXP_CARD_CLASS = `${CSS_PREFIX}__exp-card`;
 
 // ─── Formatting helpers ─────────────────────────────────────────────────────
 
@@ -331,11 +335,13 @@ class GuildXPDisplay {
                 timeToLevel !== null
                     ? `<div class="${CSS_PREFIX}" style="color: var(--color-space-300); font-size: 13px;">${formatTimeLeft(timeToLevel)}</div>`
                     : '';
-            // Find the "Exp to Next Level" data block and append
+            // Find the "Exp to Next Level" data block, expand it to fit this extra content
+            // (native card keeps a fixed height otherwise), and append.
             const dataBlocks = dataGridEl.querySelectorAll('.GuildPanel_dataBlock__3qVhK');
             for (const block of dataBlocks) {
                 const label = block.querySelector('.GuildPanel_label__-A63g');
                 if (label && label.textContent.includes('Exp to')) {
+                    this._expandExpCardIfNeeded(block);
                     block.insertAdjacentHTML('beforeend', ttlHTML + nextSlotHTML);
                     break;
                 }
@@ -344,9 +350,28 @@ class GuildXPDisplay {
     }
 
     /**
-     * Build the "Next Guild Level Slot (+1)" line HTML from tracker ETA info.
-     * Deliberately never claims to predict Guild Hall capacity increases - only the
-     * level-earned +1 base slot, which is the only thing this data can prove.
+     * Expand the native "Exp to Level Up" data block to auto-height (once per DOM node) so
+     * Toolasha's appended ETA/slot content never falls below the native card background.
+     * Idempotent: skipped once the block already carries the marker class, so repeated
+     * `_renderOverview()` calls on the same persistent React-owned node never re-measure or
+     * accumulate style. A remounted/replaced block starts without the marker and is measured
+     * fresh, so no stale styling can leak across navigation.
+     * @param {Element} block - The native `.GuildPanel_dataBlock__3qVhK` element
+     */
+    _expandExpCardIfNeeded(block) {
+        if (block.classList.contains(EXP_CARD_CLASS)) return;
+        const nativeHeight = window.getComputedStyle(block).height;
+        block.classList.add(EXP_CARD_CLASS);
+        block.style.minHeight = nativeHeight;
+        block.style.height = 'auto';
+        block.style.paddingBottom = '8px';
+    }
+
+    /**
+     * Build the "Next Guild Level Slot (+1)" block HTML from tracker ETA info, as three compact
+     * lines that fit the narrow native "Exp to Level Up" card. Deliberately never claims to
+     * predict Guild Hall capacity increases - only the level-earned +1 base slot, which is the
+     * only thing this data can prove.
      * @param {null|{targetLevel: number, xpRemaining: number, status: string, etaMs?: number, rateBasis?: string, rateValue?: number}} slotEta
      * @returns {string} HTML, or '' if unavailable
      */
@@ -365,8 +390,10 @@ class GuildXPDisplay {
             etaText = 'collecting data';
         }
 
-        return `<div class="${CSS_PREFIX}" style="color: var(--color-space-300); font-size: 13px; margin-top: 4px;"${tooltip ? ` title="${tooltip}"` : ''}>
-            <span style="color: #9ca3af;">Next Guild Level Slot (+1):</span> Lv ${slotEta.targetLevel} · ${fNum(slotEta.xpRemaining)} XP remaining · ${etaText}
+        return `<div class="${CSS_PREFIX}" style="margin-top: 4px; font-size: 13px; line-height: 1.5;"${tooltip ? ` title="${tooltip}"` : ''}>
+            <div style="color: #9ca3af;">Next Guild Level Slot (+1)</div>
+            <div style="color: var(--color-space-300);">To Lv ${slotEta.targetLevel} · ${fNum(slotEta.xpRemaining)} XP</div>
+            <div style="color: var(--color-space-300); opacity: 0.85;">ETA: ${etaText}</div>
         </div>`;
     }
 
@@ -1015,11 +1042,23 @@ class GuildXPDisplay {
         document.querySelectorAll(`.${CSS_PREFIX}__tooltip`).forEach((el) => el.remove());
         document.getElementById('mwi-guild-activity-hide')?.remove();
 
+        // Restore the native "Exp to Level Up" card's own height/class (never destroyed by the
+        // injected-element removal above, since the expansion is applied to the native block
+        // itself rather than to a removable Toolasha-owned element).
+        document.querySelectorAll(`.${EXP_CARD_CLASS}`).forEach((el) => {
+            el.classList.remove(EXP_CARD_CLASS);
+            el.style.height = '';
+            el.style.minHeight = '';
+            el.style.paddingBottom = '';
+        });
+
         this.initialized = false;
     }
 }
 
 const guildXPDisplay = new GuildXPDisplay();
+
+export { GuildXPDisplay };
 
 export default {
     name: 'Guild XP Display',


### PR DESCRIPTION
## Summary
- The injected `Next Guild Level Slot (+1)` line fell below the native `Exp to Level Up` card's fixed-height background on longer content (looked detached/floating).
- Rewrites the injected block into the requested compact three-line layout and expands only that native card (auto-height + a min-height captured from its own native computed height) to fit it, idempotently across re-renders.
- `disable()` now also reverts the native card's expansion class/style, in addition to removing injected content.

No changes to Guild slot math, XP remaining math, ETA rate policy, storage, WebSocket behavior, or neighboring Guild cards.

## Test plan
- [x] New focused regression suite (`guild-xp-display.exp-card.test.js`, 8 tests) - confirmed failing against pre-fix source for the correct reason via `git stash`
- [x] Full suite: 1085/1085 passed
- [x] Lint clean
- [x] Format check clean
- [x] Dev + production builds succeeded
- [x] Bundle sizes all under the 2MB CI gate
- [x] Built dev artifact verified to contain the fix (3-line layout, marker class) and no leftover "XP remaining" phrasing in the slot block
- [ ] Live manual verification in Guild Overview (not observable in this sandbox) - checklist provided to Celasha for manual confirmation