### PR TITLE
feat: add openable analytics and luck tracking

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -175,7 +175,19 @@ function workerBundlePlugin() {
 // Check if we should build for production (multi-bundle)
 const isProduction = process.env.BUILD_MODE === 'production';
 const buildTarget = process.env.BUILD_TARGET || 'dev';
-const devOutputFile = buildTarget === 'dev-standalone' ? 'dist/Toolasha-dev.user.js' : 'dist/Toolasha.user.js';
+const isStandaloneDevBuild = buildTarget === 'dev-standalone';
+const devOutputFile = isStandaloneDevBuild ? 'dist/Toolasha-dev.user.js' : 'dist/Toolasha.user.js';
+
+// The standalone dev/test build must be visibly distinct from production and must never share
+// its persistent IndexedDB namespace (TLA-022) - both are driven off this one build-time marker
+// so no runtime heuristic (filename/URL/version) has to guess which build is running.
+const devUserscriptHeader = isStandaloneDevBuild
+    ? userscriptHeader
+          .replace('// @name         Toolasha\n', '// @name         Toolasha DEV\n')
+          .replace(/^\/\/ @downloadURL.*\n/m, '')
+          .replace(/^\/\/ @updateURL.*\n/m, '')
+    : userscriptHeader;
+const devBuildIntro = isStandaloneDevBuild ? "globalThis.__TOOLASHA_BUILD_CHANNEL__ = 'dev-standalone';\n" : '';
 
 // Development build configuration (single bundle for local testing)
 const devConfig = {
@@ -184,7 +196,8 @@ const devConfig = {
         file: devOutputFile,
         format: 'iife',
         name: 'Toolasha',
-        banner: userscriptHeader,
+        banner: devUserscriptHeader,
+        intro: devBuildIntro,
     },
     plugins: [
         cssRawPlugin(),

--- a/src/core/data-manager.js
+++ b/src/core/data-manager.js
@@ -564,6 +564,20 @@ class DataManager {
                 this.characterQuests = this.characterQuests.filter((q) => q.status !== '/quest_status/claimed');
             }
         });
+
+        // `loot_opened` is character-scoped, but it has no dedicated DataManager-owned state -
+        // feature modules (Openable Analytics) consume it directly. Route it through the same
+        // TLA-018 accepted-socket ownership as every other character-scoped handler instead of
+        // letting a feature invent its own socket ownership, and capture characterId at
+        // acceptance time so a later character switch can't cause the opening to be attributed
+        // to whichever character happens to be current when an async consumer continuation
+        // resumes.
+        this.webSocketHook.on('loot_opened', (data, context) => {
+            if (!this._isFromActiveSocket(context)) return;
+            if (!this.currentCharacterId) return;
+
+            this.emit('loot_opened', { data, characterId: this.currentCharacterId });
+        });
     }
 
     /**
@@ -1433,8 +1447,10 @@ class DataManager {
 
     /**
      * Emit event to all listeners
-     * Only character_switching is critical (must run immediately for proper cleanup)
-     * All other events including character_switched and character_initialized are deferred
+     * character_switching must run immediately for proper cleanup. `loot_opened` is also
+     * dispatched synchronously: it is an accepted character-scoped event whose consumer must
+     * capture the opening before a subsequent character cleanup can invalidate feature state.
+     * All other events including character_switched and character_initialized are deferred.
      * @param {string} event - Event name
      * @param {*} data - Event data
      */
@@ -1445,9 +1461,9 @@ class DataManager {
         // be delivered to listeners that subscribed after the event was emitted.
         const listeners = [...(this.eventListeners.get(event) || [])];
 
-        // Only character_switching must run immediately (cleanup phase)
-        // character_switched can be deferred - it just schedules re-init anyway
-        const isCritical = event === 'character_switching';
+        // character_switching (cleanup) and loot_opened (accepted character-scoped event) must
+        // run immediately. character_switched can be deferred - it just schedules re-init anyway.
+        const isCritical = event === 'character_switching' || event === 'loot_opened';
 
         if (isCritical) {
             // Run immediately on main thread

--- a/src/core/data-manager.test.js
+++ b/src/core/data-manager.test.js
@@ -1110,6 +1110,81 @@ describe('DataManager character-WebSocket ownership (TLA-018)', () => {
         );
         expect(dataManager.getHouseRoomLevel('/house_rooms/b')).toBe(7);
     });
+
+    test('loot_opened is emitted with the accepted character id only when it arrives on the active socket', async () => {
+        const { default: dataManager } = await import('./data-manager.js');
+        const initHandler = webSocketHandlers.get('init_character_data');
+        const lootHandler = webSocketHandlers.get('loot_opened');
+        const socketA = {};
+        const socketB = {};
+        const listener = vi.fn();
+        dataManager.on('loot_opened', listener);
+
+        await initHandler(makePayload(11001), { socket: socketA });
+        await initHandler(makePayload(11002), { socket: socketB });
+
+        // OWN-1: A accepted -> B accepted -> delayed A loot_opened must be ignored.
+        lootHandler({ openedItem: { itemHrid: '/items/chest', count: 1 } }, { socket: socketA });
+        expect(listener).not.toHaveBeenCalled();
+
+        // B's own opening is accepted and carries B's character id.
+        lootHandler({ openedItem: { itemHrid: '/items/chest', count: 1 } }, { socket: socketB });
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(listener.mock.calls[0][0].characterId).toBe(11002);
+        expect(listener.mock.calls[0][0].data.openedItem.itemHrid).toBe('/items/chest');
+
+        dataManager.off('loot_opened', listener);
+    });
+
+    test('OWN-2: a same-character reconnect to a new socket makes the old socket stale for loot_opened too', async () => {
+        const { default: dataManager } = await import('./data-manager.js');
+        const initHandler = webSocketHandlers.get('init_character_data');
+        const lootHandler = webSocketHandlers.get('loot_opened');
+        const socket1 = {};
+        const socket2 = {};
+        const listener = vi.fn();
+        dataManager.on('loot_opened', listener);
+
+        await initHandler(makePayload(11101), { socket: socket1 });
+        await initHandler(makePayload(11101), { socket: socket2 }); // same character, new socket
+
+        lootHandler({ openedItem: { itemHrid: '/items/crate', count: 1 } }, { socket: socket1 });
+        expect(listener).not.toHaveBeenCalled();
+
+        lootHandler({ openedItem: { itemHrid: '/items/crate', count: 1 } }, { socket: socket2 });
+        expect(listener).toHaveBeenCalledTimes(1);
+
+        dataManager.off('loot_opened', listener);
+    });
+
+    test('loot_opened is delivered synchronously (critical dispatch) so it cannot be lost to a following character_switching cleanup', async () => {
+        const { default: dataManager } = await import('./data-manager.js');
+        const initHandler = webSocketHandlers.get('init_character_data');
+        const lootHandler = webSocketHandlers.get('loot_opened');
+        const socketA = {};
+        const listener = vi.fn();
+        dataManager.on('loot_opened', listener);
+
+        await initHandler(makePayload(11201), { socket: socketA });
+        lootHandler({ openedItem: { itemHrid: '/items/chest', count: 1 } }, { socket: socketA });
+
+        // No need to flush timers: a critical/synchronous event must already be delivered.
+        expect(listener).toHaveBeenCalledTimes(1);
+
+        dataManager.off('loot_opened', listener);
+    });
+
+    test('loot_opened is ignored before any character is accepted', async () => {
+        const { default: dataManager } = await import('./data-manager.js');
+        const lootHandler = webSocketHandlers.get('loot_opened');
+        const listener = vi.fn();
+        dataManager.on('loot_opened', listener);
+
+        lootHandler({ openedItem: { itemHrid: '/items/chest', count: 1 } }, { socket: {} });
+
+        expect(listener).not.toHaveBeenCalled();
+        dataManager.off('loot_opened', listener);
+    });
 });
 
 describe('DataManager offline-progress cap / MooPass getters', () => {

--- a/src/core/settings-schema.js
+++ b/src/core/settings-schema.js
@@ -1408,6 +1408,13 @@ export const settingsGroups = {
                 default: true,
                 help: 'When enabled, Scroll of... items from the Labyrinth are not auto-opened',
             },
+            openableAnalytics: {
+                id: 'openableAnalytics',
+                label: 'Openable Analytics: Track Actual vs Expected Value + Luck',
+                type: 'checkbox',
+                default: true,
+                help: 'Shows Actual Value, Expected Value, and Luck for chests/crates/caches you open, plus a character-scoped Analytics view with session/lifetime history',
+            },
         },
     },
 

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -8,8 +8,14 @@ class Storage {
     constructor() {
         this.db = null;
         this.available = false;
-        this.dbName = 'ToolashaDB';
         this.dbVersion = 20; // Bumped for characterActivityStatus and openableAnalytics stores
+        // Standalone dev/test builds (BUILD_TARGET=dev-standalone) must never share the released
+        // product's IndexedDB namespace: a dev build carrying an unreleased schema bump upgrades
+        // ToolashaDB in place, and released code can then never reopen it (VersionError) once the
+        // dev build is removed. The build-channel marker is injected by rollup.config.js only for
+        // that target, so production/watch builds are unaffected.
+        const isStandaloneDevBuild = globalThis.__TOOLASHA_BUILD_CHANNEL__ === 'dev-standalone';
+        this.dbName = isStandaloneDevBuild ? `ToolashaDB-dev-v${this.dbVersion}` : 'ToolashaDB';
         this.saveDebounceTimers = new Map(); // Per-key debounce timers
         this.pendingWrites = new Map(); // Per-key pending write data: {value, storeName, resolvers, generation}
         this._writeGeneration = new Map(); // Per-key monotonic generation counter
@@ -43,7 +49,18 @@ class Storage {
             const request = indexedDB.open(this.dbName, this.dbVersion);
 
             request.onerror = () => {
-                console.error('[Storage] Failed to open IndexedDB', request.error);
+                if (request.error?.name === 'VersionError') {
+                    // The physical DB was created by a newer Toolasha schema than this build
+                    // requests. Never delete/recreate it here - the data is intact and only
+                    // needs a compatible/newer Toolasha version to open it again.
+                    console.error(
+                        `[Storage] ${this.dbName} was created by a newer Toolasha schema. ` +
+                            'Stored data has been preserved; install a compatible/newer Toolasha version.',
+                        request.error
+                    );
+                } else {
+                    console.error('[Storage] Failed to open IndexedDB', request.error);
+                }
                 reject(request.error);
             };
 

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -9,7 +9,7 @@ class Storage {
         this.db = null;
         this.available = false;
         this.dbName = 'ToolashaDB';
-        this.dbVersion = 19; // Bumped for characterActivityStatus store
+        this.dbVersion = 20; // Bumped for characterActivityStatus and openableAnalytics stores
         this.saveDebounceTimers = new Map(); // Per-key debounce timers
         this.pendingWrites = new Map(); // Per-key pending write data: {value, storeName, resolvers, generation}
         this._writeGeneration = new Map(); // Per-key monotonic generation counter
@@ -178,6 +178,12 @@ class Storage {
                 // Activity Status projections + account-level presentation preferences)
                 if (!db.objectStoreNames.contains('characterActivityStatus')) {
                     db.createObjectStore('characterActivityStatus');
+                }
+
+                // Create openableAnalytics store if it doesn't exist (for Openable Analytics
+                // lifetime aggregates and bounded detailed opening history)
+                if (!db.objectStoreNames.contains('openableAnalytics')) {
+                    db.createObjectStore('openableAnalytics');
                 }
             };
         });

--- a/src/core/storage.test.js
+++ b/src/core/storage.test.js
@@ -39,8 +39,13 @@ function makeFakeDb(shouldFail = false) {
 
 // ── Fresh Storage instance per test ─────────────────────────────────────────
 
-async function makeStorage() {
+async function makeStorage({ devStandalone = false } = {}) {
     vi.resetModules();
+    if (devStandalone) {
+        globalThis.__TOOLASHA_BUILD_CHANNEL__ = 'dev-standalone';
+    } else {
+        delete globalThis.__TOOLASHA_BUILD_CHANNEL__;
+    }
     const mod = await import('./storage.js');
     const s = mod.default;
     // Reset internal state for isolation
@@ -61,6 +66,7 @@ describe('Storage write durability (TLA-007)', () => {
 
     afterEach(() => {
         vi.useRealTimers();
+        delete globalThis.__TOOLASHA_BUILD_CHANNEL__;
     });
 
     test('DB closes before debounce fires: value is requeued and survives', async () => {
@@ -197,5 +203,56 @@ describe('Storage write durability (TLA-007)', () => {
         // All coalesced into the last write — the winning write should resolve true
         expect(results[results.length - 1]).toBe(true);
         expect(goodDb._store['c']).toBe('v3');
+    });
+});
+
+describe('Storage database identity and VersionError safety (TLA-022)', () => {
+    afterEach(() => {
+        delete globalThis.__TOOLASHA_BUILD_CHANNEL__;
+        vi.unstubAllGlobals();
+    });
+
+    test('STORAGE-DEV-1: production storage keeps the released ToolashaDB namespace', async () => {
+        const s = await makeStorage();
+        expect(s.dbName).toBe('ToolashaDB');
+    });
+
+    test('STORAGE-DEV-2/3: standalone dev storage is isolated and schema-scoped', async () => {
+        const s = await makeStorage({ devStandalone: true });
+        expect(s.dbName).toBe(`ToolashaDB-dev-v${s.dbVersion}`);
+        expect(s.dbName).not.toBe('ToolashaDB');
+    });
+
+    test('STORAGE-DEV-5: removing the dev build marker returns to the production database identity', async () => {
+        const dev = await makeStorage({ devStandalone: true });
+        expect(dev.dbName).not.toBe('ToolashaDB');
+
+        const stable = await makeStorage();
+        expect(stable.dbName).toBe('ToolashaDB');
+    });
+
+    test('STORAGE-DEV-7/8: VersionError preserves the database and reports a newer-schema diagnostic', async () => {
+        const s = await makeStorage();
+        const request = {};
+        const deleteDatabase = vi.fn();
+        const versionError = new Error('requested version is lower than existing version');
+        versionError.name = 'VersionError';
+
+        vi.stubGlobal('indexedDB', {
+            open: vi.fn(() => {
+                queueMicrotask(() => {
+                    request.error = versionError;
+                    request.onerror?.();
+                });
+                return request;
+            }),
+            deleteDatabase,
+        });
+
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        await expect(s.openDatabase()).rejects.toMatchObject({ name: 'VersionError' });
+        expect(deleteDatabase).not.toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('newer Toolasha schema'), versionError);
     });
 });

--- a/src/core/websocket.js
+++ b/src/core/websocket.js
@@ -31,7 +31,10 @@ class WebSocketHook {
         this.processedMessages = new Map(); // socket-scoped message hash -> timestamp
         this.socketDedupIds = new WeakMap();
         this.nextSocketDedupId = 1;
-        this.recentActionCompleted = new Map(); // message content -> timestamp (50ms TTL dedup)
+        // Some character event types must bypass the lossy first-100-char dedup because two
+        // genuine messages can share the same prefix. Keep a tiny socket-scoped exact-message
+        // guard for duplicate interception of the same physical payload instead.
+        this.recentExactMessages = new Map(); // socket + type + full message -> timestamp
         this.messageCleanupInterval = null;
         this.isSocketWrapped = false;
         this.originalWebSocket = null;
@@ -254,7 +257,8 @@ class WebSocketHook {
             messageType === 'setting_updated' ||
             messageType === 'labyrinth_room_progress' ||
             messageType === 'leaderboard_updated' ||
-            messageType === 'guild_updated';
+            messageType === 'guild_updated' ||
+            messageType === 'loot_opened';
 
         if (!skipDedup) {
             // Deduplicate by message content to prevent multiple interception paths from
@@ -274,23 +278,28 @@ class WebSocketHook {
             if (this.processedMessages.size > 100) {
                 this.cleanupProcessedMessages();
             }
-        } else if (messageType === 'action_completed') {
-            // action_completed bypasses the content-hash dedup (Gabriel's fix, commit 1007215)
-            // but the WebSocket prototype wrapper can fire two listeners for the same physical
-            // message object. The WeakSet guard catches same-object duplicates, but if two
-            // independent listeners each receive a distinct MessageEvent wrapping the same
-            // payload, both pass the WeakSet check and processMessage is called twice.
-            // Use a short 50ms TTL keyed on full message content to collapse these duplicates.
-            // Two genuine consecutive action_completed messages are always seconds apart.
+        } else if (messageType === 'action_completed' || messageType === 'loot_opened') {
+            // These types bypass the lossy first-100-char dedup (Gabriel's fix, commit 1007215,
+            // extended to loot_opened) because two genuine consecutive messages can share the
+            // same prefix while differing later. The WebSocket prototype wrapper can still fire
+            // two listeners for the same physical message object - the WeakSet guard catches
+            // same-object duplicates, but if two independent listeners each receive a distinct
+            // MessageEvent wrapping the same payload, both pass the WeakSet check and
+            // processMessage is called twice. Collapse only that exact-duplicate interception in
+            // a short 50ms TTL window, scoped per socket and message type so a reconnect can
+            // replay identical state without being suppressed by the old socket's guard.
             const now = Date.now();
-            if (this.recentActionCompleted.has(message)) {
+            const socketKey = this.getSocketDedupKey(socket);
+            const exactKey = `${socketKey}:${messageType}:${message}`;
+            const previous = this.recentExactMessages.get(exactKey);
+            if (previous !== undefined && now - previous <= 50) {
                 return; // Duplicate from second listener — skip
             }
-            this.recentActionCompleted.set(message, now);
+            this.recentExactMessages.set(exactKey, now);
             // Prune entries older than 50ms to keep memory bounded
-            for (const [key, ts] of this.recentActionCompleted) {
+            for (const [key, ts] of this.recentExactMessages) {
                 if (now - ts > 50) {
-                    this.recentActionCompleted.delete(key);
+                    this.recentExactMessages.delete(key);
                 }
             }
         }
@@ -511,6 +520,7 @@ class WebSocketHook {
     cleanup() {
         this.clearClientDataRetry();
         this.processedMessages.clear();
+        this.recentExactMessages.clear();
     }
 
     /**

--- a/src/core/websocket.test.js
+++ b/src/core/websocket.test.js
@@ -174,3 +174,67 @@ describe('WebSocket hook — guild_updated must not be dropped by content-hash d
         expect(handler.mock.calls[1][0].guild.experience).toBe(2500);
     });
 });
+
+describe('WebSocket hook — loot_opened dedup (OA-1)', () => {
+    let webSocketHook;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        const mod = await import('./websocket.js');
+        webSocketHook = mod.default;
+    });
+
+    // A real loot_opened payload's `openedItem` alone can fill the first 100 raw chars, so two
+    // genuine consecutive openings of the same container that differ only in `gainedItems`
+    // (further into the object) would hash identically under the lossy first-100-char dedup.
+    function lootOpenedMessage(gainedItemCount) {
+        const openedItem = { itemHrid: '/items/chimerical_chest', enhancementLevel: 0, count: 1 };
+        return JSON.stringify({
+            type: 'loot_opened',
+            openedItem,
+            gainedItems: [{ itemHrid: '/items/coin', enhancementLevel: 0, count: gainedItemCount }],
+            grantedBuffs: [],
+        });
+    }
+
+    test('DEDUP-1: two same-socket loot_opened messages sharing the first 100 chars but differing later both dispatch', () => {
+        const handler = vi.fn();
+        webSocketHook.on('loot_opened', handler);
+        const socket = makeFakeWebSocket();
+
+        const first = lootOpenedMessage(100);
+        const second = lootOpenedMessage(200);
+        expect(first.substring(0, 100)).toBe(second.substring(0, 100));
+
+        webSocketHook.processMessage(first, socket);
+        webSocketHook.processMessage(second, socket);
+
+        expect(handler).toHaveBeenCalledTimes(2);
+        expect(handler.mock.calls[1][0].gainedItems[0].count).toBe(200);
+    });
+
+    test('DEDUP-2: an exact duplicate interception of the same physical message collapses to one dispatch', () => {
+        const handler = vi.fn();
+        webSocketHook.on('loot_opened', handler);
+        const socket = makeFakeWebSocket();
+        const message = lootOpenedMessage(100);
+
+        webSocketHook.processMessage(message, socket);
+        webSocketHook.processMessage(message, socket);
+
+        expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    test('DEDUP-3: the same raw content on a newly accepted socket is not suppressed by an old socket’s dedup state', () => {
+        const handler = vi.fn();
+        webSocketHook.on('loot_opened', handler);
+        const socketA = makeFakeWebSocket();
+        const socketB = makeFakeWebSocket();
+        const message = lootOpenedMessage(100);
+
+        webSocketHook.processMessage(message, socketA);
+        webSocketHook.processMessage(message, socketB);
+
+        expect(handler).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/entrypoint-feature-registration.test.js
+++ b/src/entrypoint-feature-registration.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)));
+const entrypointSource = readFileSync(resolve(ROOT, 'entrypoint.js'), 'utf8');
+
+/**
+ * OA-RUNTIME-2 regression: the Expected Value Calculator is shared infrastructure consumed by
+ * both the tooltip feature and Openable Analytics. FeatureRegistry only initializes a feature
+ * when its customCheck (or config.isFeatureEnabled fallback) returns true, so gating solely on
+ * `itemTooltip_expectedValue` would leave Openable Analytics without Expected/Luck after any
+ * character switch where that tooltip setting is off. This is a static source assertion (rather
+ * than an executed FeatureRegistry test) because entrypoint.js reads its dependencies from
+ * `window.Toolasha.*` globals rather than ES imports and isn't meant to run standalone.
+ */
+describe('Expected Value Calculator feature registration (OA-RUNTIME-2)', () => {
+    function extractFeatureBlock(key) {
+        const keyIndex = entrypointSource.indexOf(`key: '${key}'`);
+        expect(keyIndex).toBeGreaterThan(-1);
+        const blockEnd = entrypointSource.indexOf('},', keyIndex);
+        return entrypointSource.slice(keyIndex, blockEnd);
+    }
+
+    test('has a customCheck rather than relying only on the tooltip feature toggle', () => {
+        const block = extractFeatureBlock('expectedValueCalculator');
+
+        expect(block).toContain('customCheck');
+    });
+
+    test('customCheck references both consumer settings', () => {
+        const block = extractFeatureBlock('expectedValueCalculator');
+
+        expect(block).toContain('itemTooltip_expectedValue');
+        expect(block).toContain('openableAnalytics');
+    });
+});

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -216,6 +216,13 @@ function registerFeatures() {
             async: false,
         },
         {
+            key: 'openableAnalytics',
+            name: 'Openable Analytics',
+            category: 'Inventory',
+            module: Market.openableAnalytics,
+            async: true,
+        },
+        {
             key: 'inventoryTabs',
             name: 'Custom Inventory Tabs',
             category: 'Inventory',

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -56,6 +56,10 @@ function registerFeatures() {
             category: 'Market',
             module: Market.expectedValueCalculator,
             async: true,
+            // Shared infrastructure: initialize when either consumer needs it, not only when the
+            // tooltip UI setting is on, so Openable Analytics keeps working after a character
+            // switch even when itemTooltip_expectedValue is off (OA-RUNTIME-2).
+            customCheck: () => config.getSetting('itemTooltip_expectedValue') || config.getSetting('openableAnalytics'),
         },
         {
             key: 'tooltipConsumables',

--- a/src/features/inventory/openable-analytics/openable-analytics-calculator.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-calculator.js
@@ -1,0 +1,157 @@
+/**
+ * Openable Analytics Calculator
+ * Pure valuation math for one opening: Actual Value, Expected Value, and Luck (Actual - Expected).
+ * Consumes Toolasha's existing Expected Value calculator and sell-side pricing stack rather than
+ * duplicating drop/pricing formulas.
+ */
+
+import dataManager from '../../../core/data-manager.js';
+import config from '../../../core/config.js';
+import expectedValueCalculator from '../../market/expected-value-calculator.js';
+import { calculatePriceAfterTax } from '../../../utils/profit-helpers.js';
+import { MARKET_TAX } from '../../../utils/profit-constants.js';
+
+/**
+ * Value one gained item stack at event-time sell-side prices, applying market tax when the
+ * resolved value source requires it (mirrors `resolveSellSideValue`'s own `needsTax` contract).
+ * @param {string} itemHrid - Gained item HRID
+ * @param {number} enhancementLevel - Enhancement level of the gained stack
+ * @param {number} count - Number of this item gained
+ * @returns {{value: number, resolved: boolean}} Value contribution and whether it could be priced
+ */
+function valueGainedItemStack(itemHrid, enhancementLevel, count) {
+    const resolved = expectedValueCalculator.resolveSellSideValue(itemHrid, enhancementLevel || 0);
+    if (!resolved) {
+        return { value: 0, resolved: false };
+    }
+
+    const itemDetails = dataManager.getItemDetails(itemHrid);
+    const isTradable = itemDetails?.isTradable !== false;
+    const perUnit =
+        resolved.needsTax && isTradable ? calculatePriceAfterTax(resolved.value, MARKET_TAX) : resolved.value;
+
+    return { value: perUnit * (count || 0), resolved: true };
+}
+
+/**
+ * Calculate the Actual Value of one opening from its gained items. Never treats a missing
+ * price as zero silently - items that cannot be priced are excluded from the total and the
+ * result is marked incomplete so callers/UI can surface a partial state instead of a false
+ * precise number.
+ * @param {Array<{itemHrid: string, enhancementLevel?: number, count: number}>} gainedItems
+ * @returns {{value: number, complete: boolean}} Actual value and whether every item was priced
+ */
+export function calculateActualValue(gainedItems) {
+    let total = 0;
+    let complete = true;
+
+    for (const item of gainedItems || []) {
+        if (!item?.itemHrid) continue;
+        const { value, resolved } = valueGainedItemStack(item.itemHrid, item.enhancementLevel, item.count);
+        total += value;
+        if (!resolved) complete = false;
+    }
+
+    return { value: total, complete };
+}
+
+/**
+ * Calculate the Expected Value of one opening using Toolasha's existing container EV calculator.
+ * Returns `available: false` (never a fake zero) when the opened item has no meaningful
+ * monetary EV model - e.g. a not-yet-initialized calculator, or a buff-only openable that has
+ * no entry in `openableLootDropMap`.
+ * @param {string} containerHrid - Opened container item HRID
+ * @param {number} containerCount - Number of containers opened by this event
+ * @returns {{value: number|null, available: boolean}}
+ */
+export function calculateExpectedValueForOpening(containerHrid, containerCount) {
+    if (!containerHrid || !(containerCount > 0)) {
+        return { value: null, available: false };
+    }
+
+    const ev = expectedValueCalculator.calculateExpectedValue(containerHrid);
+    if (!ev || !(ev.expectedValue >= 0)) {
+        return { value: null, available: false };
+    }
+
+    return { value: ev.expectedValue * containerCount, available: true };
+}
+
+/**
+ * Calculate Luck (Actual - Expected) and Luck % for one opening. Luck is only meaningful when
+ * Expected Value is available; otherwise both fields are `null`, never a fabricated zero.
+ * @param {number} actualValue
+ * @param {number|null} expectedValue
+ * @param {boolean} expectedAvailable
+ * @returns {{luckValue: number|null, luckPercent: number|null}}
+ */
+export function calculateLuck(actualValue, expectedValue, expectedAvailable) {
+    if (!expectedAvailable || expectedValue === null) {
+        return { luckValue: null, luckPercent: null };
+    }
+
+    const luckValue = actualValue - expectedValue;
+    const luckPercent = expectedValue > 0 ? (luckValue / expectedValue) * 100 : null;
+
+    return { luckValue, luckPercent };
+}
+
+/**
+ * Build a fully normalized opening record from already-extracted opening data. This is the
+ * shared seam for both the live `loot_opened` WebSocket path and any future historical-import
+ * adapter (e.g. Edible Tools / MWI Combat Suite data) - a future importer only needs to map its
+ * own data into this same `{containerHrid, containerCount, gainedItems, grantedBuffs, timestamp,
+ * characterId, source}` shape and call this function, without needing to know about
+ * `loot_opened` at all.
+ * @param {Object} input
+ * @param {string} input.containerHrid
+ * @param {number} input.containerCount
+ * @param {Array} input.gainedItems
+ * @param {Array} [input.grantedBuffs]
+ * @param {number} input.timestamp
+ * @param {string} input.characterId
+ * @param {string} [input.source] - Provenance tag, e.g. 'loot_opened' or a future 'import:*'
+ * @returns {Object} Normalized opening record
+ */
+export function buildOpeningRecord({
+    containerHrid,
+    containerCount,
+    gainedItems,
+    grantedBuffs,
+    timestamp,
+    characterId,
+    source = 'loot_opened',
+}) {
+    const normalizedGainedItems = (gainedItems || [])
+        .filter((item) => item?.itemHrid)
+        .map((item) => ({
+            itemHrid: item.itemHrid,
+            enhancementLevel: item.enhancementLevel || 0,
+            count: item.count || 0,
+        }));
+
+    const { value: actualValue, complete: actualValueComplete } = calculateActualValue(normalizedGainedItems);
+    const { value: expectedValue, available: expectedValueAvailable } = calculateExpectedValueForOpening(
+        containerHrid,
+        containerCount
+    );
+    const { luckValue, luckPercent } = calculateLuck(actualValue, expectedValue, expectedValueAvailable);
+
+    return {
+        timestamp,
+        characterId,
+        containerHrid,
+        containerCount,
+        gainedItems: normalizedGainedItems,
+        grantedBuffs: (grantedBuffs || []).map((buff) => ({ typeHrid: buff.typeHrid, duration: buff.duration })),
+        actualValue,
+        actualValueComplete,
+        expectedValue,
+        expectedValueAvailable,
+        luckValue,
+        luckPercent,
+        pricingMode: config.getSettingValue('profitCalc_pricingMode', 'hybrid'),
+        keyPricingMode: config.getSettingValue('profitCalc_keyPricingMode', 'ask'),
+        source,
+    };
+}

--- a/src/features/inventory/openable-analytics/openable-analytics-calculator.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-calculator.js
@@ -68,34 +68,53 @@ export function calculateActualValue(gainedItems) {
  * Calculate the Expected Value of one opening using Toolasha's existing container EV calculator.
  * Returns `available: false` (never a fake zero) when the opened item has no meaningful
  * monetary EV model - e.g. a not-yet-initialized calculator, or a buff-only openable that has
- * no entry in `openableLootDropMap`.
+ * no entry in `openableLootDropMap`. `isOpenable` alone is broader than "has a monetary loot
+ * model": Labyrinth Scroll/Seal items are openable because they grant a buff, so the underlying
+ * drop table must be checked directly rather than trusting a non-negative EV total.
  * @param {string} containerHrid - Opened container item HRID
  * @param {number} containerCount - Number of containers opened by this event
- * @returns {{value: number|null, available: boolean}}
+ * @returns {{value: number|null, available: boolean, complete: boolean}}
  */
 export function calculateExpectedValueForOpening(containerHrid, containerCount) {
     if (!containerHrid || !(containerCount > 0)) {
-        return { value: null, available: false };
+        return { value: null, available: false, complete: false };
+    }
+
+    const dropTable = dataManager.getInitClientData?.()?.openableLootDropMap?.[containerHrid];
+    if (!Array.isArray(dropTable) || dropTable.length === 0) {
+        return { value: null, available: false, complete: false };
     }
 
     const ev = expectedValueCalculator.calculateExpectedValue(containerHrid);
     if (!ev || !(ev.expectedValue >= 0)) {
-        return { value: null, available: false };
+        return { value: null, available: false, complete: false };
     }
 
-    return { value: ev.expectedValue * containerCount, available: true };
+    // The shared EV breakdown already reports per-drop hasPriceData. Keep the numeric subtotal
+    // available as partial information, but never let it be treated as complete for Luck.
+    const complete = !Array.isArray(ev.drops) || ev.drops.every((drop) => drop?.hasPriceData !== false);
+    return { value: ev.expectedValue * containerCount, available: true, complete };
 }
 
 /**
  * Calculate Luck (Actual - Expected) and Luck % for one opening. Luck is only meaningful when
- * Expected Value is available; otherwise both fields are `null`, never a fabricated zero.
+ * both sides of the comparison are complete: an incomplete Actual subtotal or a partial Expected
+ * breakdown must never be presented as a precise, comparable Luck number.
  * @param {number} actualValue
  * @param {number|null} expectedValue
  * @param {boolean} expectedAvailable
+ * @param {boolean} [actualComplete] - Whether the Actual subtotal priced every gained item
+ * @param {boolean} [expectedComplete] - Whether every modeled Expected drop could be priced
  * @returns {{luckValue: number|null, luckPercent: number|null}}
  */
-export function calculateLuck(actualValue, expectedValue, expectedAvailable) {
-    if (!expectedAvailable || expectedValue === null) {
+export function calculateLuck(
+    actualValue,
+    expectedValue,
+    expectedAvailable,
+    actualComplete = true,
+    expectedComplete = true
+) {
+    if (!actualComplete || !expectedAvailable || !expectedComplete || expectedValue === null) {
         return { luckValue: null, luckPercent: null };
     }
 
@@ -120,6 +139,9 @@ export function calculateLuck(actualValue, expectedValue, expectedAvailable) {
  * @param {number} input.timestamp
  * @param {string} input.characterId
  * @param {string} [input.source] - Provenance tag, e.g. 'loot_opened' or a future 'import:*'
+ * @param {boolean} [input.sourceDataComplete] - False when the caller already knows part of its
+ *      own source data could not be resolved (e.g. an import parser that had to drop an unmatched
+ *      gained-item name) - keeps that upstream gap from silently looking like a complete Actual.
  * @returns {Object} Normalized opening record
  */
 export function buildOpeningRecord({
@@ -130,6 +152,7 @@ export function buildOpeningRecord({
     timestamp,
     characterId,
     source = 'loot_opened',
+    sourceDataComplete = true,
 }) {
     const normalizedGainedItems = (gainedItems || [])
         .filter((item) => item?.itemHrid)
@@ -144,11 +167,19 @@ export function buildOpeningRecord({
         complete: actualValueComplete,
         breakdown: actualValueBreakdown,
     } = calculateActualValue(normalizedGainedItems);
-    const { value: expectedValue, available: expectedValueAvailable } = calculateExpectedValueForOpening(
-        containerHrid,
-        containerCount
+    const effectiveActualComplete = actualValueComplete && sourceDataComplete;
+    const {
+        value: expectedValue,
+        available: expectedValueAvailable,
+        complete: expectedValueComplete,
+    } = calculateExpectedValueForOpening(containerHrid, containerCount);
+    const { luckValue, luckPercent } = calculateLuck(
+        actualValue,
+        expectedValue,
+        expectedValueAvailable,
+        effectiveActualComplete,
+        expectedValueComplete
     );
-    const { luckValue, luckPercent } = calculateLuck(actualValue, expectedValue, expectedValueAvailable);
 
     return {
         timestamp,
@@ -158,10 +189,12 @@ export function buildOpeningRecord({
         gainedItems: normalizedGainedItems,
         grantedBuffs: (grantedBuffs || []).map((buff) => ({ typeHrid: buff.typeHrid, duration: buff.duration })),
         actualValue,
-        actualValueComplete,
+        actualValueComplete: effectiveActualComplete,
         actualValueBreakdown,
         expectedValue,
         expectedValueAvailable,
+        expectedValueComplete,
+        sourceDataComplete,
         luckValue,
         luckPercent,
         pricingMode: config.getSettingValue('profitCalc_pricingMode', 'hybrid'),
@@ -184,6 +217,8 @@ export function buildOpeningRecord({
  * @param {number} input.timestamp
  * @param {string} input.characterId
  * @param {string} input.source - e.g. 'import:edible' or 'import:mwi-combat-suite'
+ * @param {boolean} [input.sourceDataComplete] - False when the import parser had to drop an
+ *      unresolved gained-item name, so this synthetic record's Actual is only a subtotal.
  * @returns {Object} Normalized opening record (enhancementLevel always 0 - imports don't track it)
  */
 export function buildImportedAggregateRecord({
@@ -193,6 +228,7 @@ export function buildImportedAggregateRecord({
     timestamp,
     characterId,
     source,
+    sourceDataComplete = true,
 }) {
     const gainedItems = Object.entries(itemTotals || {}).map(([itemHrid, count]) => ({
         itemHrid,
@@ -208,5 +244,6 @@ export function buildImportedAggregateRecord({
         timestamp,
         characterId,
         source,
+        sourceDataComplete,
     });
 }

--- a/src/features/inventory/openable-analytics/openable-analytics-calculator.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-calculator.js
@@ -90,9 +90,16 @@ export function calculateExpectedValueForOpening(containerHrid, containerCount) 
         return { value: null, available: false, complete: false };
     }
 
-    // The shared EV breakdown already reports per-drop hasPriceData. Keep the numeric subtotal
-    // available as partial information, but never let it be treated as complete for Luck.
-    const complete = !Array.isArray(ev.drops) || ev.drops.every((drop) => drop?.hasPriceData !== false);
+    // The shared calculator's breakdown (`ev.drops`) can silently omit an active raw drop
+    // entirely when it can't resolve that item's details, rather than reporting it with
+    // `hasPriceData: false`. Checking `hasPriceData` on only the rows that survived into
+    // `ev.drops` can therefore falsely prove completeness. Compare against every drop the raw
+    // table itself considers active (a positive drop rate) before trusting the breakdown.
+    const activeRawDrops = dropTable.filter((drop) => (drop?.dropRate || 0) > 0);
+    const complete =
+        Array.isArray(ev.drops) &&
+        ev.drops.length === activeRawDrops.length &&
+        ev.drops.every((drop) => drop?.hasPriceData !== false);
     return { value: ev.expectedValue * containerCount, available: true, complete };
 }
 

--- a/src/features/inventory/openable-analytics/openable-analytics-calculator.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-calculator.js
@@ -155,3 +155,44 @@ export function buildOpeningRecord({
         source,
     };
 }
+
+/**
+ * Build a normalized opening record from a bulk `{itemHrid: count}` map instead of an
+ * individual `gainedItems` array. This is the seam for historical bulk-import sources (Edible
+ * Tools, MWI Combat Suite) that only retain cumulative item totals per container, not
+ * per-opening detail - the import produces one synthetic record representing the entire
+ * imported total, valued through the exact same `buildOpeningRecord` math (and therefore
+ * Toolasha's own pricing/EV, never the source tool's own stored numbers).
+ * @param {Object} input
+ * @param {string} input.containerHrid
+ * @param {number} input.containerCount - Total containers opened, per the import source
+ * @param {Object} input.itemTotals - Map of itemHrid -> cumulative count gained
+ * @param {number} input.timestamp
+ * @param {string} input.characterId
+ * @param {string} input.source - e.g. 'import:edible' or 'import:mwi-combat-suite'
+ * @returns {Object} Normalized opening record (enhancementLevel always 0 - imports don't track it)
+ */
+export function buildImportedAggregateRecord({
+    containerHrid,
+    containerCount,
+    itemTotals,
+    timestamp,
+    characterId,
+    source,
+}) {
+    const gainedItems = Object.entries(itemTotals || {}).map(([itemHrid, count]) => ({
+        itemHrid,
+        enhancementLevel: 0,
+        count,
+    }));
+
+    return buildOpeningRecord({
+        containerHrid,
+        containerCount,
+        gainedItems,
+        grantedBuffs: [],
+        timestamp,
+        characterId,
+        source,
+    });
+}

--- a/src/features/inventory/openable-analytics/openable-analytics-calculator.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-calculator.js
@@ -37,22 +37,31 @@ function valueGainedItemStack(itemHrid, enhancementLevel, count) {
  * Calculate the Actual Value of one opening from its gained items. Never treats a missing
  * price as zero silently - items that cannot be priced are excluded from the total and the
  * result is marked incomplete so callers/UI can surface a partial state instead of a false
- * precise number.
+ * precise number. Also returns a per-item breakdown (mirrors the totals) so callers can show or
+ * snapshot individual item values, not just the aggregate.
  * @param {Array<{itemHrid: string, enhancementLevel?: number, count: number}>} gainedItems
- * @returns {{value: number, complete: boolean}} Actual value and whether every item was priced
+ * @returns {{value: number, complete: boolean, breakdown: Array<{itemHrid: string, enhancementLevel: number, count: number, value: number, resolved: boolean}>}}
  */
 export function calculateActualValue(gainedItems) {
     let total = 0;
     let complete = true;
+    const breakdown = [];
 
     for (const item of gainedItems || []) {
         if (!item?.itemHrid) continue;
         const { value, resolved } = valueGainedItemStack(item.itemHrid, item.enhancementLevel, item.count);
         total += value;
         if (!resolved) complete = false;
+        breakdown.push({
+            itemHrid: item.itemHrid,
+            enhancementLevel: item.enhancementLevel || 0,
+            count: item.count || 0,
+            value,
+            resolved,
+        });
     }
 
-    return { value: total, complete };
+    return { value: total, complete, breakdown };
 }
 
 /**
@@ -130,7 +139,11 @@ export function buildOpeningRecord({
             count: item.count || 0,
         }));
 
-    const { value: actualValue, complete: actualValueComplete } = calculateActualValue(normalizedGainedItems);
+    const {
+        value: actualValue,
+        complete: actualValueComplete,
+        breakdown: actualValueBreakdown,
+    } = calculateActualValue(normalizedGainedItems);
     const { value: expectedValue, available: expectedValueAvailable } = calculateExpectedValueForOpening(
         containerHrid,
         containerCount
@@ -146,6 +159,7 @@ export function buildOpeningRecord({
         grantedBuffs: (grantedBuffs || []).map((buff) => ({ typeHrid: buff.typeHrid, duration: buff.duration })),
         actualValue,
         actualValueComplete,
+        actualValueBreakdown,
         expectedValue,
         expectedValueAvailable,
         luckValue,

--- a/src/features/inventory/openable-analytics/openable-analytics-calculator.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-calculator.test.js
@@ -15,8 +15,13 @@ vi.mock('../../market/expected-value-calculator.js', () => ({
 
 const { default: dataManager } = await import('../../../core/data-manager.js');
 const { default: expectedValueCalculator } = await import('../../market/expected-value-calculator.js');
-const { calculateActualValue, calculateExpectedValueForOpening, calculateLuck, buildOpeningRecord } =
-    await import('./openable-analytics-calculator.js');
+const {
+    calculateActualValue,
+    calculateExpectedValueForOpening,
+    calculateLuck,
+    buildOpeningRecord,
+    buildImportedAggregateRecord,
+} = await import('./openable-analytics-calculator.js');
 
 beforeEach(() => {
     vi.clearAllMocks();
@@ -195,5 +200,51 @@ describe('buildOpeningRecord', () => {
 
         expect(record.containerCount).toBe(100);
         expect(record.expectedValue).toBe(10000);
+    });
+});
+
+describe('buildImportedAggregateRecord', () => {
+    test('converts an itemTotals map into gainedItems and reuses buildOpeningRecord math', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({ expectedValue: 100 });
+        expectedValueCalculator.resolveSellSideValue.mockImplementation((itemHrid) =>
+            itemHrid === '/items/coin' ? { value: 1, needsTax: false } : { value: 10, needsTax: false }
+        );
+
+        const record = buildImportedAggregateRecord({
+            containerHrid: '/items/chest',
+            containerCount: 50,
+            itemTotals: { '/items/coin': 1000, '/items/pearl': 5 },
+            timestamp: 111,
+            characterId: 'char1',
+            source: 'import:mwi-combat-suite',
+        });
+
+        expect(record.gainedItems).toEqual(
+            expect.arrayContaining([
+                { itemHrid: '/items/coin', enhancementLevel: 0, count: 1000 },
+                { itemHrid: '/items/pearl', enhancementLevel: 0, count: 5 },
+            ])
+        );
+        expect(record.actualValue).toBe(1050); // 1000*1 + 5*10
+        expect(record.expectedValue).toBe(5000); // 100 * 50
+        expect(record.source).toBe('import:mwi-combat-suite');
+    });
+
+    test('never trusts the import source’s own valuation - recomputes from raw counts', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue(null);
+        expectedValueCalculator.resolveSellSideValue.mockReturnValue(null);
+
+        const record = buildImportedAggregateRecord({
+            containerHrid: '/items/unmodelled_chest',
+            containerCount: 10,
+            itemTotals: { '/items/mystery_item': 1 },
+            timestamp: 222,
+            characterId: 'char1',
+            source: 'import:edible',
+        });
+
+        expect(record.actualValue).toBe(0);
+        expect(record.actualValueComplete).toBe(false);
+        expect(record.expectedValueAvailable).toBe(false);
     });
 });

--- a/src/features/inventory/openable-analytics/openable-analytics-calculator.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-calculator.test.js
@@ -1,0 +1,199 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../core/data-manager.js', () => ({
+    default: { getItemDetails: vi.fn(() => ({ isTradable: true })) },
+}));
+vi.mock('../../../core/config.js', () => ({
+    default: { getSettingValue: vi.fn((key, defaultValue) => defaultValue) },
+}));
+vi.mock('../../market/expected-value-calculator.js', () => ({
+    default: {
+        resolveSellSideValue: vi.fn(),
+        calculateExpectedValue: vi.fn(),
+    },
+}));
+
+const { default: dataManager } = await import('../../../core/data-manager.js');
+const { default: expectedValueCalculator } = await import('../../market/expected-value-calculator.js');
+const { calculateActualValue, calculateExpectedValueForOpening, calculateLuck, buildOpeningRecord } =
+    await import('./openable-analytics-calculator.js');
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    dataManager.getItemDetails.mockReturnValue({ isTradable: true });
+});
+
+describe('calculateActualValue', () => {
+    test('sums resolved gained-item values, applying tax when the source requires it', () => {
+        expectedValueCalculator.resolveSellSideValue.mockReturnValue({ value: 100, source: 'market', needsTax: true });
+
+        const { value, complete } = calculateActualValue([{ itemHrid: '/items/x', enhancementLevel: 0, count: 2 }]);
+
+        // 100 * 2 = 200, taxed at 5% => 190
+        expect(value).toBeCloseTo(190);
+        expect(complete).toBe(true);
+    });
+
+    test('does not tax non-tradable items even when needsTax is true', () => {
+        dataManager.getItemDetails.mockReturnValue({ isTradable: false });
+        expectedValueCalculator.resolveSellSideValue.mockReturnValue({ value: 100, source: 'market', needsTax: true });
+
+        const { value } = calculateActualValue([{ itemHrid: '/items/x', enhancementLevel: 0, count: 1 }]);
+
+        expect(value).toBe(100);
+    });
+
+    test('does not tax coin (needsTax: false)', () => {
+        expectedValueCalculator.resolveSellSideValue.mockReturnValue({ value: 1, source: 'coin', needsTax: false });
+
+        const { value } = calculateActualValue([{ itemHrid: '/items/coin', enhancementLevel: 0, count: 500 }]);
+
+        expect(value).toBe(500);
+    });
+
+    test('marks the result partial and excludes the item when a price cannot be resolved', () => {
+        expectedValueCalculator.resolveSellSideValue.mockReturnValueOnce(null).mockReturnValueOnce({
+            value: 50,
+            source: 'market',
+            needsTax: false,
+        });
+
+        const { value, complete } = calculateActualValue([
+            { itemHrid: '/items/unpriced', enhancementLevel: 0, count: 1 },
+            { itemHrid: '/items/priced', enhancementLevel: 0, count: 1 },
+        ]);
+
+        expect(value).toBe(50);
+        expect(complete).toBe(false);
+    });
+
+    test('returns zero/complete for an empty gained-items list (buff-only opening)', () => {
+        const { value, complete } = calculateActualValue([]);
+
+        expect(value).toBe(0);
+        expect(complete).toBe(true);
+    });
+});
+
+describe('calculateExpectedValueForOpening', () => {
+    test('multiplies per-container EV by container count', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({ expectedValue: 1000 });
+
+        const { value, available } = calculateExpectedValueForOpening('/items/chest', 3);
+
+        expect(value).toBe(3000);
+        expect(available).toBe(true);
+    });
+
+    test('returns unavailable (not zero) when the EV calculator has no model for the item', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue(null);
+
+        const { value, available } = calculateExpectedValueForOpening('/items/seal_of_rare_find', 1);
+
+        expect(value).toBeNull();
+        expect(available).toBe(false);
+    });
+
+    test('returns unavailable when containerCount is zero or missing', () => {
+        const { value, available } = calculateExpectedValueForOpening('/items/chest', 0);
+
+        expect(value).toBeNull();
+        expect(available).toBe(false);
+        expect(expectedValueCalculator.calculateExpectedValue).not.toHaveBeenCalled();
+    });
+});
+
+describe('calculateLuck', () => {
+    test('positive luck when actual exceeds expected', () => {
+        const { luckValue, luckPercent } = calculateLuck(1500, 1000, true);
+
+        expect(luckValue).toBe(500);
+        expect(luckPercent).toBe(50);
+    });
+
+    test('negative luck when actual is below expected', () => {
+        const { luckValue, luckPercent } = calculateLuck(500, 1000, true);
+
+        expect(luckValue).toBe(-500);
+        expect(luckPercent).toBe(-50);
+    });
+
+    test('zero luck when actual equals expected', () => {
+        const { luckValue, luckPercent } = calculateLuck(1000, 1000, true);
+
+        expect(luckValue).toBe(0);
+        expect(luckPercent).toBe(0);
+    });
+
+    test('returns null (not zero) when expected value is unavailable', () => {
+        const { luckValue, luckPercent } = calculateLuck(500, null, false);
+
+        expect(luckValue).toBeNull();
+        expect(luckPercent).toBeNull();
+    });
+
+    test('returns null percent (not divide-by-zero) when expected value is exactly zero', () => {
+        const { luckValue, luckPercent } = calculateLuck(500, 0, true);
+
+        expect(luckValue).toBe(500);
+        expect(luckPercent).toBeNull();
+    });
+});
+
+describe('buildOpeningRecord', () => {
+    test('a granted-buff-only opening (no gained items, no EV model) is counted without fake luck', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue(null);
+
+        const record = buildOpeningRecord({
+            containerHrid: '/items/seal_of_rare_find',
+            containerCount: 1,
+            gainedItems: [],
+            grantedBuffs: [{ typeHrid: '/buff_types/rare_find', duration: 3600 }],
+            timestamp: 123,
+            characterId: 'char1',
+        });
+
+        expect(record.actualValue).toBe(0);
+        expect(record.actualValueComplete).toBe(true);
+        expect(record.expectedValue).toBeNull();
+        expect(record.expectedValueAvailable).toBe(false);
+        expect(record.luckValue).toBeNull();
+        expect(record.luckPercent).toBeNull();
+        expect(record.grantedBuffs).toHaveLength(1);
+    });
+
+    test('persists event-time pricing mode metadata for stable historical valuation', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({ expectedValue: 100 });
+        expectedValueCalculator.resolveSellSideValue.mockReturnValue({ value: 10, needsTax: false });
+
+        const record = buildOpeningRecord({
+            containerHrid: '/items/chest',
+            containerCount: 1,
+            gainedItems: [{ itemHrid: '/items/x', enhancementLevel: 0, count: 1 }],
+            timestamp: 456,
+            characterId: 'char1',
+        });
+
+        expect(record.pricingMode).toBe('hybrid');
+        expect(record.keyPricingMode).toBe('ask');
+        expect(record.source).toBe('loot_opened');
+        expect(record.timestamp).toBe(456);
+        expect(record.characterId).toBe('char1');
+    });
+
+    test('an openedItem.count > 1 (Open N) increments container count correctly and scales expected value', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({ expectedValue: 100 });
+        expectedValueCalculator.resolveSellSideValue.mockReturnValue({ value: 0, needsTax: false });
+
+        const record = buildOpeningRecord({
+            containerHrid: '/items/chest',
+            containerCount: 100,
+            gainedItems: [],
+            timestamp: 789,
+            characterId: 'char1',
+        });
+
+        expect(record.containerCount).toBe(100);
+        expect(record.expectedValue).toBe(10000);
+    });
+});

--- a/src/features/inventory/openable-analytics/openable-analytics-calculator.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-calculator.test.js
@@ -29,6 +29,32 @@ beforeEach(() => {
 });
 
 describe('calculateActualValue', () => {
+    test('returns a per-item breakdown alongside the total, in gainedItems order', () => {
+        expectedValueCalculator.resolveSellSideValue.mockImplementation((itemHrid) =>
+            itemHrid === '/items/coin' ? { value: 1, needsTax: false } : { value: 50, needsTax: false }
+        );
+
+        const { breakdown } = calculateActualValue([
+            { itemHrid: '/items/coin', enhancementLevel: 0, count: 100 },
+            { itemHrid: '/items/pearl', enhancementLevel: 0, count: 3 },
+        ]);
+
+        expect(breakdown).toEqual([
+            { itemHrid: '/items/coin', enhancementLevel: 0, count: 100, value: 100, resolved: true },
+            { itemHrid: '/items/pearl', enhancementLevel: 0, count: 3, value: 150, resolved: true },
+        ]);
+    });
+
+    test('marks an unpriced item as unresolved with a value of 0 in the breakdown, not a fake price', () => {
+        expectedValueCalculator.resolveSellSideValue.mockReturnValue(null);
+
+        const { breakdown } = calculateActualValue([{ itemHrid: '/items/mystery', enhancementLevel: 0, count: 1 }]);
+
+        expect(breakdown).toEqual([
+            { itemHrid: '/items/mystery', enhancementLevel: 0, count: 1, value: 0, resolved: false },
+        ]);
+    });
+
     test('sums resolved gained-item values, applying tax when the source requires it', () => {
         expectedValueCalculator.resolveSellSideValue.mockReturnValue({ value: 100, source: 'market', needsTax: true });
 
@@ -146,6 +172,23 @@ describe('calculateLuck', () => {
 });
 
 describe('buildOpeningRecord', () => {
+    test('includes a per-item actualValueBreakdown for the modal/history to consume', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({ expectedValue: 100 });
+        expectedValueCalculator.resolveSellSideValue.mockReturnValue({ value: 20, needsTax: false });
+
+        const record = buildOpeningRecord({
+            containerHrid: '/items/chest',
+            containerCount: 1,
+            gainedItems: [{ itemHrid: '/items/pearl', enhancementLevel: 0, count: 5 }],
+            timestamp: 999,
+            characterId: 'char1',
+        });
+
+        expect(record.actualValueBreakdown).toEqual([
+            { itemHrid: '/items/pearl', enhancementLevel: 0, count: 5, value: 100, resolved: true },
+        ]);
+    });
+
     test('a granted-buff-only opening (no gained items, no EV model) is counted without fake luck', () => {
         expectedValueCalculator.calculateExpectedValue.mockReturnValue(null);
 

--- a/src/features/inventory/openable-analytics/openable-analytics-calculator.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-calculator.test.js
@@ -1,7 +1,10 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../../core/data-manager.js', () => ({
-    default: { getItemDetails: vi.fn(() => ({ isTradable: true })) },
+    default: {
+        getItemDetails: vi.fn(() => ({ isTradable: true })),
+        getInitClientData: vi.fn(() => ({ openableLootDropMap: { '/items/chest': [{ itemHrid: '/items/coin' }] } })),
+    },
 }));
 vi.mock('../../../core/config.js', () => ({
     default: { getSettingValue: vi.fn((key, defaultValue) => defaultValue) },
@@ -125,12 +128,53 @@ describe('calculateExpectedValueForOpening', () => {
         expect(available).toBe(false);
     });
 
+    test('EV-1: a buff-only openable (isOpenable, no openableLootDropMap entry) is N/A even if the shared EV calculator returns a zero-EV object instead of null', () => {
+        // This is the real production shape for e.g. /items/seal_of_rare_find: isOpenable=true
+        // but no openableLootDropMap entry, so the generic calculator's empty-drop reduction can
+        // return { expectedValue: 0, drops: [] } rather than null. The dropTable gate must catch
+        // this before ever trusting a non-negative expectedValue as a real monetary model.
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({ expectedValue: 0, drops: [] });
+
+        const { value, available } = calculateExpectedValueForOpening('/items/seal_of_rare_find', 1);
+
+        expect(value).toBeNull();
+        expect(available).toBe(false);
+        expect(expectedValueCalculator.calculateExpectedValue).not.toHaveBeenCalled();
+    });
+
     test('returns unavailable when containerCount is zero or missing', () => {
         const { value, available } = calculateExpectedValueForOpening('/items/chest', 0);
 
         expect(value).toBeNull();
         expect(available).toBe(false);
         expect(expectedValueCalculator.calculateExpectedValue).not.toHaveBeenCalled();
+    });
+
+    test('EV-3: marks Expected partial (never Luck-complete) when one modeled drop could not be priced', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({
+            expectedValue: 500,
+            drops: [
+                { itemHrid: '/items/coin', expectedValue: 500, hasPriceData: true },
+                { itemHrid: '/items/mystery', expectedValue: 0, hasPriceData: false },
+            ],
+        });
+
+        const { value, available, complete } = calculateExpectedValueForOpening('/items/chest', 1);
+
+        expect(value).toBe(500);
+        expect(available).toBe(true);
+        expect(complete).toBe(false);
+    });
+
+    test('is complete when every modeled drop could be priced', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({
+            expectedValue: 500,
+            drops: [{ itemHrid: '/items/coin', expectedValue: 500, hasPriceData: true }],
+        });
+
+        const { complete } = calculateExpectedValueForOpening('/items/chest', 1);
+
+        expect(complete).toBe(true);
     });
 });
 
@@ -168,6 +212,27 @@ describe('calculateLuck', () => {
 
         expect(luckValue).toBe(500);
         expect(luckPercent).toBeNull();
+    });
+
+    test('EV-2 / OA-7: returns null when Actual is partial, even though Expected is fully available', () => {
+        const { luckValue, luckPercent } = calculateLuck(500, 1000, true, false);
+
+        expect(luckValue).toBeNull();
+        expect(luckPercent).toBeNull();
+    });
+
+    test('EV-3 / OA-8: returns null when Expected is only partially priced, even though Actual is complete', () => {
+        const { luckValue, luckPercent } = calculateLuck(500, 1000, true, true, false);
+
+        expect(luckValue).toBeNull();
+        expect(luckPercent).toBeNull();
+    });
+
+    test('EV-4: returns a real Luck value when both Actual and Expected are fully complete', () => {
+        const { luckValue, luckPercent } = calculateLuck(1500, 1000, true, true, true);
+
+        expect(luckValue).toBe(500);
+        expect(luckPercent).toBe(50);
     });
 });
 
@@ -244,6 +309,65 @@ describe('buildOpeningRecord', () => {
         expect(record.containerCount).toBe(100);
         expect(record.expectedValue).toBe(10000);
     });
+
+    test('EV-2 / OA-7: a partial Actual (one unpriced gained item) makes Luck N/A even though Expected is available', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({ expectedValue: 100 });
+        expectedValueCalculator.resolveSellSideValue.mockReturnValueOnce(null);
+
+        const record = buildOpeningRecord({
+            containerHrid: '/items/chest',
+            containerCount: 1,
+            gainedItems: [{ itemHrid: '/items/mystery', enhancementLevel: 0, count: 1 }],
+            timestamp: 1,
+            characterId: 'char1',
+        });
+
+        expect(record.actualValueComplete).toBe(false);
+        expect(record.expectedValueAvailable).toBe(true);
+        expect(record.luckValue).toBeNull();
+        expect(record.luckPercent).toBeNull();
+    });
+
+    test('EV-3 / OA-8: a partial Expected (one unpriced modeled drop) makes Luck N/A even though Actual is complete', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({
+            expectedValue: 100,
+            drops: [{ itemHrid: '/items/mystery', expectedValue: 0, hasPriceData: false }],
+        });
+        expectedValueCalculator.resolveSellSideValue.mockReturnValue({ value: 10, needsTax: false });
+
+        const record = buildOpeningRecord({
+            containerHrid: '/items/chest',
+            containerCount: 1,
+            gainedItems: [{ itemHrid: '/items/x', enhancementLevel: 0, count: 1 }],
+            timestamp: 1,
+            characterId: 'char1',
+        });
+
+        expect(record.actualValueComplete).toBe(true);
+        expect(record.expectedValueAvailable).toBe(true);
+        expect(record.expectedValueComplete).toBe(false);
+        expect(record.luckValue).toBeNull();
+    });
+
+    test('OA-9: sourceDataComplete=false (e.g. an import that dropped an unmatched item) forces Actual partial and Luck N/A', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({ expectedValue: 100 });
+        expectedValueCalculator.resolveSellSideValue.mockReturnValue({ value: 10, needsTax: false });
+
+        const record = buildOpeningRecord({
+            containerHrid: '/items/chest',
+            containerCount: 1,
+            gainedItems: [{ itemHrid: '/items/x', enhancementLevel: 0, count: 1 }],
+            timestamp: 1,
+            characterId: 'char1',
+            sourceDataComplete: false,
+        });
+
+        // Every gained item it does know about was priced, but the source told us it dropped
+        // an unresolved one - Actual must still be reported as partial.
+        expect(record.actualValueComplete).toBe(false);
+        expect(record.sourceDataComplete).toBe(false);
+        expect(record.luckValue).toBeNull();
+    });
 });
 
 describe('buildImportedAggregateRecord', () => {
@@ -289,5 +413,23 @@ describe('buildImportedAggregateRecord', () => {
         expect(record.actualValue).toBe(0);
         expect(record.actualValueComplete).toBe(false);
         expect(record.expectedValueAvailable).toBe(false);
+    });
+
+    test('IMPORT-3 / OA-9: propagates sourceDataComplete: false through to the built record', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({ expectedValue: 100 });
+        expectedValueCalculator.resolveSellSideValue.mockReturnValue({ value: 1, needsTax: false });
+
+        const record = buildImportedAggregateRecord({
+            containerHrid: '/items/chest',
+            containerCount: 10,
+            itemTotals: { '/items/coin': 100 },
+            timestamp: 333,
+            characterId: 'char1',
+            source: 'import:edible',
+            sourceDataComplete: false,
+        });
+
+        expect(record.actualValueComplete).toBe(false);
+        expect(record.luckValue).toBeNull();
     });
 });

--- a/src/features/inventory/openable-analytics/openable-analytics-calculator.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-calculator.test.js
@@ -3,7 +3,9 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 vi.mock('../../../core/data-manager.js', () => ({
     default: {
         getItemDetails: vi.fn(() => ({ isTradable: true })),
-        getInitClientData: vi.fn(() => ({ openableLootDropMap: { '/items/chest': [{ itemHrid: '/items/coin' }] } })),
+        getInitClientData: vi.fn(() => ({
+            openableLootDropMap: { '/items/chest': [{ itemHrid: '/items/coin', dropRate: 0.9 }] },
+        })),
     },
 }));
 vi.mock('../../../core/config.js', () => ({
@@ -29,6 +31,9 @@ const {
 beforeEach(() => {
     vi.clearAllMocks();
     dataManager.getItemDetails.mockReturnValue({ isTradable: true });
+    dataManager.getInitClientData.mockReturnValue({
+        openableLootDropMap: { '/items/chest': [{ itemHrid: '/items/coin', dropRate: 0.9 }] },
+    });
 });
 
 describe('calculateActualValue', () => {
@@ -174,6 +179,52 @@ describe('calculateExpectedValueForOpening', () => {
 
         const { complete } = calculateExpectedValueForOpening('/items/chest', 1);
 
+        expect(complete).toBe(true);
+    });
+
+    test('section 4: active raw drop silently missing from the shared breakdown is still partial even though the surviving row is priced', () => {
+        dataManager.getInitClientData.mockReturnValue({
+            openableLootDropMap: {
+                '/items/chest': [
+                    { itemHrid: '/items/coin', dropRate: 0.9 },
+                    { itemHrid: '/items/pearl', dropRate: 0.1 },
+                ],
+            },
+        });
+        // The shared calculator silently dropped /items/pearl from its own breakdown (e.g. it
+        // could not resolve itemDetails for it) instead of reporting hasPriceData: false.
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({
+            expectedValue: 500,
+            drops: [{ itemHrid: '/items/coin', expectedValue: 500, hasPriceData: true }],
+        });
+
+        const { complete } = calculateExpectedValueForOpening('/items/chest', 1);
+
+        expect(complete).toBe(false);
+    });
+
+    test('section 4: no ev.drops array at all cannot prove completeness', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({ expectedValue: 500 });
+
+        const { available, complete } = calculateExpectedValueForOpening('/items/chest', 1);
+
+        expect(available).toBe(true);
+        expect(complete).toBe(false);
+    });
+
+    test('section 4: complete Expected of exactly zero is still a valid absolute value, not missing', () => {
+        expectedValueCalculator.calculateExpectedValue.mockReturnValue({ expectedValue: 0, drops: [] });
+        dataManager.getInitClientData.mockReturnValue({ openableLootDropMap: { '/items/chest': [] } });
+        // An empty-but-present drop table (0 active raw drops) still counts as a real monetary
+        // model with a legitimately zero EV - distinct from no dropTable entry at all.
+        dataManager.getInitClientData.mockReturnValue({
+            openableLootDropMap: { '/items/chest': [{ itemHrid: '/items/coin', dropRate: 0 }] },
+        });
+
+        const { value, available, complete } = calculateExpectedValueForOpening('/items/chest', 1);
+
+        expect(value).toBe(0);
+        expect(available).toBe(true);
         expect(complete).toBe(true);
     });
 });

--- a/src/features/inventory/openable-analytics/openable-analytics-data-collector.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-data-collector.js
@@ -1,0 +1,233 @@
+/**
+ * Openable Analytics Data Collector
+ * Listens for the native `loot_opened` WebSocket message, builds a normalized opening record via
+ * the shared calculator, and maintains character-scoped session (in-memory) and lifetime
+ * (persisted) aggregates plus a bounded detailed history.
+ */
+
+import webSocketHook from '../../../core/websocket.js';
+import dataManager from '../../../core/data-manager.js';
+import { buildOpeningRecord } from './openable-analytics-calculator.js';
+import {
+    loadLifetime,
+    saveLifetime,
+    loadHistory,
+    appendHistory,
+    foldRecordIntoAggregate,
+    createEmptyAggregate,
+    resetContainer as storageResetContainer,
+    resetAll as storageResetAll,
+} from './openable-analytics-storage.js';
+
+class OpenableAnalyticsDataCollector {
+    constructor() {
+        this.isInitialized = false;
+        this.characterId = null;
+        this.lifecycleGeneration = 0;
+        this.lootOpenedHandler = null;
+        this.lifetime = {};
+        this.history = [];
+        this.session = {};
+        this.latestRecord = null;
+        this.updateListeners = new Set();
+    }
+
+    /**
+     * Initialize the collector for the current character. Session aggregates always start
+     * empty here - Session is page/character-lifecycle scoped, never manually started/resumed.
+     */
+    async initialize() {
+        if (this.isInitialized) {
+            return;
+        }
+
+        this.isInitialized = true;
+        this.characterId = dataManager.getCurrentCharacterId();
+        const generation = ++this.lifecycleGeneration;
+
+        this.session = {};
+        this.latestRecord = null;
+
+        if (this.characterId) {
+            this.lifetime = await loadLifetime(this.characterId);
+            this.history = await loadHistory(this.characterId);
+        } else {
+            this.lifetime = {};
+            this.history = [];
+        }
+
+        if (generation !== this.lifecycleGeneration || !this.isInitialized) return;
+
+        this.lootOpenedHandler = (data) => this.onLootOpened(data, generation);
+        webSocketHook.on('loot_opened', this.lootOpenedHandler);
+    }
+
+    /**
+     * Handle a native `loot_opened` message: normalize, fold into session/lifetime aggregates,
+     * persist, and notify UI listeners.
+     * @param {Object} data - Raw `loot_opened` message payload
+     * @param {number} generation - Lifecycle generation captured at registration time
+     */
+    async onLootOpened(data, generation) {
+        if (generation !== this.lifecycleGeneration) return;
+        if (!data?.openedItem?.itemHrid) return;
+
+        await this.recordOpening(
+            {
+                containerHrid: data.openedItem.itemHrid,
+                containerCount: data.openedItem.count || 1,
+                gainedItems: data.gainedItems,
+                grantedBuffs: data.grantedBuffs,
+                timestamp: Date.now(),
+                characterId: this.characterId,
+            },
+            { generation }
+        );
+    }
+
+    /**
+     * Build and record one opening from already-normalized input. This is the shared entry
+     * point for both the live WebSocket path and any future historical-import adapter (Edible
+     * Tools / MWI Combat Suite) - an importer can call this directly with `source: 'import:...'`
+     * without needing to go through `loot_opened` at all.
+     * @param {Object} input - See `buildOpeningRecord` for shape
+     * @param {Object} [options]
+     * @param {number} [options.generation] - Lifecycle generation to guard against a stale
+     *      continuation resuming after `cleanup()`/a character switch
+     * @returns {Promise<Object>} The normalized record that was recorded
+     */
+    async recordOpening(input, { generation = this.lifecycleGeneration } = {}) {
+        const record = buildOpeningRecord(input);
+
+        if (generation !== this.lifecycleGeneration) return record;
+
+        this.session[record.containerHrid] = foldRecordIntoAggregate(this.session[record.containerHrid], record);
+        this.latestRecord = record;
+        this.notifyListeners(record);
+
+        if (record.characterId) {
+            this.lifetime = {
+                ...this.lifetime,
+                [record.containerHrid]: foldRecordIntoAggregate(this.lifetime[record.containerHrid], record),
+            };
+            this.history = await appendHistory(record.characterId, this.history, record);
+
+            if (generation !== this.lifecycleGeneration) return record;
+            await saveLifetime(record.characterId, this.lifetime);
+        }
+
+        return record;
+    }
+
+    /**
+     * Subscribe to newly recorded openings (used by the modal-line injector to update
+     * immediately, without waiting for a DOM-mount fallback).
+     * @param {Function} callback - Called with the new normalized record
+     * @returns {Function} Unsubscribe function
+     */
+    onUpdate(callback) {
+        this.updateListeners.add(callback);
+        return () => this.updateListeners.delete(callback);
+    }
+
+    notifyListeners(record) {
+        for (const callback of this.updateListeners) {
+            try {
+                callback(record);
+            } catch (error) {
+                console.error('[OpenableAnalytics] Update listener error:', error);
+            }
+        }
+    }
+
+    /**
+     * @returns {Object|null} The most recently recorded normalized opening record, if any
+     */
+    getLatestRecord() {
+        return this.latestRecord;
+    }
+
+    /**
+     * @param {string} containerHrid
+     * @returns {Object} Session (in-memory, page/character lifecycle-scoped) aggregate
+     */
+    getSessionAggregate(containerHrid) {
+        return this.session[containerHrid] || createEmptyAggregate();
+    }
+
+    /**
+     * @param {string} containerHrid
+     * @returns {Object} Lifetime (persisted) aggregate
+     */
+    getLifetimeAggregate(containerHrid) {
+        return this.lifetime[containerHrid] || createEmptyAggregate();
+    }
+
+    /**
+     * @returns {Array<string>} Container HRIDs that have at least one lifetime opening recorded
+     */
+    getKnownContainers() {
+        return Object.keys(this.lifetime);
+    }
+
+    /**
+     * @param {string} [containerHrid] - If provided, filter history to this container only
+     * @returns {Array<Object>} Detailed history records, most recent last
+     */
+    getHistory(containerHrid) {
+        if (!containerHrid) return this.history;
+        return this.history.filter((record) => record.containerHrid === containerHrid);
+    }
+
+    /**
+     * Reset lifetime + history + in-memory session data for one container, current character.
+     * @param {string} containerHrid
+     */
+    async resetContainer(containerHrid) {
+        if (!this.characterId) return;
+        const { lifetime, history } = await storageResetContainer(this.characterId, containerHrid);
+        this.lifetime = lifetime;
+        this.history = history;
+        delete this.session[containerHrid];
+        if (this.latestRecord?.containerHrid === containerHrid) {
+            this.latestRecord = null;
+        }
+    }
+
+    /**
+     * Reset all Openable Analytics data (lifetime + history + in-memory session) for the
+     * current character.
+     */
+    async resetAll() {
+        if (!this.characterId) return;
+        await storageResetAll(this.characterId);
+        this.lifetime = {};
+        this.history = [];
+        this.session = {};
+        this.latestRecord = null;
+    }
+
+    /**
+     * Cleanup the collector's WebSocket subscription and in-memory state.
+     */
+    cleanup() {
+        this.lifecycleGeneration += 1;
+
+        if (this.lootOpenedHandler) {
+            webSocketHook.off('loot_opened', this.lootOpenedHandler);
+            this.lootOpenedHandler = null;
+        }
+
+        this.isInitialized = false;
+        this.characterId = null;
+        this.lifetime = {};
+        this.history = [];
+        this.session = {};
+        this.latestRecord = null;
+        this.updateListeners.clear();
+    }
+}
+
+const openableAnalyticsDataCollector = new OpenableAnalyticsDataCollector();
+
+export default openableAnalyticsDataCollector;

--- a/src/features/inventory/openable-analytics/openable-analytics-data-collector.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-data-collector.js
@@ -34,6 +34,7 @@ class OpenableAnalyticsDataCollector {
         this.imports = {};
         this.latestRecord = null;
         this.updateListeners = new Set();
+        this.stateChangeListeners = new Set();
         // One ordered persistence lane for opening/import/reset mutations. It intentionally
         // survives cleanup()/reinitialize so an accepted write cannot be overtaken by a later
         // reset, and initialize() waits on it so a same-character re-enable never loads a
@@ -43,16 +44,18 @@ class OpenableAnalyticsDataCollector {
 
     /**
      * Queue one persistence operation behind every earlier one, current lifecycle or not. A
-     * later opening/reset therefore always lands after everything queued before it, and a
-     * failed operation never blocks the lane for subsequent writes.
-     * @param {Function} task - Async function to run once earlier queued work has settled
-     * @returns {Promise<*>}
+     * later opening/reset therefore always lands after everything queued before it. `task` must
+     * resolve to a boolean success flag (Core Storage often resolves `false` on IndexedDB
+     * failure rather than rejecting) - a failed task still lets subsequent queued work run.
+     * @param {Function} task - Async function returning a boolean success flag
+     * @returns {Promise<boolean>} Whether this operation's persistence succeeded
      */
     enqueuePersistence(task) {
-        const run = this.persistenceQueue.then(task, task);
-        this.persistenceQueue = run.catch((error) => {
-            console.error('[OpenableAnalytics] Persistence operation failed:', error);
+        const run = this.persistenceQueue.then(task, task).catch((error) => {
+            console.error('[OpenableAnalytics] Persistence operation threw:', error);
+            return false;
         });
+        this.persistenceQueue = run.then(() => {});
         return run;
     }
 
@@ -164,6 +167,7 @@ class OpenableAnalyticsDataCollector {
 
         this.latestRecord = record;
         this.notifyListeners(record);
+        this.notifyStateChange();
 
         if (!record.characterId) return record;
 
@@ -173,10 +177,14 @@ class OpenableAnalyticsDataCollector {
         const characterId = record.characterId;
         const historySnapshot = this.history;
         const lifetimeSnapshot = this.lifetime;
-        await this.enqueuePersistence(async () => {
-            await saveHistory(characterId, historySnapshot);
-            await saveLifetime(characterId, lifetimeSnapshot);
+        const persisted = await this.enqueuePersistence(async () => {
+            const historyOk = await saveHistory(characterId, historySnapshot);
+            const lifetimeOk = await saveLifetime(characterId, lifetimeSnapshot);
+            return historyOk && lifetimeOk;
         });
+        if (!persisted) {
+            console.error('[OpenableAnalytics] Could not save this opening. It may not persist after reload.');
+        }
 
         return record;
     }
@@ -203,6 +211,28 @@ class OpenableAnalyticsDataCollector {
     }
 
     /**
+     * Subscribe to any in-memory analytics mutation (live opening, import, replace, remove
+     * import, delete container, delete all) - used by Full Analytics to refresh only while it is
+     * currently mounted. Fired immediately after the in-memory commit, before persistence.
+     * @param {Function} callback - Called with no arguments
+     * @returns {Function} Unsubscribe function
+     */
+    onStateChange(callback) {
+        this.stateChangeListeners.add(callback);
+        return () => this.stateChangeListeners.delete(callback);
+    }
+
+    notifyStateChange() {
+        for (const callback of this.stateChangeListeners) {
+            try {
+                callback();
+            } catch (error) {
+                console.error('[OpenableAnalytics] State-change listener error:', error);
+            }
+        }
+    }
+
+    /**
      * @returns {Object|null} The most recently recorded normalized opening record, if any
      */
     getLatestRecord() {
@@ -215,6 +245,14 @@ class OpenableAnalyticsDataCollector {
      */
     getSessionAggregate(containerHrid) {
         return this.session[containerHrid] || createEmptyAggregate();
+    }
+
+    /**
+     * @returns {Array<string>} Container HRIDs that actually exist in the current in-memory
+     *      Session - never containers that only have Lifetime/imported history.
+     */
+    getSessionContainers() {
+        return Object.keys(this.session);
     }
 
     /**
@@ -252,6 +290,23 @@ class OpenableAnalyticsDataCollector {
     }
 
     /**
+     * @returns {Array<string>} Import source keys that currently have at least one container
+     */
+    getImportSourceKeys() {
+        return Object.entries(this.imports)
+            .filter(([, byContainer]) => Object.keys(byContainer).length > 0)
+            .map(([source]) => source);
+    }
+
+    /**
+     * @param {string} source
+     * @returns {Set<string>} Container HRIDs currently imported under this source
+     */
+    getImportedContainerHrids(source) {
+        return new Set(Object.keys(this.imports[source] || {}));
+    }
+
+    /**
      * Import a batch of bulk historical containers from an external source (Edible Tools, MWI
      * Combat Suite, or a future source), recomputing Actual/Expected/Luck via Toolasha's own
      * valuation from the raw item counts rather than trusting the source's own stored numbers.
@@ -261,10 +316,11 @@ class OpenableAnalyticsDataCollector {
      * previous player's containers mixed into the current `import:edible` snapshot.
      * @param {string} source - e.g. 'import:edible' or 'import:mwi-combat-suite'
      * @param {Array<{containerHrid: string, containerCount: number, itemTotals: Object, sourceDataComplete?: boolean}>} containers
-     * @returns {Promise<Array<Object>>} The resulting per-container aggregates that were imported
+     * @returns {Promise<{results: Array<Object>, persisted: boolean}>} Resulting per-container
+     *      aggregates and whether the import was actually saved
      */
     async importContainers(source, containers) {
-        if (!this.characterId) return [];
+        if (!this.characterId) return { results: [], persisted: false };
 
         const bySource = {};
         const results = [];
@@ -287,9 +343,37 @@ class OpenableAnalyticsDataCollector {
         const characterId = this.characterId;
         this.imports = { ...this.imports, [source]: bySource };
         const importsSnapshot = this.imports;
-        await this.enqueuePersistence(() => saveImports(characterId, importsSnapshot));
+        this.notifyStateChange();
 
-        return results;
+        const persisted = await this.enqueuePersistence(() => saveImports(characterId, importsSnapshot));
+        if (!persisted) {
+            console.error('[OpenableAnalytics] Could not save the imported data. It may not persist after reload.');
+        }
+
+        return { results, persisted };
+    }
+
+    /**
+     * Remove one whole external source snapshot (e.g. 'import:edible'), keeping live Toolasha
+     * history, current Session, and every other import source untouched.
+     * @param {string} source
+     * @returns {Promise<boolean>} Whether the removal was actually saved
+     */
+    async removeImport(source) {
+        if (!this.characterId) return false;
+
+        const characterId = this.characterId;
+        const imports = { ...this.imports };
+        delete imports[source];
+        this.imports = imports;
+        this.notifyStateChange();
+
+        const persisted = await this.enqueuePersistence(() => saveImports(characterId, imports));
+        if (!persisted) {
+            console.error('[OpenableAnalytics] Could not remove the imported data. It may reappear after reload.');
+        }
+
+        return persisted;
     }
 
     /**
@@ -306,22 +390,26 @@ class OpenableAnalyticsDataCollector {
      * character. Commits in-memory state immediately and queues its persistence behind every
      * earlier opening/import/reset, so a later opening for a *different* container is unaffected
      * and a later opening for *this* container (arriving after this call returns) is never
-     * overwritten by this reset (OA-4).
+     * overwritten by this reset (OA-4). Prunes any import source left with zero containers so an
+     * empty `{ [source]: {} }` entry can never appear as an existing source.
      * @param {string} containerHrid
+     * @returns {Promise<boolean>} Whether the reset was actually saved
      */
     async resetContainer(containerHrid) {
-        if (!this.characterId) return;
+        if (!this.characterId) return false;
 
         const characterId = this.characterId;
         const lifetime = { ...this.lifetime };
         delete lifetime[containerHrid];
         const history = this.history.filter((record) => record.containerHrid !== containerHrid);
         const imports = Object.fromEntries(
-            Object.entries(this.imports).map(([source, byContainer]) => {
-                const next = { ...byContainer };
-                delete next[containerHrid];
-                return [source, next];
-            })
+            Object.entries(this.imports)
+                .map(([source, byContainer]) => {
+                    const next = { ...byContainer };
+                    delete next[containerHrid];
+                    return [source, next];
+                })
+                .filter(([, byContainer]) => Object.keys(byContainer).length > 0)
         );
 
         this.lifetime = lifetime;
@@ -331,12 +419,19 @@ class OpenableAnalyticsDataCollector {
         if (this.latestRecord?.containerHrid === containerHrid) {
             this.latestRecord = null;
         }
+        this.notifyStateChange();
 
-        await this.enqueuePersistence(async () => {
-            await saveLifetime(characterId, lifetime);
-            await saveHistory(characterId, history);
-            await saveImports(characterId, imports);
+        const persisted = await this.enqueuePersistence(async () => {
+            const lifetimeOk = await saveLifetime(characterId, lifetime);
+            const historyOk = await saveHistory(characterId, history);
+            const importsOk = await saveImports(characterId, imports);
+            return lifetimeOk && historyOk && importsOk;
         });
+        if (!persisted) {
+            console.error('[OpenableAnalytics] Could not save this deletion. It may reappear after reload.');
+        }
+
+        return persisted;
     }
 
     /**
@@ -344,17 +439,24 @@ class OpenableAnalyticsDataCollector {
      * the current character. Commits in-memory state immediately and queues the deletion behind
      * every earlier write, so an opening that arrives after this call starts still persists once
      * this reset's queued deletion has run (OA-4).
+     * @returns {Promise<boolean>} Whether the reset was actually saved
      */
     async resetAll() {
-        if (!this.characterId) return;
+        if (!this.characterId) return false;
         const characterId = this.characterId;
         this.lifetime = {};
         this.history = [];
         this.imports = {};
         this.session = {};
         this.latestRecord = null;
+        this.notifyStateChange();
 
-        await this.enqueuePersistence(() => storageResetAll(characterId));
+        const persisted = await this.enqueuePersistence(() => storageResetAll(characterId));
+        if (!persisted) {
+            console.error('[OpenableAnalytics] Could not save this deletion. It may reappear after reload.');
+        }
+
+        return persisted;
     }
 
     /**
@@ -376,6 +478,7 @@ class OpenableAnalyticsDataCollector {
         this.session = {};
         this.latestRecord = null;
         this.updateListeners.clear();
+        this.stateChangeListeners.clear();
         // Deliberately do not reset persistenceQueue: an accepted old-lifecycle write must
         // finish under its captured character key, and initialize() waits on this same lane
         // before loading so it can never load a snapshot from before that write landed.

--- a/src/features/inventory/openable-analytics/openable-analytics-data-collector.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-data-collector.js
@@ -1,24 +1,24 @@
 /**
  * Openable Analytics Data Collector
- * Listens for the native `loot_opened` WebSocket message, builds a normalized opening record via
+ * Consumes the character-scoped, socket-ownership-gated `loot_opened` event that DataManager
+ * derives from the native WebSocket message (TLA-018), builds a normalized opening record via
  * the shared calculator, and maintains character-scoped session (in-memory) and lifetime
  * (persisted) aggregates plus a bounded detailed history.
  */
 
-import webSocketHook from '../../../core/websocket.js';
 import dataManager from '../../../core/data-manager.js';
 import { buildOpeningRecord, buildImportedAggregateRecord } from './openable-analytics-calculator.js';
 import {
     loadLifetime,
     saveLifetime,
     loadHistory,
-    appendHistory,
+    appendHistoryRecord,
+    saveHistory,
     loadImports,
     saveImports,
     foldRecordIntoAggregate,
     createEmptyAggregate,
     mergeAggregates,
-    resetContainer as storageResetContainer,
     resetAll as storageResetAll,
 } from './openable-analytics-storage.js';
 
@@ -34,6 +34,26 @@ class OpenableAnalyticsDataCollector {
         this.imports = {};
         this.latestRecord = null;
         this.updateListeners = new Set();
+        // One ordered persistence lane for opening/import/reset mutations. It intentionally
+        // survives cleanup()/reinitialize so an accepted write cannot be overtaken by a later
+        // reset, and initialize() waits on it so a same-character re-enable never loads a
+        // pre-write snapshot (OA-3, OA-4, OA-11).
+        this.persistenceQueue = Promise.resolve();
+    }
+
+    /**
+     * Queue one persistence operation behind every earlier one, current lifecycle or not. A
+     * later opening/reset therefore always lands after everything queued before it, and a
+     * failed operation never blocks the lane for subsequent writes.
+     * @param {Function} task - Async function to run once earlier queued work has settled
+     * @returns {Promise<*>}
+     */
+    enqueuePersistence(task) {
+        const run = this.persistenceQueue.then(task, task);
+        this.persistenceQueue = run.catch((error) => {
+            console.error('[OpenableAnalytics] Persistence operation failed:', error);
+        });
+        return run;
     }
 
     /**
@@ -46,36 +66,57 @@ class OpenableAnalyticsDataCollector {
         }
 
         this.isInitialized = true;
-        this.characterId = dataManager.getCurrentCharacterId();
+        // Do not load a stale pre-write snapshot if this feature was toggled/reinitialized while
+        // an accepted persistence operation from the previous lifecycle is still finishing.
+        await this.persistenceQueue.catch(() => {});
+
+        const characterId = dataManager.getCurrentCharacterId();
         const generation = ++this.lifecycleGeneration;
 
+        const [lifetime, history, imports] = characterId
+            ? await Promise.all([loadLifetime(characterId), loadHistory(characterId), loadImports(characterId)])
+            : [{}, [], {}];
+
+        if (
+            generation !== this.lifecycleGeneration ||
+            !this.isInitialized ||
+            dataManager.getCurrentCharacterId() !== characterId
+        ) {
+            return;
+        }
+
+        // Commit the loaded snapshot only after every async load has completed and ownership is
+        // still valid - no partially loaded stale lifecycle is ever published into singleton
+        // state (OA-11).
+        this.characterId = characterId;
+        this.lifetime = lifetime;
+        this.history = history;
+        this.imports = imports;
         this.session = {};
         this.latestRecord = null;
 
-        if (this.characterId) {
-            this.lifetime = await loadLifetime(this.characterId);
-            this.history = await loadHistory(this.characterId);
-            this.imports = await loadImports(this.characterId);
-        } else {
-            this.lifetime = {};
-            this.history = [];
-            this.imports = {};
-        }
-
-        if (generation !== this.lifecycleGeneration || !this.isInitialized) return;
-
-        this.lootOpenedHandler = (data) => this.onLootOpened(data, generation);
-        webSocketHook.on('loot_opened', this.lootOpenedHandler);
+        this.lootOpenedHandler = (event) => {
+            this.onLootOpened(event, generation).catch((error) => {
+                console.error('[OpenableAnalytics] Failed to record loot_opened:', error);
+            });
+        };
+        dataManager.on('loot_opened', this.lootOpenedHandler);
     }
 
     /**
-     * Handle a native `loot_opened` message: normalize, fold into session/lifetime aggregates,
-     * persist, and notify UI listeners.
-     * @param {Object} data - Raw `loot_opened` message payload
+     * Handle a character-scoped `loot_opened` event from DataManager (already filtered to the
+     * accepted active socket - TLA-018). Ignores an event whose captured characterId no longer
+     * matches this collector's current character, which also protects against a stale
+     * continuation resuming after a character switch even though DataManager's own ownership
+     * check already covers the common case.
+     * @param {Object} event - `{data, characterId}` as emitted by DataManager
      * @param {number} generation - Lifecycle generation captured at registration time
      */
-    async onLootOpened(data, generation) {
+    async onLootOpened(event, generation) {
         if (generation !== this.lifecycleGeneration) return;
+        const data = event?.data;
+        const characterId = event?.characterId;
+        if (!characterId || characterId !== this.characterId) return;
         if (!data?.openedItem?.itemHrid) return;
 
         await this.recordOpening(
@@ -85,7 +126,7 @@ class OpenableAnalyticsDataCollector {
                 gainedItems: data.gainedItems,
                 grantedBuffs: data.grantedBuffs,
                 timestamp: Date.now(),
-                characterId: this.characterId,
+                characterId,
             },
             { generation }
         );
@@ -93,9 +134,9 @@ class OpenableAnalyticsDataCollector {
 
     /**
      * Build and record one opening from already-normalized input. This is the shared entry
-     * point for both the live WebSocket path and any future historical-import adapter (Edible
-     * Tools / MWI Combat Suite) - an importer can call this directly with `source: 'import:...'`
-     * without needing to go through `loot_opened` at all.
+     * point for both the live WebSocket path and the historical-import adapters (Edible Tools /
+     * MWI Combat Suite) - an importer can call this directly with `source: 'import:...'` without
+     * needing to go through `loot_opened` at all.
      * @param {Object} input - See `buildOpeningRecord` for shape
      * @param {Object} [options]
      * @param {number} [options.generation] - Lifecycle generation to guard against a stale
@@ -107,20 +148,35 @@ class OpenableAnalyticsDataCollector {
 
         if (generation !== this.lifecycleGeneration) return record;
 
+        // Commit every in-memory view synchronously, in this exact order, before notifying
+        // listeners. This guarantees two overlapping openings each derive their history append
+        // from the collector's own latest in-memory array rather than a shared stale snapshot
+        // (OA-3), and that a mounted modal's data-driven refresh always sees Lifetime already
+        // including the opening that triggered it (OA-10).
         this.session[record.containerHrid] = foldRecordIntoAggregate(this.session[record.containerHrid], record);
-        this.latestRecord = record;
-        this.notifyListeners(record);
-
         if (record.characterId) {
             this.lifetime = {
                 ...this.lifetime,
                 [record.containerHrid]: foldRecordIntoAggregate(this.lifetime[record.containerHrid], record),
             };
-            this.history = await appendHistory(record.characterId, this.history, record);
-
-            if (generation !== this.lifecycleGeneration) return record;
-            await saveLifetime(record.characterId, this.lifetime);
+            this.history = appendHistoryRecord(this.history, record);
         }
+
+        this.latestRecord = record;
+        this.notifyListeners(record);
+
+        if (!record.characterId) return record;
+
+        // Queue persistence behind everything already queued (including any earlier opening or
+        // a reset). A later reset therefore cannot resurrect this opening, and this opening
+        // cannot be lost to a reset that was already in flight when it arrived (OA-4).
+        const characterId = record.characterId;
+        const historySnapshot = this.history;
+        const lifetimeSnapshot = this.lifetime;
+        await this.enqueuePersistence(async () => {
+            await saveHistory(characterId, historySnapshot);
+            await saveLifetime(characterId, lifetimeSnapshot);
+        });
 
         return record;
     }
@@ -199,19 +255,21 @@ class OpenableAnalyticsDataCollector {
      * Import a batch of bulk historical containers from an external source (Edible Tools, MWI
      * Combat Suite, or a future source), recomputing Actual/Expected/Luck via Toolasha's own
      * valuation from the raw item counts rather than trusting the source's own stored numbers.
-     * Re-importing the same source replaces (not adds to) that source's per-container totals, so
-     * importing an updated export is idempotent rather than double-counting.
+     * Re-importing the same source atomically replaces that source's entire snapshot - containers
+     * present in an older export but absent from the new one do not survive (OA-5), which matters
+     * for Edible multi-player exports where switching the selected player must not leave the
+     * previous player's containers mixed into the current `import:edible` snapshot.
      * @param {string} source - e.g. 'import:edible' or 'import:mwi-combat-suite'
-     * @param {Array<{containerHrid: string, containerCount: number, itemTotals: Object}>} containers
+     * @param {Array<{containerHrid: string, containerCount: number, itemTotals: Object, sourceDataComplete?: boolean}>} containers
      * @returns {Promise<Array<Object>>} The resulting per-container aggregates that were imported
      */
     async importContainers(source, containers) {
         if (!this.characterId) return [];
 
-        const bySource = { ...(this.imports[source] || {}) };
+        const bySource = {};
         const results = [];
 
-        for (const { containerHrid, containerCount, itemTotals } of containers) {
+        for (const { containerHrid, containerCount, itemTotals, sourceDataComplete = true } of containers) {
             const record = buildImportedAggregateRecord({
                 containerHrid,
                 containerCount,
@@ -219,14 +277,17 @@ class OpenableAnalyticsDataCollector {
                 timestamp: Date.now(),
                 characterId: this.characterId,
                 source,
+                sourceDataComplete,
             });
             const aggregate = foldRecordIntoAggregate(createEmptyAggregate(), record);
             bySource[containerHrid] = aggregate;
             results.push({ containerHrid, aggregate });
         }
 
+        const characterId = this.characterId;
         this.imports = { ...this.imports, [source]: bySource };
-        await saveImports(this.characterId, this.imports);
+        const importsSnapshot = this.imports;
+        await this.enqueuePersistence(() => saveImports(characterId, importsSnapshot));
 
         return results;
     }
@@ -241,12 +302,28 @@ class OpenableAnalyticsDataCollector {
     }
 
     /**
-     * Reset lifetime + history + imports + in-memory session data for one container, current character.
+     * Reset lifetime + history + imports + in-memory session data for one container, current
+     * character. Commits in-memory state immediately and queues its persistence behind every
+     * earlier opening/import/reset, so a later opening for a *different* container is unaffected
+     * and a later opening for *this* container (arriving after this call returns) is never
+     * overwritten by this reset (OA-4).
      * @param {string} containerHrid
      */
     async resetContainer(containerHrid) {
         if (!this.characterId) return;
-        const { lifetime, history, imports } = await storageResetContainer(this.characterId, containerHrid);
+
+        const characterId = this.characterId;
+        const lifetime = { ...this.lifetime };
+        delete lifetime[containerHrid];
+        const history = this.history.filter((record) => record.containerHrid !== containerHrid);
+        const imports = Object.fromEntries(
+            Object.entries(this.imports).map(([source, byContainer]) => {
+                const next = { ...byContainer };
+                delete next[containerHrid];
+                return [source, next];
+            })
+        );
+
         this.lifetime = lifetime;
         this.history = history;
         this.imports = imports;
@@ -254,30 +331,40 @@ class OpenableAnalyticsDataCollector {
         if (this.latestRecord?.containerHrid === containerHrid) {
             this.latestRecord = null;
         }
+
+        await this.enqueuePersistence(async () => {
+            await saveLifetime(characterId, lifetime);
+            await saveHistory(characterId, history);
+            await saveImports(characterId, imports);
+        });
     }
 
     /**
      * Reset all Openable Analytics data (lifetime + history + imports + in-memory session) for
-     * the current character.
+     * the current character. Commits in-memory state immediately and queues the deletion behind
+     * every earlier write, so an opening that arrives after this call starts still persists once
+     * this reset's queued deletion has run (OA-4).
      */
     async resetAll() {
         if (!this.characterId) return;
-        await storageResetAll(this.characterId);
+        const characterId = this.characterId;
         this.lifetime = {};
         this.history = [];
         this.imports = {};
         this.session = {};
         this.latestRecord = null;
+
+        await this.enqueuePersistence(() => storageResetAll(characterId));
     }
 
     /**
-     * Cleanup the collector's WebSocket subscription and in-memory state.
+     * Cleanup the collector's `loot_opened` subscription and in-memory state.
      */
     cleanup() {
         this.lifecycleGeneration += 1;
 
         if (this.lootOpenedHandler) {
-            webSocketHook.off('loot_opened', this.lootOpenedHandler);
+            dataManager.off('loot_opened', this.lootOpenedHandler);
             this.lootOpenedHandler = null;
         }
 
@@ -289,6 +376,9 @@ class OpenableAnalyticsDataCollector {
         this.session = {};
         this.latestRecord = null;
         this.updateListeners.clear();
+        // Deliberately do not reset persistenceQueue: an accepted old-lifecycle write must
+        // finish under its captured character key, and initialize() waits on this same lane
+        // before loading so it can never load a snapshot from before that write landed.
     }
 }
 

--- a/src/features/inventory/openable-analytics/openable-analytics-data-collector.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-data-collector.js
@@ -7,14 +7,17 @@
 
 import webSocketHook from '../../../core/websocket.js';
 import dataManager from '../../../core/data-manager.js';
-import { buildOpeningRecord } from './openable-analytics-calculator.js';
+import { buildOpeningRecord, buildImportedAggregateRecord } from './openable-analytics-calculator.js';
 import {
     loadLifetime,
     saveLifetime,
     loadHistory,
     appendHistory,
+    loadImports,
+    saveImports,
     foldRecordIntoAggregate,
     createEmptyAggregate,
+    mergeAggregates,
     resetContainer as storageResetContainer,
     resetAll as storageResetAll,
 } from './openable-analytics-storage.js';
@@ -28,6 +31,7 @@ class OpenableAnalyticsDataCollector {
         this.lifetime = {};
         this.history = [];
         this.session = {};
+        this.imports = {};
         this.latestRecord = null;
         this.updateListeners = new Set();
     }
@@ -51,9 +55,11 @@ class OpenableAnalyticsDataCollector {
         if (this.characterId) {
             this.lifetime = await loadLifetime(this.characterId);
             this.history = await loadHistory(this.characterId);
+            this.imports = await loadImports(this.characterId);
         } else {
             this.lifetime = {};
             this.history = [];
+            this.imports = {};
         }
 
         if (generation !== this.lifecycleGeneration || !this.isInitialized) return;
@@ -157,17 +163,72 @@ class OpenableAnalyticsDataCollector {
 
     /**
      * @param {string} containerHrid
-     * @returns {Object} Lifetime (persisted) aggregate
+     * @returns {Object} Lifetime (persisted, live-tracked) aggregate, excluding bulk imports -
+     *      use `getLifetimeAggregate` for the combined total shown in the UI.
      */
-    getLifetimeAggregate(containerHrid) {
+    getLiveLifetimeAggregate(containerHrid) {
         return this.lifetime[containerHrid] || createEmptyAggregate();
     }
 
     /**
-     * @returns {Array<string>} Container HRIDs that have at least one lifetime opening recorded
+     * @param {string} containerHrid
+     * @returns {Object} Lifetime aggregate combining live-tracked openings with any bulk-imported
+     *      historical totals (Edible Tools / MWI Combat Suite / future sources) for this container.
+     */
+    getLifetimeAggregate(containerHrid) {
+        const importedAggregates = Object.values(this.imports)
+            .map((bySource) => bySource[containerHrid])
+            .filter(Boolean);
+        return mergeAggregates(this.lifetime[containerHrid], ...importedAggregates);
+    }
+
+    /**
+     * @returns {Array<string>} Container HRIDs with at least one lifetime opening, live or imported
      */
     getKnownContainers() {
-        return Object.keys(this.lifetime);
+        const containers = new Set(Object.keys(this.lifetime));
+        for (const bySource of Object.values(this.imports)) {
+            for (const containerHrid of Object.keys(bySource)) {
+                containers.add(containerHrid);
+            }
+        }
+        return [...containers];
+    }
+
+    /**
+     * Import a batch of bulk historical containers from an external source (Edible Tools, MWI
+     * Combat Suite, or a future source), recomputing Actual/Expected/Luck via Toolasha's own
+     * valuation from the raw item counts rather than trusting the source's own stored numbers.
+     * Re-importing the same source replaces (not adds to) that source's per-container totals, so
+     * importing an updated export is idempotent rather than double-counting.
+     * @param {string} source - e.g. 'import:edible' or 'import:mwi-combat-suite'
+     * @param {Array<{containerHrid: string, containerCount: number, itemTotals: Object}>} containers
+     * @returns {Promise<Array<Object>>} The resulting per-container aggregates that were imported
+     */
+    async importContainers(source, containers) {
+        if (!this.characterId) return [];
+
+        const bySource = { ...(this.imports[source] || {}) };
+        const results = [];
+
+        for (const { containerHrid, containerCount, itemTotals } of containers) {
+            const record = buildImportedAggregateRecord({
+                containerHrid,
+                containerCount,
+                itemTotals,
+                timestamp: Date.now(),
+                characterId: this.characterId,
+                source,
+            });
+            const aggregate = foldRecordIntoAggregate(createEmptyAggregate(), record);
+            bySource[containerHrid] = aggregate;
+            results.push({ containerHrid, aggregate });
+        }
+
+        this.imports = { ...this.imports, [source]: bySource };
+        await saveImports(this.characterId, this.imports);
+
+        return results;
     }
 
     /**
@@ -180,14 +241,15 @@ class OpenableAnalyticsDataCollector {
     }
 
     /**
-     * Reset lifetime + history + in-memory session data for one container, current character.
+     * Reset lifetime + history + imports + in-memory session data for one container, current character.
      * @param {string} containerHrid
      */
     async resetContainer(containerHrid) {
         if (!this.characterId) return;
-        const { lifetime, history } = await storageResetContainer(this.characterId, containerHrid);
+        const { lifetime, history, imports } = await storageResetContainer(this.characterId, containerHrid);
         this.lifetime = lifetime;
         this.history = history;
+        this.imports = imports;
         delete this.session[containerHrid];
         if (this.latestRecord?.containerHrid === containerHrid) {
             this.latestRecord = null;
@@ -195,14 +257,15 @@ class OpenableAnalyticsDataCollector {
     }
 
     /**
-     * Reset all Openable Analytics data (lifetime + history + in-memory session) for the
-     * current character.
+     * Reset all Openable Analytics data (lifetime + history + imports + in-memory session) for
+     * the current character.
      */
     async resetAll() {
         if (!this.characterId) return;
         await storageResetAll(this.characterId);
         this.lifetime = {};
         this.history = [];
+        this.imports = {};
         this.session = {};
         this.latestRecord = null;
     }
@@ -222,6 +285,7 @@ class OpenableAnalyticsDataCollector {
         this.characterId = null;
         this.lifetime = {};
         this.history = [];
+        this.imports = {};
         this.session = {};
         this.latestRecord = null;
         this.updateListeners.clear();

--- a/src/features/inventory/openable-analytics/openable-analytics-data-collector.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-data-collector.test.js
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    values: new Map(),
+    currentCharacterId: 'char-a',
+    on: vi.fn(),
+    off: vi.fn(),
+    evAvailable: true,
+    evValue: 90,
+    sellSideValue: { value: 10, needsTax: false },
+}));
+
+vi.mock('../../../core/storage.js', () => ({
+    default: {
+        getJSON: vi.fn(async (key, _store, defaultValue = null) =>
+            mocks.values.has(key) ? mocks.values.get(key) : defaultValue
+        ),
+        setJSON: vi.fn(async (key, value) => {
+            mocks.values.set(key, value);
+            return true;
+        }),
+        delete: vi.fn(async (key) => {
+            mocks.values.delete(key);
+            return true;
+        }),
+    },
+}));
+
+vi.mock('../../../core/data-manager.js', () => ({
+    default: {
+        getCurrentCharacterId: vi.fn(() => mocks.currentCharacterId),
+        getItemDetails: vi.fn(() => ({ isTradable: true })),
+    },
+}));
+
+vi.mock('../../../core/websocket.js', () => ({
+    default: { on: mocks.on, off: mocks.off, onSocketEvent: vi.fn(), offSocketEvent: vi.fn() },
+}));
+
+vi.mock('../../../core/config.js', () => ({
+    default: { getSettingValue: vi.fn((key, defaultValue) => defaultValue) },
+}));
+
+vi.mock('../../../utils/market-data.js', () => ({
+    getItemPrice: vi.fn(),
+}));
+
+vi.mock('../../market/expected-value-calculator.js', () => ({
+    default: {
+        resolveSellSideValue: vi.fn(() => mocks.sellSideValue),
+        calculateExpectedValue: vi.fn(() => (mocks.evAvailable ? { expectedValue: mocks.evValue } : null)),
+    },
+}));
+
+const { default: openableAnalyticsDataCollector } = await import('./openable-analytics-data-collector.js');
+
+function lootOpenedMessage(overrides = {}) {
+    return {
+        openedItem: { itemHrid: '/items/chimerical_chest', enhancementLevel: 0, count: 1 },
+        gainedItems: [{ itemHrid: '/items/coin', enhancementLevel: 0, count: 100 }],
+        grantedBuffs: [],
+        ...overrides,
+    };
+}
+
+beforeEach(async () => {
+    mocks.values.clear();
+    mocks.currentCharacterId = 'char-a';
+    mocks.evAvailable = true;
+    mocks.evValue = 90;
+    mocks.on.mockClear();
+    mocks.off.mockClear();
+    openableAnalyticsDataCollector.cleanup();
+    await openableAnalyticsDataCollector.initialize();
+});
+
+describe('loot_opened ingestion', () => {
+    test('registers exactly one handler for loot_opened on initialize', () => {
+        expect(mocks.on).toHaveBeenCalledWith('loot_opened', expect.any(Function));
+    });
+
+    test('a direct loot_opened message is recorded into the latest record and session aggregate', async () => {
+        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        await handler(lootOpenedMessage());
+
+        const record = openableAnalyticsDataCollector.getLatestRecord();
+        expect(record.containerHrid).toBe('/items/chimerical_chest');
+        expect(record.containerCount).toBe(1);
+
+        const session = openableAnalyticsDataCollector.getSessionAggregate('/items/chimerical_chest');
+        expect(session.eventsCount).toBe(1);
+    });
+
+    test('openedItem.count > 1 increments container count correctly', async () => {
+        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        await handler(lootOpenedMessage({ openedItem: { itemHrid: '/items/chimerical_chest', count: 100 } }));
+
+        const record = openableAnalyticsDataCollector.getLatestRecord();
+        expect(record.containerCount).toBe(100);
+
+        const session = openableAnalyticsDataCollector.getSessionAggregate('/items/chimerical_chest');
+        expect(session.containersOpened).toBe(100);
+    });
+
+    test('a message with no openedItem is ignored, not recorded as a broken event', async () => {
+        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        await handler({ gainedItems: [], grantedBuffs: [] });
+
+        expect(openableAnalyticsDataCollector.getLatestRecord()).toBeNull();
+    });
+});
+
+describe('character separation', () => {
+    test('lifetime aggregates loaded on initialize are scoped to the current character', async () => {
+        mocks.values.set('lifetime:char-a', { '/items/chest': { eventsCount: 5 } });
+        mocks.currentCharacterId = 'char-b';
+
+        openableAnalyticsDataCollector.cleanup();
+        await openableAnalyticsDataCollector.initialize();
+
+        expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chest').eventsCount).toBe(0);
+    });
+
+    test('recording an opening persists lifetime data under the current character’s key only', async () => {
+        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        await handler(lootOpenedMessage());
+
+        expect(mocks.values.has('lifetime:char-a')).toBe(true);
+        expect(mocks.values.get('lifetime:char-a')['/items/chimerical_chest'].eventsCount).toBe(1);
+    });
+});
+
+describe('session reset on character/page lifecycle', () => {
+    test('re-initializing (character switch or page reload) clears the in-memory session aggregate', async () => {
+        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        await handler(lootOpenedMessage());
+        expect(openableAnalyticsDataCollector.getSessionAggregate('/items/chimerical_chest').eventsCount).toBe(1);
+
+        openableAnalyticsDataCollector.cleanup();
+        await openableAnalyticsDataCollector.initialize();
+
+        expect(openableAnalyticsDataCollector.getSessionAggregate('/items/chimerical_chest').eventsCount).toBe(0);
+    });
+
+    test('a stale handler continuation from before cleanup() cannot record after a new initialize()', async () => {
+        const staleHandler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+
+        openableAnalyticsDataCollector.cleanup();
+        await openableAnalyticsDataCollector.initialize();
+
+        // Simulate the old WebSocket listener firing one more time before it was unregistered.
+        await staleHandler(lootOpenedMessage());
+
+        expect(openableAnalyticsDataCollector.getLatestRecord()).toBeNull();
+    });
+});
+
+describe('granted-buff / non-monetary openings', () => {
+    test('can be counted (session aggregate increments) without fake Luck', async () => {
+        mocks.evAvailable = false;
+        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        await handler(
+            lootOpenedMessage({
+                openedItem: { itemHrid: '/items/seal_of_rare_find', count: 1 },
+                gainedItems: [],
+                grantedBuffs: [{ typeHrid: '/buff_types/rare_find', duration: 3600 }],
+            })
+        );
+
+        const record = openableAnalyticsDataCollector.getLatestRecord();
+        expect(record.expectedValueAvailable).toBe(false);
+        expect(record.luckValue).toBeNull();
+
+        const session = openableAnalyticsDataCollector.getSessionAggregate('/items/seal_of_rare_find');
+        expect(session.eventsCount).toBe(1);
+        expect(session.grantedBuffEvents).toBe(1);
+    });
+});
+
+describe('update listeners', () => {
+    test('onUpdate subscribers are notified with the new record, and can unsubscribe', async () => {
+        const seen = [];
+        const unsubscribe = openableAnalyticsDataCollector.onUpdate((record) => seen.push(record));
+
+        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        await handler(lootOpenedMessage());
+        expect(seen).toHaveLength(1);
+
+        unsubscribe();
+        await handler(lootOpenedMessage());
+        expect(seen).toHaveLength(1);
+    });
+});
+
+describe('reset controls', () => {
+    test('resetAll clears session, lifetime, and latest record for the current character', async () => {
+        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        await handler(lootOpenedMessage());
+
+        await openableAnalyticsDataCollector.resetAll();
+
+        expect(openableAnalyticsDataCollector.getLatestRecord()).toBeNull();
+        expect(openableAnalyticsDataCollector.getSessionAggregate('/items/chimerical_chest').eventsCount).toBe(0);
+        expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest').eventsCount).toBe(0);
+    });
+});

--- a/src/features/inventory/openable-analytics/openable-analytics-data-collector.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-data-collector.test.js
@@ -204,3 +204,95 @@ describe('reset controls', () => {
         expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest').eventsCount).toBe(0);
     });
 });
+
+describe('bulk imports (Edible Tools / MWI Combat Suite)', () => {
+    test('importContainers adds an imported aggregate that is combined into getLifetimeAggregate alongside live tracking', async () => {
+        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        await handler(lootOpenedMessage()); // 1 live event, 100 coin
+
+        await openableAnalyticsDataCollector.importContainers('import:mwi-combat-suite', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 500, itemTotals: { '/items/coin': 50000 } },
+        ]);
+
+        const combined = openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest');
+        expect(combined.containersOpened).toBe(501);
+        expect(combined.itemTotals['/items/coin']).toBe(50100);
+    });
+
+    test('getLiveLifetimeAggregate excludes imports (only live-tracked openings)', async () => {
+        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        await handler(lootOpenedMessage());
+
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 999, itemTotals: {} },
+        ]);
+
+        expect(
+            openableAnalyticsDataCollector.getLiveLifetimeAggregate('/items/chimerical_chest').containersOpened
+        ).toBe(1);
+    });
+
+    test('re-importing the same source replaces (does not add to) its previous per-container total', async () => {
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 100, itemTotals: { '/items/coin': 1000 } },
+        ]);
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 150, itemTotals: { '/items/coin': 1500 } },
+        ]);
+
+        const combined = openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest');
+        expect(combined.containersOpened).toBe(150);
+        expect(combined.itemTotals['/items/coin']).toBe(1500);
+    });
+
+    test('two different import sources for the same container both contribute to the combined total', async () => {
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 100, itemTotals: {} },
+        ]);
+        await openableAnalyticsDataCollector.importContainers('import:mwi-combat-suite', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 200, itemTotals: {} },
+        ]);
+
+        expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest').containersOpened).toBe(
+            300
+        );
+    });
+
+    test('getKnownContainers includes containers that only have imported data, no live openings', async () => {
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/purples_gift', containerCount: 5, itemTotals: {} },
+        ]);
+
+        expect(openableAnalyticsDataCollector.getKnownContainers()).toContain('/items/purples_gift');
+    });
+
+    test('imports are persisted under a character-scoped storage key', async () => {
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 10, itemTotals: {} },
+        ]);
+
+        expect(mocks.values.has('imports:char-a')).toBe(true);
+    });
+
+    test('resetContainer clears imported data for that container too', async () => {
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 10, itemTotals: {} },
+        ]);
+
+        await openableAnalyticsDataCollector.resetContainer('/items/chimerical_chest');
+
+        expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest').containersOpened).toBe(0);
+    });
+
+    test('imports loaded on initialize are scoped to the current character', async () => {
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 10, itemTotals: {} },
+        ]);
+
+        mocks.currentCharacterId = 'char-b';
+        openableAnalyticsDataCollector.cleanup();
+        await openableAnalyticsDataCollector.initialize();
+
+        expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest').containersOpened).toBe(0);
+    });
+});

--- a/src/features/inventory/openable-analytics/openable-analytics-data-collector.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-data-collector.test.js
@@ -91,6 +91,19 @@ describe('loot_opened ingestion', () => {
         expect(session.eventsCount).toBe(1);
     });
 
+    test('the recorded record carries a per-item actualValueBreakdown, and it flows into the lifetime aggregate’s itemValueTotals', async () => {
+        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        await handler(lootOpenedMessage());
+
+        const record = openableAnalyticsDataCollector.getLatestRecord();
+        expect(record.actualValueBreakdown).toEqual([
+            { itemHrid: '/items/coin', enhancementLevel: 0, count: 100, value: 1000, resolved: true },
+        ]);
+
+        const lifetime = openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest');
+        expect(lifetime.itemValueTotals['/items/coin']).toBe(1000);
+    });
+
     test('openedItem.count > 1 increments container count correctly', async () => {
         const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
         await handler(lootOpenedMessage({ openedItem: { itemHrid: '/items/chimerical_chest', count: 100 } }));

--- a/src/features/inventory/openable-analytics/openable-analytics-data-collector.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-data-collector.test.js
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
     evAvailable: true,
     evValue: 90,
     sellSideValue: { value: 10, needsTax: false },
+    dropTable: { '/items/chimerical_chest': [{ itemHrid: '/items/coin' }] },
 }));
 
 vi.mock('../../../core/storage.js', () => ({
@@ -30,11 +31,10 @@ vi.mock('../../../core/data-manager.js', () => ({
     default: {
         getCurrentCharacterId: vi.fn(() => mocks.currentCharacterId),
         getItemDetails: vi.fn(() => ({ isTradable: true })),
+        getInitClientData: vi.fn(() => ({ openableLootDropMap: mocks.dropTable })),
+        on: mocks.on,
+        off: mocks.off,
     },
-}));
-
-vi.mock('../../../core/websocket.js', () => ({
-    default: { on: mocks.on, off: mocks.off, onSocketEvent: vi.fn(), offSocketEvent: vi.fn() },
 }));
 
 vi.mock('../../../core/config.js', () => ({
@@ -48,7 +48,7 @@ vi.mock('../../../utils/market-data.js', () => ({
 vi.mock('../../market/expected-value-calculator.js', () => ({
     default: {
         resolveSellSideValue: vi.fn(() => mocks.sellSideValue),
-        calculateExpectedValue: vi.fn(() => (mocks.evAvailable ? { expectedValue: mocks.evValue } : null)),
+        calculateExpectedValue: vi.fn(() => (mocks.evAvailable ? { expectedValue: mocks.evValue, drops: [] } : null)),
     },
 }));
 
@@ -63,11 +63,28 @@ function lootOpenedMessage(overrides = {}) {
     };
 }
 
+function lootOpenedEvent(overrides = {}, characterId = mocks.currentCharacterId) {
+    return { data: lootOpenedMessage(overrides), characterId };
+}
+
+function lootHandler() {
+    const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+    // The registered handler is intentionally fire-and-forget in production (DataManager's
+    // critical/synchronous emit does not await listeners; ordering is enforced internally by the
+    // collector's own persistence queue). Wrap it here so tests can still await the resulting
+    // persistence deterministically without changing that production contract.
+    return (event) => {
+        handler(event);
+        return openableAnalyticsDataCollector.persistenceQueue;
+    };
+}
+
 beforeEach(async () => {
     mocks.values.clear();
     mocks.currentCharacterId = 'char-a';
     mocks.evAvailable = true;
     mocks.evValue = 90;
+    mocks.dropTable = { '/items/chimerical_chest': [{ itemHrid: '/items/coin' }] };
     mocks.on.mockClear();
     mocks.off.mockClear();
     openableAnalyticsDataCollector.cleanup();
@@ -79,9 +96,8 @@ describe('loot_opened ingestion', () => {
         expect(mocks.on).toHaveBeenCalledWith('loot_opened', expect.any(Function));
     });
 
-    test('a direct loot_opened message is recorded into the latest record and session aggregate', async () => {
-        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
-        await handler(lootOpenedMessage());
+    test('a direct loot_opened event is recorded into the latest record and session aggregate', async () => {
+        await lootHandler()(lootOpenedEvent());
 
         const record = openableAnalyticsDataCollector.getLatestRecord();
         expect(record.containerHrid).toBe('/items/chimerical_chest');
@@ -92,8 +108,7 @@ describe('loot_opened ingestion', () => {
     });
 
     test('the recorded record carries a per-item actualValueBreakdown, and it flows into the lifetime aggregate’s itemValueTotals', async () => {
-        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
-        await handler(lootOpenedMessage());
+        await lootHandler()(lootOpenedEvent());
 
         const record = openableAnalyticsDataCollector.getLatestRecord();
         expect(record.actualValueBreakdown).toEqual([
@@ -105,8 +120,7 @@ describe('loot_opened ingestion', () => {
     });
 
     test('openedItem.count > 1 increments container count correctly', async () => {
-        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
-        await handler(lootOpenedMessage({ openedItem: { itemHrid: '/items/chimerical_chest', count: 100 } }));
+        await lootHandler()(lootOpenedEvent({ openedItem: { itemHrid: '/items/chimerical_chest', count: 100 } }));
 
         const record = openableAnalyticsDataCollector.getLatestRecord();
         expect(record.containerCount).toBe(100);
@@ -116,8 +130,19 @@ describe('loot_opened ingestion', () => {
     });
 
     test('a message with no openedItem is ignored, not recorded as a broken event', async () => {
-        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
-        await handler({ gainedItems: [], grantedBuffs: [] });
+        await lootHandler()({ data: { gainedItems: [], grantedBuffs: [] }, characterId: 'char-a' });
+
+        expect(openableAnalyticsDataCollector.getLatestRecord()).toBeNull();
+    });
+
+    test('OWN-1: an event carrying a stale/different characterId than the collector’s own is ignored', async () => {
+        await lootHandler()(lootOpenedEvent({}, 'char-other'));
+
+        expect(openableAnalyticsDataCollector.getLatestRecord()).toBeNull();
+    });
+
+    test('an event with no characterId is ignored', async () => {
+        await lootHandler()({ data: lootOpenedMessage(), characterId: null });
 
         expect(openableAnalyticsDataCollector.getLatestRecord()).toBeNull();
     });
@@ -135,8 +160,7 @@ describe('character separation', () => {
     });
 
     test('recording an opening persists lifetime data under the current character’s key only', async () => {
-        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
-        await handler(lootOpenedMessage());
+        await lootHandler()(lootOpenedEvent());
 
         expect(mocks.values.has('lifetime:char-a')).toBe(true);
         expect(mocks.values.get('lifetime:char-a')['/items/chimerical_chest'].eventsCount).toBe(1);
@@ -145,8 +169,7 @@ describe('character separation', () => {
 
 describe('session reset on character/page lifecycle', () => {
     test('re-initializing (character switch or page reload) clears the in-memory session aggregate', async () => {
-        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
-        await handler(lootOpenedMessage());
+        await lootHandler()(lootOpenedEvent());
         expect(openableAnalyticsDataCollector.getSessionAggregate('/items/chimerical_chest').eventsCount).toBe(1);
 
         openableAnalyticsDataCollector.cleanup();
@@ -156,24 +179,49 @@ describe('session reset on character/page lifecycle', () => {
     });
 
     test('a stale handler continuation from before cleanup() cannot record after a new initialize()', async () => {
-        const staleHandler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
+        const staleHandler = lootHandler();
 
         openableAnalyticsDataCollector.cleanup();
         await openableAnalyticsDataCollector.initialize();
 
-        // Simulate the old WebSocket listener firing one more time before it was unregistered.
-        await staleHandler(lootOpenedMessage());
+        // Simulate the old listener firing one more time before it was unregistered.
+        await staleHandler(lootOpenedEvent());
 
         expect(openableAnalyticsDataCollector.getLatestRecord()).toBeNull();
+    });
+
+    test('INIT-1 / LIFE-1: a stale initialize continuation cannot publish loaded state once a newer lifecycle has taken over', async () => {
+        // Make the character-scoped storage load hang so a second initialize() can race ahead of it.
+        let resolveLoad;
+        const { default: storage } = await import('../../../core/storage.js');
+        storage.getJSON.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    resolveLoad = resolve;
+                })
+        );
+
+        openableAnalyticsDataCollector.cleanup();
+        const pendingInit = openableAnalyticsDataCollector.initialize();
+
+        // A second, newer initialize() completes fully while the first is still awaiting its load.
+        mocks.values.set('lifetime:char-a', { '/items/chest': { eventsCount: 99 } });
+        openableAnalyticsDataCollector.cleanup();
+        await openableAnalyticsDataCollector.initialize();
+
+        // The first initialize's delayed load now resolves - it must not publish over current state.
+        resolveLoad({});
+        await pendingInit;
+
+        expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chest').eventsCount).toBe(99);
     });
 });
 
 describe('granted-buff / non-monetary openings', () => {
     test('can be counted (session aggregate increments) without fake Luck', async () => {
         mocks.evAvailable = false;
-        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
-        await handler(
-            lootOpenedMessage({
+        await lootHandler()(
+            lootOpenedEvent({
                 openedItem: { itemHrid: '/items/seal_of_rare_find', count: 1 },
                 gainedItems: [],
                 grantedBuffs: [{ typeHrid: '/buff_types/rare_find', duration: 3600 }],
@@ -195,20 +243,47 @@ describe('update listeners', () => {
         const seen = [];
         const unsubscribe = openableAnalyticsDataCollector.onUpdate((record) => seen.push(record));
 
-        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
-        await handler(lootOpenedMessage());
+        await lootHandler()(lootOpenedEvent());
         expect(seen).toHaveLength(1);
 
         unsubscribe();
-        await handler(lootOpenedMessage());
+        await lootHandler()(lootOpenedEvent());
         expect(seen).toHaveLength(1);
+    });
+
+    test('NOTIFY-1: Lifetime already includes the current opening by the time update listeners run', async () => {
+        let lifetimeAtNotifyTime = null;
+        openableAnalyticsDataCollector.onUpdate(() => {
+            lifetimeAtNotifyTime = openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest');
+        });
+
+        await lootHandler()(lootOpenedEvent());
+
+        expect(lifetimeAtNotifyTime.eventsCount).toBe(1);
+    });
+});
+
+describe('HIST-1: concurrent openings both survive (OA-3)', () => {
+    test('two overlapping recordOpening() calls both land in session, lifetime, and detailed history', async () => {
+        const handler = lootHandler();
+
+        // Both calls are started before either awaits its persistence, simulating truly
+        // overlapping loot_opened deliveries.
+        const first = handler(lootOpenedEvent({ openedItem: { itemHrid: '/items/chest', count: 1 } }));
+        const second = handler(lootOpenedEvent({ openedItem: { itemHrid: '/items/crate', count: 1 } }));
+        await Promise.all([first, second]);
+
+        expect(openableAnalyticsDataCollector.getSessionAggregate('/items/chest').eventsCount).toBe(1);
+        expect(openableAnalyticsDataCollector.getSessionAggregate('/items/crate').eventsCount).toBe(1);
+        expect(openableAnalyticsDataCollector.getHistory()).toHaveLength(2);
+        expect(mocks.values.get('lifetime:char-a')['/items/chest'].eventsCount).toBe(1);
+        expect(mocks.values.get('lifetime:char-a')['/items/crate'].eventsCount).toBe(1);
     });
 });
 
 describe('reset controls', () => {
     test('resetAll clears session, lifetime, and latest record for the current character', async () => {
-        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
-        await handler(lootOpenedMessage());
+        await lootHandler()(lootOpenedEvent());
 
         await openableAnalyticsDataCollector.resetAll();
 
@@ -216,12 +291,50 @@ describe('reset controls', () => {
         expect(openableAnalyticsDataCollector.getSessionAggregate('/items/chimerical_chest').eventsCount).toBe(0);
         expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest').eventsCount).toBe(0);
     });
+
+    test('RESET-1: an opening queued before Reset All does not resurrect after reset completes', async () => {
+        await lootHandler()(lootOpenedEvent());
+        await openableAnalyticsDataCollector.resetAll();
+
+        expect(mocks.values.has('lifetime:char-a')).toBe(false);
+        expect(mocks.values.has('history:char-a')).toBe(false);
+    });
+
+    test('RESET-2: a new opening arriving after Reset All survives', async () => {
+        await lootHandler()(lootOpenedEvent());
+        await openableAnalyticsDataCollector.resetAll();
+        await lootHandler()(lootOpenedEvent({ openedItem: { itemHrid: '/items/chimerical_chest', count: 1 } }));
+
+        expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest').eventsCount).toBe(1);
+        expect(mocks.values.get('history:char-a')).toHaveLength(1);
+    });
+
+    test('RESET-2b: an opening that starts before Reset All resolves but is ordered after it still survives', async () => {
+        const handler = lootHandler();
+        const opening = handler(lootOpenedEvent());
+        const reset = openableAnalyticsDataCollector.resetAll();
+        await Promise.all([opening, reset]);
+
+        // In-memory state reflects reset (opening ran first, reset ran second and cleared it).
+        expect(openableAnalyticsDataCollector.getLatestRecord()).toBeNull();
+    });
+
+    test('RESET-3: resetting one container does not affect another container’s data', async () => {
+        await lootHandler()(lootOpenedEvent({ openedItem: { itemHrid: '/items/chest', count: 1 } }));
+        await lootHandler()(lootOpenedEvent({ openedItem: { itemHrid: '/items/crate', count: 1 } }));
+
+        await openableAnalyticsDataCollector.resetContainer('/items/chest');
+
+        expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chest').eventsCount).toBe(0);
+        expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/crate').eventsCount).toBe(1);
+        expect(mocks.values.get('history:char-a').some((r) => r.containerHrid === '/items/chest')).toBe(false);
+        expect(mocks.values.get('history:char-a').some((r) => r.containerHrid === '/items/crate')).toBe(true);
+    });
 });
 
 describe('bulk imports (Edible Tools / MWI Combat Suite)', () => {
     test('importContainers adds an imported aggregate that is combined into getLifetimeAggregate alongside live tracking', async () => {
-        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
-        await handler(lootOpenedMessage()); // 1 live event, 100 coin
+        await lootHandler()(lootOpenedEvent()); // 1 live event, 100 coin
 
         await openableAnalyticsDataCollector.importContainers('import:mwi-combat-suite', [
             { containerHrid: '/items/chimerical_chest', containerCount: 500, itemTotals: { '/items/coin': 50000 } },
@@ -233,8 +346,7 @@ describe('bulk imports (Edible Tools / MWI Combat Suite)', () => {
     });
 
     test('getLiveLifetimeAggregate excludes imports (only live-tracked openings)', async () => {
-        const handler = mocks.on.mock.calls.find(([type]) => type === 'loot_opened')[1];
-        await handler(lootOpenedMessage());
+        await lootHandler()(lootOpenedEvent());
 
         await openableAnalyticsDataCollector.importContainers('import:edible', [
             { containerHrid: '/items/chimerical_chest', containerCount: 999, itemTotals: {} },
@@ -245,7 +357,7 @@ describe('bulk imports (Edible Tools / MWI Combat Suite)', () => {
         ).toBe(1);
     });
 
-    test('re-importing the same source replaces (does not add to) its previous per-container total', async () => {
+    test('IMPORT-1: re-importing the same source replaces (does not add to) its previous per-container total', async () => {
         await openableAnalyticsDataCollector.importContainers('import:edible', [
             { containerHrid: '/items/chimerical_chest', containerCount: 100, itemTotals: { '/items/coin': 1000 } },
         ]);
@@ -256,6 +368,38 @@ describe('bulk imports (Edible Tools / MWI Combat Suite)', () => {
         const combined = openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest');
         expect(combined.containersOpened).toBe(150);
         expect(combined.itemTotals['/items/coin']).toBe(1500);
+    });
+
+    test('IMPORT-1b: a container present in the old import but absent from the new one is gone (whole-source replacement, OA-5)', async () => {
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 100, itemTotals: {} },
+            { containerHrid: '/items/purples_gift', containerCount: 5, itemTotals: {} },
+        ]);
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 150, itemTotals: {} },
+        ]);
+
+        expect(openableAnalyticsDataCollector.getKnownContainers()).not.toContain('/items/purples_gift');
+        expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest').containersOpened).toBe(
+            150
+        );
+    });
+
+    test('IMPORT-2: switching the imported Edible player leaves no old-player-only containers behind', async () => {
+        // Player A's export.
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 100, itemTotals: {} },
+            { containerHrid: '/items/player_a_only_chest', containerCount: 3, itemTotals: {} },
+        ]);
+        // Player B's export under the same source.
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 20, itemTotals: {} },
+        ]);
+
+        expect(openableAnalyticsDataCollector.getKnownContainers()).not.toContain('/items/player_a_only_chest');
+        expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest').containersOpened).toBe(
+            20
+        );
     });
 
     test('two different import sources for the same container both contribute to the combined total', async () => {
@@ -285,6 +429,16 @@ describe('bulk imports (Edible Tools / MWI Combat Suite)', () => {
         ]);
 
         expect(mocks.values.has('imports:char-a')).toBe(true);
+    });
+
+    test('AGG-2: an imported cumulative snapshot does not increment tracked opening events', async () => {
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 500, itemTotals: {} },
+        ]);
+
+        const combined = openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest');
+        expect(combined.eventsCount).toBe(0);
+        expect(combined.containersOpened).toBe(500);
     });
 
     test('resetContainer clears imported data for that container too', async () => {

--- a/src/features/inventory/openable-analytics/openable-analytics-data-collector.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-data-collector.test.js
@@ -462,4 +462,124 @@ describe('bulk imports (Edible Tools / MWI Combat Suite)', () => {
 
         expect(openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest').containersOpened).toBe(0);
     });
+
+    test('removeImport removes one whole source, keeping live history and other sources intact', async () => {
+        await lootHandler()(lootOpenedEvent({ openedItem: { itemHrid: '/items/chimerical_chest', count: 1 } }));
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 100, itemTotals: {} },
+        ]);
+        await openableAnalyticsDataCollector.importContainers('import:mwi-combat-suite', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 200, itemTotals: {} },
+        ]);
+
+        const persisted = await openableAnalyticsDataCollector.removeImport('import:edible');
+
+        expect(persisted).toBe(true);
+        const combined = openableAnalyticsDataCollector.getLifetimeAggregate('/items/chimerical_chest');
+        expect(combined.containersOpened).toBe(201); // 1 live + 200 mwi-combat-suite, edible's 100 gone
+    });
+
+    test('resetContainer prunes an import source left with zero containers rather than leaving an empty {} entry', async () => {
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 10, itemTotals: {} },
+        ]);
+
+        await openableAnalyticsDataCollector.resetContainer('/items/chimerical_chest');
+
+        expect(openableAnalyticsDataCollector.getImportSourceKeys()).not.toContain('import:edible');
+    });
+});
+
+describe('section 22: persistence-failure handling', () => {
+    test('recordOpening logs when the underlying save fails, but in-memory state still reflects the opening', async () => {
+        const { default: storage } = await import('../../../core/storage.js');
+        storage.setJSON.mockResolvedValueOnce(false); // saveHistory fails
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        await lootHandler()(lootOpenedEvent());
+
+        expect(openableAnalyticsDataCollector.getLatestRecord()).not.toBeNull();
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Could not save'));
+        errorSpy.mockRestore();
+    });
+
+    test('a failed persistence operation does not poison the queue for later queued work', async () => {
+        const { default: storage } = await import('../../../core/storage.js');
+        storage.setJSON.mockResolvedValueOnce(false); // first opening's saveHistory fails
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        await lootHandler()(lootOpenedEvent({ openedItem: { itemHrid: '/items/chest', count: 1 } }));
+        await lootHandler()(lootOpenedEvent({ openedItem: { itemHrid: '/items/crate', count: 1 } }));
+
+        // The second opening's persistence must still run and succeed.
+        expect(mocks.values.get('lifetime:char-a')['/items/crate'].eventsCount).toBe(1);
+    });
+
+    test('importContainers reports persisted: false when the save fails', async () => {
+        const { default: storage } = await import('../../../core/storage.js');
+        storage.setJSON.mockResolvedValueOnce(false);
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const { persisted } = await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 10, itemTotals: {} },
+        ]);
+
+        expect(persisted).toBe(false);
+    });
+
+    test('resetAll reports false when a delete fails', async () => {
+        const { default: storage } = await import('../../../core/storage.js');
+        storage.delete.mockResolvedValueOnce(false);
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const persisted = await openableAnalyticsDataCollector.resetAll();
+
+        expect(persisted).toBe(false);
+    });
+});
+
+describe('section 23: state-change subscription', () => {
+    test('fires immediately after in-memory commit for a live opening', async () => {
+        const seen = [];
+        openableAnalyticsDataCollector.onStateChange(() => seen.push(true));
+
+        await lootHandler()(lootOpenedEvent());
+
+        expect(seen).toHaveLength(1);
+    });
+
+    test('fires for import, remove import, delete container, and delete all', async () => {
+        let count = 0;
+        openableAnalyticsDataCollector.onStateChange(() => count++);
+
+        await openableAnalyticsDataCollector.importContainers('import:edible', [
+            { containerHrid: '/items/chimerical_chest', containerCount: 10, itemTotals: {} },
+        ]);
+        await openableAnalyticsDataCollector.removeImport('import:edible');
+        await openableAnalyticsDataCollector.resetContainer('/items/chimerical_chest');
+        await openableAnalyticsDataCollector.resetAll();
+
+        expect(count).toBe(4);
+    });
+
+    test('can unsubscribe', async () => {
+        const seen = [];
+        const unsubscribe = openableAnalyticsDataCollector.onStateChange(() => seen.push(true));
+        unsubscribe();
+
+        await lootHandler()(lootOpenedEvent());
+
+        expect(seen).toHaveLength(0);
+    });
+
+    test('cleanup clears state-change listeners', async () => {
+        const seen = [];
+        openableAnalyticsDataCollector.onStateChange(() => seen.push(true));
+
+        openableAnalyticsDataCollector.cleanup();
+        await openableAnalyticsDataCollector.initialize();
+        await lootHandler()(lootOpenedEvent());
+
+        expect(seen).toHaveLength(0);
+    });
 });

--- a/src/features/inventory/openable-analytics/openable-analytics-import-parsers.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-import-parsers.js
@@ -1,0 +1,155 @@
+/**
+ * Openable Analytics Import Parsers
+ * Parses pasted/uploaded historical container-opening data from other tools into the same
+ * `{containerHrid, containerCount, itemTotals}` shape the data collector's live tracking uses,
+ * so recomputation always goes through Toolasha's own pricing/EV stack rather than trusting a
+ * source tool's own stored numbers. Adding a future third source only means adding one more
+ * parser here that returns this same shape - no other module needs to change.
+ */
+
+import dataManager from '../../../core/data-manager.js';
+
+/**
+ * Build a lowercased item/container display-name -> HRID map from the current game data, for
+ * resolving name-keyed import sources (Edible Tools) back to HRIDs. Sources that are already
+ * HRID-keyed (MWI Combat Suite) don't need this.
+ * @returns {Object} Map of lowercased name -> item HRID
+ */
+export function buildItemNameToHridMap() {
+    const initData = dataManager.getInitClientData();
+    const itemDetailMap = initData?.itemDetailMap || {};
+    const map = {};
+    for (const [itemHrid, details] of Object.entries(itemDetailMap)) {
+        if (details?.name) {
+            map[details.name.toLowerCase()] = itemHrid;
+        }
+    }
+    return map;
+}
+
+/**
+ * Parse an MWI Combat Suite export (a downloaded/pasted JSON file, already HRID-keyed). Only
+ * cumulative `total.opened` / `total.loot` counts are read - the source's own
+ * actualValue/expectedValue/luck fields are intentionally ignored so the import is recomputed
+ * under Toolasha's own valuation.
+ * @param {string} rawText - Raw JSON text (file contents or pasted text)
+ * @returns {{containers: Array<{containerHrid: string, containerCount: number, itemTotals: Object}>, warnings: Array<string>}}
+ */
+export function parseCombatSuiteExport(rawText) {
+    const warnings = [];
+    let parsed;
+    try {
+        parsed = JSON.parse(rawText);
+    } catch {
+        return { containers: [], warnings: ['Could not parse the pasted/uploaded text as JSON.'] };
+    }
+
+    const chests = parsed?.chests;
+    if (!chests || typeof chests !== 'object') {
+        return { containers: [], warnings: ['No "chests" data found in this export.'] };
+    }
+
+    const containers = [];
+    for (const [containerHrid, chest] of Object.entries(chests)) {
+        const containerCount = chest?.total?.opened;
+        if (!(containerCount > 0)) {
+            warnings.push(`Skipped ${chest?.name || containerHrid}: no openings recorded.`);
+            continue;
+        }
+
+        const itemTotals = {};
+        for (const [itemHrid, item] of Object.entries(chest?.total?.loot || {})) {
+            if (item?.count > 0) {
+                itemTotals[itemHrid] = item.count;
+            }
+        }
+
+        containers.push({ containerHrid, containerCount, itemTotals });
+    }
+
+    return { containers, warnings };
+}
+
+/**
+ * Parse an Edible Tools `Edible_Tools` localStorage value (pasted as text). Edible only retains
+ * cumulative totals per chest, keyed by localized display name rather than HRID, so this
+ * resolves names against the current game's item list and reports anything it can't match
+ * rather than silently dropping it.
+ * @param {string} rawText - Raw JSON text pasted from `localStorage.getItem('Edible_Tools')`
+ * @param {Object} [options]
+ * @param {string} [options.playerId] - Which player's data to import, if the export has more than one
+ * @returns {{containers: Array, warnings: Array<string>, needsPlayerSelection?: boolean, players?: Array<{id: string, name: string}>}}
+ */
+export function parseEdibleExport(rawText, { playerId } = {}) {
+    let parsed;
+    try {
+        parsed = JSON.parse(rawText);
+    } catch {
+        return { containers: [], warnings: ['Could not parse the pasted text as JSON.'] };
+    }
+
+    const chestOpenData = parsed?.Chest_Open_Data;
+    if (!chestOpenData || typeof chestOpenData !== 'object') {
+        return { containers: [], warnings: ['No "Chest_Open_Data" found in this Edible Tools data.'] };
+    }
+
+    const players = Object.entries(chestOpenData).map(([id, playerData]) => ({
+        id,
+        name: playerData?.['玩家昵称'] || id,
+    }));
+
+    if (!playerId) {
+        if (players.length > 1) {
+            return { containers: [], warnings: [], needsPlayerSelection: true, players };
+        }
+        if (players.length === 0) {
+            return { containers: [], warnings: ['No player data found in this Edible Tools data.'] };
+        }
+        playerId = players[0].id;
+    }
+
+    const playerData = chestOpenData[playerId];
+    const chestData = playerData?.['开箱数据'];
+    if (!chestData || typeof chestData !== 'object') {
+        return { containers: [], warnings: [`No chest data found for ${playerData?.['玩家昵称'] || playerId}.`] };
+    }
+
+    const nameToHrid = buildItemNameToHridMap();
+    const warnings = [];
+    const containers = [];
+
+    for (const [chestName, chest] of Object.entries(chestData)) {
+        const containerHrid = nameToHrid[chestName.toLowerCase()];
+        const containerCount = chest?.['总计开箱数量'];
+
+        if (!containerHrid) {
+            warnings.push(`Skipped "${chestName}": could not match to a known item.`);
+            continue;
+        }
+        if (!(containerCount > 0)) {
+            warnings.push(`Skipped ${chestName}: no openings recorded.`);
+            continue;
+        }
+
+        const itemTotals = {};
+        let unmatchedItemCount = 0;
+        for (const [itemName, itemData] of Object.entries(chest?.['获得物品'] || {})) {
+            const itemHrid = nameToHrid[itemName.toLowerCase()];
+            if (!itemHrid) {
+                unmatchedItemCount++;
+                continue;
+            }
+            if (itemData?.['数量'] > 0) {
+                itemTotals[itemHrid] = itemData['数量'];
+            }
+        }
+
+        if (unmatchedItemCount > 0) {
+            warnings.push(`${chestName}: ${unmatchedItemCount} gained item(s) could not be matched and were excluded.`);
+        }
+
+        containers.push({ containerHrid, containerCount, itemTotals });
+    }
+
+    return { containers, warnings };
+}

--- a/src/features/inventory/openable-analytics/openable-analytics-import-parsers.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-import-parsers.js
@@ -250,6 +250,21 @@ export function parseEdibleExport(rawText, { playerId } = {}) {
         return invalidResult(`No chest data found for ${playerData?.['玩家昵称'] || playerId}.`);
     }
 
+    // Same ownership preflight contract as parseCombatSuiteExport: the strongest available
+    // evidence is an exact resolved-player-ID match, then an exact nickname/character-name
+    // match, then explicit unknown - never a silent omission that skips the mismatch warning.
+    const ownerName = typeof playerData?.['玩家昵称'] === 'string' ? playerData['玩家昵称'] : null;
+    const currentCharacterId = dataManager.getCurrentCharacterId?.() ?? null;
+    const currentCharacterName = dataManager.getCurrentCharacterName?.() ?? null;
+    let ownerMismatch;
+    if (currentCharacterId !== null && String(playerId) === String(currentCharacterId)) {
+        ownerMismatch = false;
+    } else if (ownerName && currentCharacterName) {
+        ownerMismatch = ownerName !== currentCharacterName;
+    } else {
+        ownerMismatch = null;
+    }
+
     const nameToHrid = buildItemNameToHridMap();
     const warnings = [];
     const containers = [];
@@ -327,10 +342,10 @@ export function parseEdibleExport(rawText, { playerId } = {}) {
     }
 
     if (containers.length === 0) {
-        return { ...emptyResult(), warnings };
+        return { ...emptyResult(), warnings, ownerName, ownerMismatch };
     }
 
-    return { status: 'ready', containers, warnings };
+    return { status: 'ready', containers, warnings, ownerName, ownerMismatch };
 }
 
 function invalidResult(message) {

--- a/src/features/inventory/openable-analytics/openable-analytics-import-parsers.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-import-parsers.js
@@ -3,11 +3,51 @@
  * Parses pasted/uploaded historical container-opening data from other tools into the same
  * `{containerHrid, containerCount, itemTotals}` shape the data collector's live tracking uses,
  * so recomputation always goes through Toolasha's own pricing/EV stack rather than trusting a
- * source tool's own stored numbers. Adding a future third source only means adding one more
- * parser here that returns this same shape - no other module needs to change.
+ * source tool's own stored numbers.
+ *
+ * Historical import is a baseline/migration feature, not a synchronization engine: supported
+ * external exports are cumulative totals with no reliable per-opening identities/timestamps, so
+ * Toolasha cannot prove a newer import doesn't already include live-tracked openings, or that two
+ * imported sources don't cover the same historical period. Same-source replacement only prevents
+ * stacking two old snapshots of the same source - it does not prove no overlap with anything else.
  */
 
 import dataManager from '../../../core/data-manager.js';
+
+const ITEM_HRID_PATTERN = /^\/items\/[a-z0-9_]+$/;
+
+/**
+ * @param {*} value
+ * @returns {boolean} True only for a real, non-negative, finite safe-integer count - never a
+ *      coerced string, negative, fractional, or unsafe number.
+ */
+function isValidCount(value) {
+    return typeof value === 'number' && Number.isFinite(value) && Number.isSafeInteger(value) && value >= 0;
+}
+
+/**
+ * @param {*} value
+ * @returns {boolean} True for a plain object (map-like), explicitly excluding arrays and null -
+ *      import sources describe maps, and an array in that position is a malformed export.
+ */
+function isPlainObject(value) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * A container with real current game data but no monetary loot model and nothing imported for it
+ * has no economic information Openable Analytics can display - safe to skip entirely rather than
+ * list a permanently empty/unavailable row.
+ * @param {string} containerHrid
+ * @param {Object} itemTotals
+ * @returns {boolean}
+ */
+function isKnownNonMonetaryWithNoLoot(containerHrid, itemTotals) {
+    if (Object.keys(itemTotals).length > 0) return false;
+    if (!dataManager.getItemDetails(containerHrid)) return false; // unknown HRID - keep it (section 19)
+    const dropTable = dataManager.getInitClientData?.()?.openableLootDropMap?.[containerHrid];
+    return !Array.isArray(dropTable) || dropTable.length === 0;
+}
 
 /**
  * Build a lowercased item/container display-name -> HRID map from the current game data, for
@@ -28,71 +68,148 @@ export function buildItemNameToHridMap() {
 }
 
 /**
+ * Detect which supported import format a pasted/uploaded text matches, from its validated JSON
+ * shape alone - the source-select dropdown is intentionally removed (section 16).
+ * @param {string} rawText
+ * @returns {{source: 'edible'|'mwi-combat-suite'|null, error?: string}}
+ */
+export function detectImportSource(rawText) {
+    let parsed;
+    try {
+        parsed = JSON.parse(rawText);
+    } catch {
+        return { source: null, error: 'Could not parse this text as JSON.' };
+    }
+
+    if (!isPlainObject(parsed)) {
+        return { source: null, error: 'This does not look like a supported export.' };
+    }
+
+    const hasCombatSuiteShape = isPlainObject(parsed.chests);
+    const hasEdibleShape = isPlainObject(parsed.Chest_Open_Data);
+
+    if (hasCombatSuiteShape && hasEdibleShape) {
+        return { source: null, error: 'This data matches more than one supported format and cannot be imported.' };
+    }
+    if (hasCombatSuiteShape) return { source: 'mwi-combat-suite' };
+    if (hasEdibleShape) return { source: 'edible' };
+    return { source: null, error: 'This does not match a supported Edible Tools or MWI Combat Suite export.' };
+}
+
+/**
  * Parse an MWI Combat Suite export (a downloaded/pasted JSON file, already HRID-keyed). Only
  * cumulative `total.opened` / `total.loot` counts are read - the source's own
  * actualValue/expectedValue/luck fields are intentionally ignored so the import is recomputed
  * under Toolasha's own valuation.
  * @param {string} rawText - Raw JSON text (file contents or pasted text)
- * @returns {{containers: Array<{containerHrid: string, containerCount: number, itemTotals: Object}>, warnings: Array<string>}}
+ * @returns {{status: 'invalid'|'empty'|'ready', message?: string, containers: Array, warnings: Array<string>, ownerName: string|null, ownerMismatch: boolean|null}}
  */
 export function parseCombatSuiteExport(rawText) {
-    const warnings = [];
     let parsed;
     try {
         parsed = JSON.parse(rawText);
     } catch {
-        return { containers: [], warnings: ['Could not parse the pasted/uploaded text as JSON.'] };
+        return invalidResult('Could not parse the pasted/uploaded text as JSON.');
     }
 
     const chests = parsed?.chests;
-    if (!chests || typeof chests !== 'object') {
-        return { containers: [], warnings: ['No "chests" data found in this export.'] };
+    if (!isPlainObject(chests)) {
+        return invalidResult('No "chests" data found in this export.');
     }
 
+    const ownerName = typeof parsed?.player === 'string' ? parsed.player : null;
+    const currentCharacterName = dataManager.getCurrentCharacterName?.() ?? null;
+    const ownerMismatch = ownerName === null ? null : ownerName !== currentCharacterName;
+
+    const warnings = [];
     const containers = [];
+
     for (const [containerHrid, chest] of Object.entries(chests)) {
+        if (!ITEM_HRID_PATTERN.test(containerHrid)) {
+            warnings.push(`Skipped an entry with an invalid item id: "${containerHrid}".`);
+            continue;
+        }
+
         const containerCount = chest?.total?.opened;
-        if (!(containerCount > 0)) {
-            warnings.push(`Skipped ${chest?.name || containerHrid}: no openings recorded.`);
+        if (containerCount === undefined || containerCount === 0) {
+            continue; // no openings recorded - silently ignored, not a warning
+        }
+        if (!isValidCount(containerCount) || containerCount === 0) {
+            warnings.push(`Skipped ${chest?.name || containerHrid}: invalid opened count.`);
+            continue;
+        }
+
+        // Distinguish a missing/malformed loot block (corrupted data) from an explicitly present
+        // empty one (a real record of "opened N times, gained nothing"). Importing the former as
+        // if it were the latter would silently fabricate Actual 0 / a huge Expected / Luck -100%.
+        const total = chest?.total || {};
+        if (!('loot' in total)) {
+            warnings.push(`Skipped ${chest?.name || containerHrid}: opening count present but loot data is missing.`);
+            continue;
+        }
+        if (!isPlainObject(total.loot)) {
+            warnings.push(`Skipped ${chest?.name || containerHrid}: loot data is malformed.`);
             continue;
         }
 
         const itemTotals = {};
-        for (const [itemHrid, item] of Object.entries(chest?.total?.loot || {})) {
-            if (item?.count > 0) {
-                itemTotals[itemHrid] = item.count;
+        let hadInvalidItem = false;
+        for (const [itemHrid, item] of Object.entries(total.loot)) {
+            if (!ITEM_HRID_PATTERN.test(itemHrid)) {
+                hadInvalidItem = true;
+                continue;
             }
+            const count = item?.count;
+            if (count === undefined || count === 0) continue; // zero/absent - silently ignored
+            if (!isValidCount(count)) {
+                hadInvalidItem = true;
+                continue;
+            }
+            itemTotals[itemHrid] = count;
         }
 
-        // MWI Combat Suite is already HRID-keyed, so nothing here is dropped for being
-        // unresolvable - this source's Actual is always as complete as its own raw counts.
-        containers.push({ containerHrid, containerCount, itemTotals, sourceDataComplete: true });
+        if (hadInvalidItem) {
+            warnings.push(
+                `${chest?.name || containerHrid}: one or more gained items had invalid data and were excluded.`
+            );
+        }
+
+        if (isKnownNonMonetaryWithNoLoot(containerHrid, itemTotals)) continue;
+
+        // MWI Combat Suite is already HRID-keyed and validated above, so nothing here is dropped
+        // for being unresolvable - this source's Actual is only marked partial when validation
+        // itself excluded something.
+        containers.push({ containerHrid, containerCount, itemTotals, sourceDataComplete: !hadInvalidItem });
     }
 
-    return { containers, warnings };
+    if (containers.length === 0) {
+        return { ...emptyResult(), warnings, ownerName, ownerMismatch };
+    }
+
+    return { status: 'ready', containers, warnings, ownerName, ownerMismatch };
 }
 
 /**
- * Parse an Edible Tools `Edible_Tools` localStorage value (pasted as text). Edible only retains
- * cumulative totals per chest, keyed by localized display name rather than HRID, so this
- * resolves names against the current game's item list and reports anything it can't match
- * rather than silently dropping it.
- * @param {string} rawText - Raw JSON text pasted from `localStorage.getItem('Edible_Tools')`
+ * Parse an Edible Tools `Edible_Tools` localStorage value (pasted as text, or read directly from
+ * `localStorage.getItem('Edible_Tools')` when same-origin). Edible only retains cumulative totals
+ * per chest, keyed by localized display name rather than HRID, so this resolves names against the
+ * current game's item list and reports anything it can't match rather than silently dropping it.
+ * @param {string} rawText - Raw JSON text
  * @param {Object} [options]
  * @param {string} [options.playerId] - Which player's data to import, if the export has more than one
- * @returns {{containers: Array, warnings: Array<string>, needsPlayerSelection?: boolean, players?: Array<{id: string, name: string}>}}
+ * @returns {{status: 'invalid'|'empty'|'ready', message?: string, containers: Array, warnings: Array<string>, needsPlayerSelection?: boolean, players?: Array<{id: string, name: string}>}}
  */
 export function parseEdibleExport(rawText, { playerId } = {}) {
     let parsed;
     try {
         parsed = JSON.parse(rawText);
     } catch {
-        return { containers: [], warnings: ['Could not parse the pasted text as JSON.'] };
+        return invalidResult('Could not parse the pasted text as JSON.');
     }
 
     const chestOpenData = parsed?.Chest_Open_Data;
-    if (!chestOpenData || typeof chestOpenData !== 'object') {
-        return { containers: [], warnings: ['No "Chest_Open_Data" found in this Edible Tools data.'] };
+    if (!isPlainObject(chestOpenData)) {
+        return invalidResult('No "Chest_Open_Data" found in this Edible Tools data.');
     }
 
     const players = Object.entries(chestOpenData).map(([id, playerData]) => ({
@@ -101,60 +218,130 @@ export function parseEdibleExport(rawText, { playerId } = {}) {
     }));
 
     if (!playerId) {
-        if (players.length > 1) {
-            return { containers: [], warnings: [], needsPlayerSelection: true, players };
-        }
         if (players.length === 0) {
-            return { containers: [], warnings: ['No player data found in this Edible Tools data.'] };
+            return invalidResult('No player data found in this Edible Tools data.');
         }
-        playerId = players[0].id;
+        if (players.length === 1) {
+            playerId = players[0].id;
+        } else {
+            // Never silently guess among multiple players: try an exact current-character-ID key
+            // match, then a unique exact current-character-name match, before asking explicitly.
+            const currentCharacterId = dataManager.getCurrentCharacterId?.() ?? null;
+            const currentCharacterName = dataManager.getCurrentCharacterName?.() ?? null;
+
+            if (currentCharacterId && chestOpenData[String(currentCharacterId)]) {
+                playerId = String(currentCharacterId);
+            } else if (currentCharacterName) {
+                const nameMatches = players.filter((player) => player.name === currentCharacterName);
+                if (nameMatches.length === 1) {
+                    playerId = nameMatches[0].id;
+                }
+            }
+
+            if (!playerId) {
+                return { status: 'empty', containers: [], warnings: [], needsPlayerSelection: true, players };
+            }
+        }
     }
 
     const playerData = chestOpenData[playerId];
     const chestData = playerData?.['开箱数据'];
-    if (!chestData || typeof chestData !== 'object') {
-        return { containers: [], warnings: [`No chest data found for ${playerData?.['玩家昵称'] || playerId}.`] };
+    if (!isPlainObject(chestData)) {
+        return invalidResult(`No chest data found for ${playerData?.['玩家昵称'] || playerId}.`);
     }
 
     const nameToHrid = buildItemNameToHridMap();
     const warnings = [];
     const containers = [];
+    let anyChestNameResolved = false;
 
     for (const [chestName, chest] of Object.entries(chestData)) {
         const containerHrid = nameToHrid[chestName.toLowerCase()];
-        const containerCount = chest?.['总计开箱数量'];
 
         if (!containerHrid) {
             warnings.push(`Skipped "${chestName}": could not match to a known item.`);
             continue;
         }
-        if (!(containerCount > 0)) {
-            warnings.push(`Skipped ${chestName}: no openings recorded.`);
+        anyChestNameResolved = true;
+
+        const containerCount = chest?.['总计开箱数量'];
+        if (containerCount === undefined || containerCount === 0) {
+            continue; // no openings recorded - silently ignored, not a warning
+        }
+        if (!isValidCount(containerCount)) {
+            warnings.push(`Skipped ${chestName}: invalid opened count.`);
+            continue;
+        }
+
+        if (!('获得物品' in (chest || {}))) {
+            warnings.push(`Skipped ${chestName}: opening count present but gained-item data is missing.`);
+            continue;
+        }
+        if (!isPlainObject(chest['获得物品'])) {
+            warnings.push(`Skipped ${chestName}: gained-item data is malformed.`);
             continue;
         }
 
         const itemTotals = {};
         let unmatchedItemCount = 0;
-        for (const [itemName, itemData] of Object.entries(chest?.['获得物品'] || {})) {
+        let hadInvalidCount = false;
+        for (const [itemName, itemData] of Object.entries(chest['获得物品'])) {
             const itemHrid = nameToHrid[itemName.toLowerCase()];
             if (!itemHrid) {
                 unmatchedItemCount++;
                 continue;
             }
-            if (itemData?.['数量'] > 0) {
-                itemTotals[itemHrid] = itemData['数量'];
+            const count = itemData?.['数量'];
+            if (count === undefined || count === 0) continue;
+            if (!isValidCount(count)) {
+                hadInvalidCount = true;
+                continue;
             }
+            itemTotals[itemHrid] = count;
         }
 
         if (unmatchedItemCount > 0) {
             warnings.push(`${chestName}: ${unmatchedItemCount} gained item(s) could not be matched and were excluded.`);
         }
+        if (hadInvalidCount) {
+            warnings.push(`${chestName}: one or more gained items had invalid counts and were excluded.`);
+        }
+
+        if (isKnownNonMonetaryWithNoLoot(containerHrid, itemTotals)) continue;
 
         // Do not let a warning-only path turn into a falsely precise imported Luck value: an
-        // unmatched gained item means this container's Actual is only a subtotal of the real
-        // source data, not the complete picture.
-        containers.push({ containerHrid, containerCount, itemTotals, sourceDataComplete: unmatchedItemCount === 0 });
+        // unmatched/invalid gained item means this container's Actual is only a subtotal of the
+        // real source data, not the complete picture.
+        containers.push({
+            containerHrid,
+            containerCount,
+            itemTotals,
+            sourceDataComplete: unmatchedItemCount === 0 && !hadInvalidCount,
+        });
     }
 
-    return { containers, warnings };
+    // Edible is name-keyed/localized. If nothing at all could be resolved, this isn't legitimate
+    // valid-empty history - it's a locale/format the current item list can't match against.
+    if (!anyChestNameResolved && Object.keys(chestData).length > 0) {
+        return { ...invalidResult('None of the chest names in this export could be matched to a known item.') };
+    }
+
+    if (containers.length === 0) {
+        return { ...emptyResult(), warnings };
+    }
+
+    return { status: 'ready', containers, warnings };
+}
+
+function invalidResult(message) {
+    return { status: 'invalid', message, containers: [], warnings: [] };
+}
+
+function emptyResult() {
+    return {
+        status: 'empty',
+        message: 'No opening history found in this export. Existing import was not changed.',
+        containers: [],
+        warnings: [],
+    };
 }

--- a/src/features/inventory/openable-analytics/openable-analytics-import-parsers.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-import-parsers.js
@@ -64,7 +64,9 @@ export function parseCombatSuiteExport(rawText) {
             }
         }
 
-        containers.push({ containerHrid, containerCount, itemTotals });
+        // MWI Combat Suite is already HRID-keyed, so nothing here is dropped for being
+        // unresolvable - this source's Actual is always as complete as its own raw counts.
+        containers.push({ containerHrid, containerCount, itemTotals, sourceDataComplete: true });
     }
 
     return { containers, warnings };
@@ -148,7 +150,10 @@ export function parseEdibleExport(rawText, { playerId } = {}) {
             warnings.push(`${chestName}: ${unmatchedItemCount} gained item(s) could not be matched and were excluded.`);
         }
 
-        containers.push({ containerHrid, containerCount, itemTotals });
+        // Do not let a warning-only path turn into a falsely precise imported Luck value: an
+        // unmatched gained item means this container's Actual is only a subtotal of the real
+        // source data, not the complete picture.
+        containers.push({ containerHrid, containerCount, itemTotals, sourceDataComplete: unmatchedItemCount === 0 });
     }
 
     return { containers, warnings };

--- a/src/features/inventory/openable-analytics/openable-analytics-import-parsers.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-import-parsers.test.js
@@ -60,6 +60,7 @@ describe('parseCombatSuiteExport', () => {
             containerHrid: '/items/large_treasure_chest',
             containerCount: 3671,
             itemTotals: { '/items/coin': 246365372, '/items/pearl': 4479 },
+            sourceDataComplete: true,
         });
     });
 
@@ -117,6 +118,7 @@ describe('parseEdibleExport', () => {
                 containerHrid: '/items/large_treasure_chest',
                 containerCount: 100,
                 itemTotals: { '/items/coin': 5000, '/items/pearl': 12 },
+                sourceDataComplete: true,
             },
         ]);
     });
@@ -173,6 +175,32 @@ describe('parseEdibleExport', () => {
 
         expect(containers[0].itemTotals).toEqual({ '/items/coin': 5000 });
         expect(warnings.some((w) => w.includes('1 gained item'))).toBe(true);
+    });
+
+    test('IMPORT-3 / OA-9: an unmatched gained item marks the container sourceDataComplete: false, not a falsely complete import', () => {
+        const raw = JSON.stringify({
+            Chest_Open_Data: {
+                p1: {
+                    玩家昵称: 'Celasha',
+                    开箱数据: {
+                        'Large Treasure Chest': {
+                            总计开箱数量: 100,
+                            获得物品: { Coin: { 数量: 5000 }, 'Some Unknown Item': { 数量: 3 } },
+                        },
+                    },
+                },
+            },
+        });
+
+        const { containers } = parseEdibleExport(raw);
+
+        expect(containers[0].sourceDataComplete).toBe(false);
+    });
+
+    test('a container with every gained item matched is sourceDataComplete: true', () => {
+        const { containers } = parseEdibleExport(edibleJson());
+
+        expect(containers[0].sourceDataComplete).toBe(true);
     });
 
     test('returns an empty result with a warning for invalid JSON', () => {

--- a/src/features/inventory/openable-analytics/openable-analytics-import-parsers.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-import-parsers.test.js
@@ -1,14 +1,25 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({ itemDetailMap: {} }));
+const mocks = vi.hoisted(() => ({
+    itemDetailMap: {},
+    openableLootDropMap: {},
+    currentCharacterId: null,
+    currentCharacterName: null,
+}));
 
 vi.mock('../../../core/data-manager.js', () => ({
     default: {
-        getInitClientData: vi.fn(() => ({ itemDetailMap: mocks.itemDetailMap })),
+        getInitClientData: vi.fn(() => ({
+            itemDetailMap: mocks.itemDetailMap,
+            openableLootDropMap: mocks.openableLootDropMap,
+        })),
+        getItemDetails: vi.fn((hrid) => mocks.itemDetailMap[hrid] || null),
+        getCurrentCharacterId: vi.fn(() => mocks.currentCharacterId),
+        getCurrentCharacterName: vi.fn(() => mocks.currentCharacterName),
     },
 }));
 
-const { buildItemNameToHridMap, parseCombatSuiteExport, parseEdibleExport } =
+const { buildItemNameToHridMap, detectImportSource, parseCombatSuiteExport, parseEdibleExport } =
     await import('./openable-analytics-import-parsers.js');
 
 beforeEach(() => {
@@ -17,6 +28,11 @@ beforeEach(() => {
         '/items/coin': { name: 'Coin' },
         '/items/pearl': { name: 'Pearl' },
     };
+    // A non-empty drop table so a resolved container with real itemTotals is never silently
+    // treated as "known non-monetary with no loot" purely because a test's itemTotals is empty.
+    mocks.openableLootDropMap = { '/items/large_treasure_chest': [{ itemHrid: '/items/coin', dropRate: 0.9 }] };
+    mocks.currentCharacterId = null;
+    mocks.currentCharacterName = null;
 });
 
 describe('buildItemNameToHridMap', () => {
@@ -25,6 +41,47 @@ describe('buildItemNameToHridMap', () => {
 
         expect(map['coin']).toBe('/items/coin');
         expect(map['large treasure chest']).toBe('/items/large_treasure_chest');
+    });
+});
+
+describe('detectImportSource (section 16)', () => {
+    test('recognizes an MWI Combat Suite export by its chests shape', () => {
+        const result = detectImportSource(JSON.stringify({ chests: {} }));
+
+        expect(result.source).toBe('mwi-combat-suite');
+    });
+
+    test('recognizes an Edible Tools export by its Chest_Open_Data shape', () => {
+        const result = detectImportSource(JSON.stringify({ Chest_Open_Data: {} }));
+
+        expect(result.source).toBe('edible');
+    });
+
+    test('rejects invalid JSON', () => {
+        const result = detectImportSource('not json');
+
+        expect(result.source).toBeNull();
+        expect(result.error).toBeTruthy();
+    });
+
+    test('rejects a JSON shape matching neither supported format', () => {
+        const result = detectImportSource(JSON.stringify({ foo: 'bar' }));
+
+        expect(result.source).toBeNull();
+        expect(result.error).toBeTruthy();
+    });
+
+    test('rejects an array at the top level', () => {
+        const result = detectImportSource(JSON.stringify([1, 2, 3]));
+
+        expect(result.source).toBeNull();
+    });
+
+    test('rejects an ambiguous export matching both shapes', () => {
+        const result = detectImportSource(JSON.stringify({ chests: {}, Chest_Open_Data: {} }));
+
+        expect(result.source).toBeNull();
+        expect(result.error).toBeTruthy();
     });
 });
 
@@ -52,8 +109,9 @@ describe('parseCombatSuiteExport', () => {
     }
 
     test('reads cumulative opened count and item totals, ignoring the source’s own valuation fields', () => {
-        const { containers, warnings } = parseCombatSuiteExport(exportJson());
+        const { status, containers, warnings } = parseCombatSuiteExport(exportJson());
 
+        expect(status).toBe('ready');
         expect(warnings).toHaveLength(0);
         expect(containers).toHaveLength(1);
         expect(containers[0]).toEqual({
@@ -64,27 +122,153 @@ describe('parseCombatSuiteExport', () => {
         });
     });
 
-    test('skips a chest with zero/missing opened count and warns', () => {
+    test('reads top-level player metadata for ownership preflight', () => {
+        const result = parseCombatSuiteExport(exportJson());
+
+        expect(result.ownerName).toBe('Celasha');
+    });
+
+    test('section 19: owner matches current character -> no mismatch warning', () => {
+        mocks.currentCharacterName = 'Celasha';
+        const result = parseCombatSuiteExport(exportJson());
+
+        expect(result.ownerMismatch).toBe(false);
+    });
+
+    test('section 19: owner differs from current character -> explicit mismatch flag', () => {
+        mocks.currentCharacterName = 'SomeoneElse';
+        const result = parseCombatSuiteExport(exportJson());
+
+        expect(result.ownerMismatch).toBe(true);
+    });
+
+    test('section 19: owner metadata absent -> neither matched nor mismatched, caller must warn explicitly', () => {
+        const result = parseCombatSuiteExport(JSON.stringify({ chests: JSON.parse(exportJson()).chests }));
+
+        expect(result.ownerName).toBeNull();
+        expect(result.ownerMismatch).toBeNull();
+    });
+
+    test('section 17: a chest with zero/missing opened count is silently ignored, not a warning', () => {
         const { containers, warnings } = parseCombatSuiteExport(
             exportJson({ '/items/purples_gift': { name: 'Purples Gift', total: { opened: 0, loot: {} } } })
         );
 
         expect(containers).toHaveLength(1);
-        expect(warnings.some((w) => w.includes('Purples Gift'))).toBe(true);
+        expect(warnings).toHaveLength(0);
     });
 
-    test('returns an empty result with a warning for invalid JSON', () => {
-        const { containers, warnings } = parseCombatSuiteExport('not json');
+    test('invalid JSON is reported as an explicit invalid state, not empty', () => {
+        const result = parseCombatSuiteExport('not json');
+
+        expect(result.status).toBe('invalid');
+        expect(result.containers).toHaveLength(0);
+        expect(result.message).toBeTruthy();
+    });
+
+    test('no "chests" key is reported as invalid', () => {
+        const result = parseCombatSuiteExport(JSON.stringify({ player: 'x' }));
+
+        expect(result.status).toBe('invalid');
+    });
+
+    test('section 17: a syntactically valid export with no relevant opening history is a safe no-op, not implicit deletion', () => {
+        const result = parseCombatSuiteExport(
+            JSON.stringify({ chests: { '/items/large_treasure_chest': { total: { opened: 0, loot: {} } } } })
+        );
+
+        expect(result.status).toBe('empty');
+        expect(result.containers).toHaveLength(0);
+        expect(result.message).toMatch(/not.*changed/i);
+    });
+
+    test('section 18: rejects a malformed HRID key rather than importing it', () => {
+        const { containers, warnings } = parseCombatSuiteExport(
+            JSON.stringify({ chests: { 'not-a-real-hrid': { total: { opened: 5, loot: {} } } } })
+        );
+
+        expect(containers).toHaveLength(0);
+        expect(warnings.some((w) => w.includes('invalid item id'))).toBe(true);
+    });
+
+    test('section 18: rejects array-shaped "chests" rather than coercing it', () => {
+        const result = parseCombatSuiteExport(JSON.stringify({ chests: [] }));
+
+        expect(result.status).toBe('invalid');
+    });
+
+    test('section 18: rejects a string count instead of coercing "100" to 100', () => {
+        const { containers, warnings } = parseCombatSuiteExport(
+            JSON.stringify({
+                chests: { '/items/large_treasure_chest': { total: { opened: '100', loot: {} } } },
+            })
+        );
+
+        expect(containers).toHaveLength(0);
+        expect(warnings.some((w) => w.includes('invalid opened count'))).toBe(true);
+    });
+
+    test('section 18: rejects a negative count', () => {
+        const { containers, warnings } = parseCombatSuiteExport(
+            JSON.stringify({ chests: { '/items/large_treasure_chest': { total: { opened: -5, loot: {} } } } })
+        );
 
         expect(containers).toHaveLength(0);
         expect(warnings.length).toBeGreaterThan(0);
     });
 
-    test('returns an empty result with a warning when there is no "chests" key', () => {
-        const { containers, warnings } = parseCombatSuiteExport(JSON.stringify({ player: 'x' }));
+    test('section 18: rejects a fractional count', () => {
+        const { containers, warnings } = parseCombatSuiteExport(
+            JSON.stringify({ chests: { '/items/large_treasure_chest': { total: { opened: 5.5, loot: {} } } } })
+        );
 
         expect(containers).toHaveLength(0);
         expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    test('section 18: a missing loot block on a real opened count fails closed rather than becoming Actual 0 / huge Expected', () => {
+        const { containers, warnings } = parseCombatSuiteExport(
+            JSON.stringify({ chests: { '/items/large_treasure_chest': { total: { opened: 100 } } } })
+        );
+
+        expect(containers).toHaveLength(0);
+        expect(warnings.some((w) => w.includes('loot data is missing'))).toBe(true);
+    });
+
+    test('section 18: an explicitly present empty loot map is a legitimate zero-loot import, not corruption', () => {
+        const { containers, warnings } = parseCombatSuiteExport(
+            JSON.stringify({
+                chests: { '/items/purples_gift': { total: { opened: 100, loot: {} } } },
+            })
+        );
+
+        expect(warnings.filter((w) => w.includes('missing') || w.includes('malformed'))).toHaveLength(0);
+        expect(containers[0]).toMatchObject({ containerHrid: '/items/purples_gift', containerCount: 100 });
+    });
+
+    test('section 19: a syntactically valid unknown historical HRID is preserved, not discarded', () => {
+        const { containers } = parseCombatSuiteExport(
+            JSON.stringify({
+                chests: {
+                    '/items/long_removed_chest': {
+                        total: { opened: 10, loot: { '/items/coin': { count: 100 } } },
+                    },
+                },
+            })
+        );
+
+        expect(containers).toHaveLength(1);
+        expect(containers[0].containerHrid).toBe('/items/long_removed_chest');
+    });
+
+    test('section 19: a current-known non-monetary container with empty imported loot is silently skipped', () => {
+        mocks.openableLootDropMap = {}; // /items/large_treasure_chest has no drop model
+        const { containers, warnings } = parseCombatSuiteExport(
+            JSON.stringify({ chests: { '/items/large_treasure_chest': { total: { opened: 5, loot: {} } } } })
+        );
+
+        expect(containers).toHaveLength(0);
+        expect(warnings).toHaveLength(0);
     });
 });
 
@@ -110,8 +294,9 @@ describe('parseEdibleExport', () => {
     }
 
     test('resolves chest and item display names to HRIDs via the current game data', () => {
-        const { containers, warnings } = parseEdibleExport(edibleJson());
+        const { status, containers, warnings } = parseEdibleExport(edibleJson());
 
+        expect(status).toBe('ready');
         expect(warnings).toHaveLength(0);
         expect(containers).toEqual([
             {
@@ -123,22 +308,7 @@ describe('parseEdibleExport', () => {
         ]);
     });
 
-    test('skips and warns about a chest name that cannot be matched to a known item', () => {
-        const { containers, warnings } = parseEdibleExport(
-            edibleJson({
-                p2: {
-                    玩家昵称: 'Other',
-                    开箱数据: { 'Some Unknown Chest': { 总计开箱数量: 10, 获得物品: {} } },
-                },
-            })
-        );
-
-        // Two players present with no playerId specified -> needs a player picker instead.
-        expect(containers).toHaveLength(0);
-        expect(warnings).toHaveLength(0);
-    });
-
-    test('requests player selection when the export has more than one player and none is specified', () => {
+    test('requests player selection when the export has more than one player and none can be resolved automatically', () => {
         const result = parseEdibleExport(edibleJson({ p2: { 玩家昵称: 'Other', 开箱数据: {} } }));
 
         expect(result.needsPlayerSelection).toBe(true);
@@ -146,6 +316,27 @@ describe('parseEdibleExport', () => {
             { id: 'p1', name: 'Celasha' },
             { id: 'p2', name: 'Other' },
         ]);
+    });
+
+    test('section 20: resolves the player automatically via an exact current-character-ID match', () => {
+        mocks.currentCharacterId = 'p2';
+        const result = parseEdibleExport(edibleJson({ p2: { 玩家昵称: 'Other', 开箱数据: {} } }));
+
+        expect(result.needsPlayerSelection).toBeFalsy();
+    });
+
+    test('section 20: resolves the player automatically via a unique exact current-character-name match', () => {
+        mocks.currentCharacterName = 'Other';
+        const result = parseEdibleExport(edibleJson({ p2: { 玩家昵称: 'Other', 开箱数据: {} } }));
+
+        expect(result.needsPlayerSelection).toBeFalsy();
+    });
+
+    test('section 20: an ambiguous name match (two players share the current character name) still requires a picker', () => {
+        mocks.currentCharacterName = 'Celasha';
+        const result = parseEdibleExport(edibleJson({ p2: { 玩家昵称: 'Celasha', 开箱数据: {} } }));
+
+        expect(result.needsPlayerSelection).toBe(true);
     });
 
     test('imports the specified player’s data when playerId is provided among multiple players', () => {
@@ -203,17 +394,73 @@ describe('parseEdibleExport', () => {
         expect(containers[0].sourceDataComplete).toBe(true);
     });
 
-    test('returns an empty result with a warning for invalid JSON', () => {
-        const { containers, warnings } = parseEdibleExport('not json');
+    test('invalid JSON is reported as an explicit invalid state', () => {
+        const result = parseEdibleExport('not json');
 
-        expect(containers).toHaveLength(0);
-        expect(warnings.length).toBeGreaterThan(0);
+        expect(result.status).toBe('invalid');
+        expect(result.containers).toHaveLength(0);
     });
 
-    test('returns an empty result with a warning when there is no Chest_Open_Data', () => {
-        const { containers, warnings } = parseEdibleExport(JSON.stringify({ Edible_Tools_Set: {} }));
+    test('no Chest_Open_Data is reported as invalid', () => {
+        const result = parseEdibleExport(JSON.stringify({ Edible_Tools_Set: {} }));
+
+        expect(result.status).toBe('invalid');
+    });
+
+    test('section 20: no resolvable chest/item names at all is an explicit locale/format failure, not valid-empty', () => {
+        const raw = JSON.stringify({
+            Chest_Open_Data: {
+                p1: { 玩家昵称: 'Celasha', 开箱数据: { 'Coffre Inconnu': { 总计开箱数量: 5, 获得物品: {} } } },
+            },
+        });
+
+        const result = parseEdibleExport(raw);
+
+        expect(result.status).toBe('invalid');
+    });
+
+    test('section 17: a syntactically valid export with no relevant opening history is a safe no-op', () => {
+        const raw = JSON.stringify({
+            Chest_Open_Data: {
+                p1: {
+                    玩家昵称: 'Celasha',
+                    开箱数据: { 'Large Treasure Chest': { 总计开箱数量: 0, 获得物品: {} } },
+                },
+            },
+        });
+
+        const result = parseEdibleExport(raw);
+
+        expect(result.status).toBe('empty');
+        expect(result.message).toMatch(/not.*changed/i);
+    });
+
+    test('section 18: rejects a string count instead of coercing "100" to 100', () => {
+        const raw = JSON.stringify({
+            Chest_Open_Data: {
+                p1: {
+                    玩家昵称: 'Celasha',
+                    开箱数据: { 'Large Treasure Chest': { 总计开箱数量: '100', 获得物品: {} } },
+                },
+            },
+        });
+
+        const { containers, warnings } = parseEdibleExport(raw);
 
         expect(containers).toHaveLength(0);
-        expect(warnings.length).toBeGreaterThan(0);
+        expect(warnings.some((w) => w.includes('invalid opened count'))).toBe(true);
+    });
+
+    test('section 18: a missing gained-item block on a real opened count fails closed', () => {
+        const raw = JSON.stringify({
+            Chest_Open_Data: {
+                p1: { 玩家昵称: 'Celasha', 开箱数据: { 'Large Treasure Chest': { 总计开箱数量: 100 } } },
+            },
+        });
+
+        const { containers, warnings } = parseEdibleExport(raw);
+
+        expect(containers).toHaveLength(0);
+        expect(warnings.some((w) => w.includes('missing'))).toBe(true);
     });
 });

--- a/src/features/inventory/openable-analytics/openable-analytics-import-parsers.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-import-parsers.test.js
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ itemDetailMap: {} }));
+
+vi.mock('../../../core/data-manager.js', () => ({
+    default: {
+        getInitClientData: vi.fn(() => ({ itemDetailMap: mocks.itemDetailMap })),
+    },
+}));
+
+const { buildItemNameToHridMap, parseCombatSuiteExport, parseEdibleExport } =
+    await import('./openable-analytics-import-parsers.js');
+
+beforeEach(() => {
+    mocks.itemDetailMap = {
+        '/items/large_treasure_chest': { name: 'Large Treasure Chest' },
+        '/items/coin': { name: 'Coin' },
+        '/items/pearl': { name: 'Pearl' },
+    };
+});
+
+describe('buildItemNameToHridMap', () => {
+    test('builds a lowercased name -> HRID map from current game data', () => {
+        const map = buildItemNameToHridMap();
+
+        expect(map['coin']).toBe('/items/coin');
+        expect(map['large treasure chest']).toBe('/items/large_treasure_chest');
+    });
+});
+
+describe('parseCombatSuiteExport', () => {
+    function exportJson(overrides = {}) {
+        return JSON.stringify({
+            player: 'Celasha',
+            chests: {
+                '/items/large_treasure_chest': {
+                    name: 'Large Treasure Chest',
+                    total: {
+                        opened: 3671,
+                        actualValue: 689082381,
+                        expectedValue: 687488727.6,
+                        luck: '0.2%',
+                        loot: {
+                            '/items/coin': { name: 'Coin', count: 246365372, unitPrice: 1, totalValue: 246365372 },
+                            '/items/pearl': { name: 'Pearl', count: 4479, unitPrice: 12544, totalValue: 56184576 },
+                        },
+                    },
+                },
+                ...overrides,
+            },
+        });
+    }
+
+    test('reads cumulative opened count and item totals, ignoring the source’s own valuation fields', () => {
+        const { containers, warnings } = parseCombatSuiteExport(exportJson());
+
+        expect(warnings).toHaveLength(0);
+        expect(containers).toHaveLength(1);
+        expect(containers[0]).toEqual({
+            containerHrid: '/items/large_treasure_chest',
+            containerCount: 3671,
+            itemTotals: { '/items/coin': 246365372, '/items/pearl': 4479 },
+        });
+    });
+
+    test('skips a chest with zero/missing opened count and warns', () => {
+        const { containers, warnings } = parseCombatSuiteExport(
+            exportJson({ '/items/purples_gift': { name: 'Purples Gift', total: { opened: 0, loot: {} } } })
+        );
+
+        expect(containers).toHaveLength(1);
+        expect(warnings.some((w) => w.includes('Purples Gift'))).toBe(true);
+    });
+
+    test('returns an empty result with a warning for invalid JSON', () => {
+        const { containers, warnings } = parseCombatSuiteExport('not json');
+
+        expect(containers).toHaveLength(0);
+        expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    test('returns an empty result with a warning when there is no "chests" key', () => {
+        const { containers, warnings } = parseCombatSuiteExport(JSON.stringify({ player: 'x' }));
+
+        expect(containers).toHaveLength(0);
+        expect(warnings.length).toBeGreaterThan(0);
+    });
+});
+
+describe('parseEdibleExport', () => {
+    function edibleJson(overrides = {}) {
+        return JSON.stringify({
+            Chest_Open_Data: {
+                p1: {
+                    玩家昵称: 'Celasha',
+                    开箱数据: {
+                        'Large Treasure Chest': {
+                            总计开箱数量: 100,
+                            获得物品: {
+                                Coin: { 数量: 5000 },
+                                Pearl: { 数量: 12 },
+                            },
+                        },
+                    },
+                },
+                ...overrides,
+            },
+        });
+    }
+
+    test('resolves chest and item display names to HRIDs via the current game data', () => {
+        const { containers, warnings } = parseEdibleExport(edibleJson());
+
+        expect(warnings).toHaveLength(0);
+        expect(containers).toEqual([
+            {
+                containerHrid: '/items/large_treasure_chest',
+                containerCount: 100,
+                itemTotals: { '/items/coin': 5000, '/items/pearl': 12 },
+            },
+        ]);
+    });
+
+    test('skips and warns about a chest name that cannot be matched to a known item', () => {
+        const { containers, warnings } = parseEdibleExport(
+            edibleJson({
+                p2: {
+                    玩家昵称: 'Other',
+                    开箱数据: { 'Some Unknown Chest': { 总计开箱数量: 10, 获得物品: {} } },
+                },
+            })
+        );
+
+        // Two players present with no playerId specified -> needs a player picker instead.
+        expect(containers).toHaveLength(0);
+        expect(warnings).toHaveLength(0);
+    });
+
+    test('requests player selection when the export has more than one player and none is specified', () => {
+        const result = parseEdibleExport(edibleJson({ p2: { 玩家昵称: 'Other', 开箱数据: {} } }));
+
+        expect(result.needsPlayerSelection).toBe(true);
+        expect(result.players).toEqual([
+            { id: 'p1', name: 'Celasha' },
+            { id: 'p2', name: 'Other' },
+        ]);
+    });
+
+    test('imports the specified player’s data when playerId is provided among multiple players', () => {
+        const raw = edibleJson({ p2: { 玩家昵称: 'Other', 开箱数据: {} } });
+        const result = parseEdibleExport(raw, { playerId: 'p1' });
+
+        expect(result.needsPlayerSelection).toBeFalsy();
+        expect(result.containers).toHaveLength(1);
+    });
+
+    test('skips and warns about an unmatched gained-item name while still importing the container', () => {
+        const raw = JSON.stringify({
+            Chest_Open_Data: {
+                p1: {
+                    玩家昵称: 'Celasha',
+                    开箱数据: {
+                        'Large Treasure Chest': {
+                            总计开箱数量: 100,
+                            获得物品: { Coin: { 数量: 5000 }, 'Some Unknown Item': { 数量: 3 } },
+                        },
+                    },
+                },
+            },
+        });
+
+        const { containers, warnings } = parseEdibleExport(raw);
+
+        expect(containers[0].itemTotals).toEqual({ '/items/coin': 5000 });
+        expect(warnings.some((w) => w.includes('1 gained item'))).toBe(true);
+    });
+
+    test('returns an empty result with a warning for invalid JSON', () => {
+        const { containers, warnings } = parseEdibleExport('not json');
+
+        expect(containers).toHaveLength(0);
+        expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    test('returns an empty result with a warning when there is no Chest_Open_Data', () => {
+        const { containers, warnings } = parseEdibleExport(JSON.stringify({ Edible_Tools_Set: {} }));
+
+        expect(containers).toHaveLength(0);
+        expect(warnings.length).toBeGreaterThan(0);
+    });
+});

--- a/src/features/inventory/openable-analytics/openable-analytics-import-parsers.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-import-parsers.test.js
@@ -463,4 +463,82 @@ describe('parseEdibleExport', () => {
         expect(containers).toHaveLength(0);
         expect(warnings.some((w) => w.includes('missing'))).toBe(true);
     });
+
+    describe('ownership metadata (PR667-FINAL-3)', () => {
+        test('single-player export matching the current character -> ownerMismatch: false', () => {
+            mocks.currentCharacterName = 'Celasha';
+            const result = parseEdibleExport(edibleJson());
+
+            expect(result.ownerName).toBe('Celasha');
+            expect(result.ownerMismatch).toBe(false);
+        });
+
+        test('single-player export belonging to another named character -> ownerMismatch: true', () => {
+            mocks.currentCharacterName = 'SomeoneElse';
+            const result = parseEdibleExport(edibleJson());
+
+            expect(result.ownerName).toBe('Celasha');
+            expect(result.ownerMismatch).toBe(true);
+        });
+
+        test('exact current-character-ID match is accepted as matched even if the nickname differs', () => {
+            mocks.currentCharacterId = 'p1';
+            mocks.currentCharacterName = 'SomeoneElse';
+            const result = parseEdibleExport(edibleJson());
+
+            expect(result.ownerMismatch).toBe(false);
+        });
+
+        test('an explicitly selected player (multi-player picker) carries ownership metadata into preflight', () => {
+            mocks.currentCharacterName = 'Other';
+            const raw = edibleJson({ p2: { 玩家昵称: 'Other', 开箱数据: {} } });
+
+            const result = parseEdibleExport(raw, { playerId: 'p1' });
+
+            expect(result.ownerName).toBe('Celasha');
+            expect(result.ownerMismatch).toBe(true);
+        });
+
+        test('no ID match and no current character name available -> explicit unknown state, not a silent omission', () => {
+            const result = parseEdibleExport(edibleJson());
+
+            expect(result.ownerName).toBe('Celasha');
+            expect(result.ownerMismatch).toBeNull();
+        });
+
+        test('a player with no recorded nickname and no ID match -> explicit unknown state', () => {
+            mocks.currentCharacterName = 'Celasha';
+            const raw = JSON.stringify({
+                Chest_Open_Data: {
+                    p1: {
+                        开箱数据: {
+                            'Large Treasure Chest': { 总计开箱数量: 100, 获得物品: { Coin: { 数量: 5000 } } },
+                        },
+                    },
+                },
+            });
+
+            const result = parseEdibleExport(raw);
+
+            expect(result.ownerName).toBeNull();
+            expect(result.ownerMismatch).toBeNull();
+        });
+
+        test('ownership metadata is present on a valid-empty result, not only on ready', () => {
+            mocks.currentCharacterName = 'SomeoneElse';
+            const raw = JSON.stringify({
+                Chest_Open_Data: {
+                    p1: {
+                        玩家昵称: 'Celasha',
+                        开箱数据: { 'Large Treasure Chest': { 总计开箱数量: 0, 获得物品: {} } },
+                    },
+                },
+            });
+
+            const result = parseEdibleExport(raw);
+
+            expect(result.status).toBe('empty');
+            expect(result.ownerMismatch).toBe(true);
+        });
+    });
 });

--- a/src/features/inventory/openable-analytics/openable-analytics-modal-injector.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-modal-injector.js
@@ -1,64 +1,91 @@
 /**
  * Openable Analytics Modal Injector
- * Injects a compact Actual/Expected/Luck summary line into the native "Opened Loot" modal.
- * Idempotent by design: the injected line is located by its own marker class and its content is
+ * Injects a compact Actual/Expected/Luck footer + per-item value labels into the native "Opened
+ * Loot" modal. Idempotent by design: injected content is located by its own marker class and
  * replaced in place, so it self-corrects regardless of whether the modal remounts for a new
- * opening or is updated in place while already displayed (both are possible depending on how the
- * native inventory panel batches consecutive openings).
+ * opening or is updated in place while already displayed.
  */
 
 import domObserver from '../../../core/dom-observer.js';
 import config from '../../../core/config.js';
 import openableAnalyticsDataCollector from './openable-analytics-data-collector.js';
-import { coinFormatter } from '../../../utils/formatters.js';
+import { coinFormatter, formatKMB3Digits } from '../../../utils/formatters.js';
 
 const MODAL_CONTENT_CLASS = 'Inventory_modalContent';
 const LINE_CLASS = 'toolasha-openable-analytics-line';
 const GAINED_ITEMS_CLASS = 'Inventory_gainedItems';
 const ITEM_CONTAINER_CLASS = 'Item_itemContainer';
 const ITEM_VALUE_LABEL_CLASS = 'toolasha-openable-analytics-item-value';
+const COIN_HRID = '/items/coin';
+
+const LUCK_TOOLTIP =
+    'Luck is Actual loot value minus Expected loot value. It does not include the container/key cost and is not opening profit.';
+const LUCK_UNAVAILABLE_TOOLTIP = `Some required values are missing, so Luck can't be calculated. ${LUCK_TOOLTIP}`;
+const PARTIAL_TOOLTIP = 'One or more gained items could not be priced.';
 
 function formatValue(value) {
-    if (value === null || value === undefined) return 'N/A';
+    if (value === null || value === undefined) return '—';
     return coinFormatter(Math.round(value));
 }
 
+/** Compact tiny per-item annotation, e.g. `≈54K`, `≈1.10M`, `≈0` - always compact regardless of the user's number-format setting. */
+function formatTinyItemValue(value) {
+    const rounded = Math.round(value);
+    if (rounded === 0) return '≈0';
+    return `≈${formatKMB3Digits(rounded)}`;
+}
+
+/** Luck value with an explicit `+` on positive amounts; negative values already carry their own `-`. Zero is neutral (no sign). */
+function formatLuckValue(value) {
+    if (value === null || value === undefined) return '—';
+    const rounded = Math.round(value);
+    const sign = rounded > 0 ? '+' : '';
+    return sign + coinFormatter(rounded);
+}
+
+/** Luck percent with an explicit `+`, one decimal place, and `-0.0%` normalized to `0.0%`. */
 function formatLuckPercent(percent) {
     if (percent === null || percent === undefined) return '';
-    const sign = percent >= 0 ? '+' : '';
-    return ` (${sign}${percent.toFixed(1)}%)`;
+    let rounded = percent.toFixed(1);
+    if (rounded === '-0.0') rounded = '0.0';
+    const sign = parseFloat(rounded) > 0 ? '+' : '';
+    return ` (${sign}${rounded}%)`;
 }
 
 function luckColor(luckValue) {
-    if (luckValue === null || luckValue === undefined) return config.COLOR_TEXT_SECONDARY || '#888888';
-    return luckValue >= 0 ? config.COLOR_PROFIT : config.COLOR_LOSS;
+    if (luckValue > 0) return config.COLOR_PROFIT;
+    if (luckValue < 0) return config.COLOR_LOSS;
+    return config.COLOR_TEXT_SECONDARY || '#888888';
 }
 
 /**
- * Build the inner HTML for the injected summary line from the latest record + its lifetime
- * aggregate. `openAnalyticsView` is invoked when the "View Analytics" affordance is clicked.
+ * Build the inner HTML for the injected footer from the latest opening record + its lifetime
+ * aggregate. The container/opened-count wording is intentionally omitted - the native result
+ * already communicates what was opened and how many.
  * @param {Object} record - Latest normalized opening record
  * @param {Object} lifetimeAggregate - Lifetime aggregate for this container
- * @returns {{html: string, containerHrid: string}}
+ * @param {Function} [onViewAnalytics] - Invoked when "View Analytics" is clicked
+ * @returns {string}
  */
-function buildLineContent(record, lifetimeAggregate) {
-    const actualText = `${formatValue(record.actualValue)}${record.actualValueComplete ? '' : ' (partial)'}`;
-    const expectedText = !record.expectedValueAvailable
-        ? 'N/A'
-        : `${formatValue(record.expectedValue)}${record.expectedValueComplete === false ? ' (partial)' : ''}`;
-    const luckAvailable = record.luckValue !== null && record.luckValue !== undefined;
-    const sessionLine = `${record.containerCount} opened · Actual ${actualText} · Expected ${expectedText}${
-        luckAvailable
-            ? ` · Luck <span style="color:${luckColor(record.luckValue)}">${formatValue(
-                  record.luckValue
-              )}${formatLuckPercent(record.luckPercent)}</span>`
-            : ''
+function buildFooterContent(record, lifetimeAggregate) {
+    const actualPartial = !record.actualValueComplete;
+    const actualText = `${formatValue(record.actualValue)}${
+        actualPartial ? ` <span title="${PARTIAL_TOOLTIP}">[Partial]</span>` : ''
     }`;
+    const expectedText = record.expectedValueAvailable ? formatValue(record.expectedValue) : '—';
+    const luckAvailable = record.luckValue !== null && record.luckValue !== undefined;
+    const luckTitle = luckAvailable ? LUCK_TOOLTIP : LUCK_UNAVAILABLE_TOOLTIP;
+    const luckText = luckAvailable
+        ? `<span style="color:${luckColor(record.luckValue)}">${formatLuckValue(record.luckValue)}${formatLuckPercent(record.luckPercent)}</span>`
+        : '—';
 
-    // Aggregate Luck must fail closed as a whole: it is only meaningful when every valuation
-    // component folded into this lifetime aggregate is itself Luck-eligible (section 3.2) -
-    // never subtract a partial/unavailable Expected subset from a superset Actual total.
+    const currentLine = `Actual ${actualText} · Expected ${expectedText} · <span title="${luckTitle}">Luck</span> ${luckText}`;
+
+    // Suppress a Lifetime row that would just repeat this exact first event: semantically, this
+    // container's Lifetime consists of nothing but this one live event and no imported data.
+    const isOnlyEverEvent = lifetimeAggregate.eventsCount === 1 && !lifetimeAggregate.hasImportedData;
     const lifetimeLuckAvailable =
+        !isOnlyEverEvent &&
         (lifetimeAggregate.valuationRecordCount || 0) > 0 &&
         lifetimeAggregate.luckEligibleRecordCount === lifetimeAggregate.valuationRecordCount;
     const lifetimeLuckValue = lifetimeLuckAvailable
@@ -69,13 +96,16 @@ function buildLineContent(record, lifetimeAggregate) {
             ? (lifetimeLuckValue / lifetimeAggregate.expectedValueTotal) * 100
             : null;
 
-    const lifetimeLine = lifetimeLuckAvailable
-        ? `Lifetime: ${lifetimeAggregate.containersOpened} opened · Luck <span style="color:${luckColor(
-              lifetimeLuckValue
-          )}">${formatValue(lifetimeLuckValue)}${formatLuckPercent(lifetimeLuckPercent)}</span>`
-        : `Lifetime: ${lifetimeAggregate.containersOpened} opened`;
+    const viewLink = `<span class="toolasha-openable-analytics-view-link" style="cursor:pointer;text-decoration:underline">View Analytics</span>`;
+    const lifetimeLine = isOnlyEverEvent
+        ? viewLink
+        : `Lifetime ×${lifetimeAggregate.containersOpened}${
+              lifetimeLuckAvailable
+                  ? ` · Luck <span style="color:${luckColor(lifetimeLuckValue)}">${formatLuckValue(lifetimeLuckValue)}${formatLuckPercent(lifetimeLuckPercent)}</span>`
+                  : ''
+          } · ${viewLink}`;
 
-    return `<div>${sessionLine}</div><div style="opacity:0.75">${lifetimeLine} · <span class="toolasha-openable-analytics-view-link" style="cursor:pointer;text-decoration:underline">View Analytics</span></div>`;
+    return `<div>${currentLine}</div><div style="opacity:0.75">${lifetimeLine}</div>`;
 }
 
 class OpenableAnalyticsModalInjector {
@@ -105,92 +135,123 @@ class OpenableAnalyticsModalInjector {
             'openableAnalyticsModalItems',
             ITEM_CONTAINER_CLASS,
             (node) => {
+                if (!this.isInitialized) return;
                 const container = node.closest(`[class*="${MODAL_CONTENT_CLASS}"]`);
                 if (!container) return;
-                const record = openableAnalyticsDataCollector.getLatestRecord();
-                if (!record) return;
-                this.renderItemValueLabels(container, record);
+                this.reconcileModal(container);
             }
         );
 
-        // Data-driven fallback: covers the summary line (and opportunistically the per-item
-        // labels) as soon as new data arrives, ahead of any DOM mutation.
+        // Data-driven fallback: covers the footer (and opportunistically the per-item labels)
+        // as soon as new data arrives, ahead of any DOM mutation.
         this.unsubscribeCollector = openableAnalyticsDataCollector.onUpdate(() => this.refreshMountedModal());
     }
 
     tryInject(container) {
+        if (!this.isInitialized) return;
         if (!container?.classList) return;
         const className = typeof container.className === 'string' ? container.className : '';
         if (!className.includes(MODAL_CONTENT_CLASS)) return;
 
-        const record = openableAnalyticsDataCollector.getLatestRecord();
-        if (!record) return;
-
-        this.renderLine(container, record);
+        this.reconcileModal(container);
     }
 
     refreshMountedModal() {
+        if (!this.isInitialized) return;
         const container = document.querySelector(`[class*="${MODAL_CONTENT_CLASS}"]`);
         if (!container) return;
 
-        const record = openableAnalyticsDataCollector.getLatestRecord();
-        if (!record) return;
-
-        this.renderLine(container, record);
+        this.reconcileModal(container);
     }
 
-    renderLine(container, record) {
+    /**
+     * Never trust a generic `Inventory_modalContent` match alone. Only treat a mounted container
+     * as the current monetary reward result when the DOM structurally proves it: it must contain
+     * a real, non-empty gained-items section, and the collector's latest record must itself be a
+     * monetary opening (at least one gained item). This also naturally excludes buff-only
+     * openables, which never render a gained-items section at all. If ownership cannot be
+     * established, any previously injected OA content is stripped instead of left stale - this
+     * also handles the native modal being reused from a monetary opening into a buff-only result.
+     * @param {HTMLElement} container - Candidate `Inventory_modalContent` root
+     */
+    reconcileModal(container) {
+        if (!this.isInitialized) return;
+
+        const record = openableAnalyticsDataCollector.getLatestRecord();
+        const gainedItemsContainer = container.querySelector(`[class*="${GAINED_ITEMS_CLASS}"]`);
+        const itemContainers = gainedItemsContainer
+            ? gainedItemsContainer.querySelectorAll(`[class*="${ITEM_CONTAINER_CLASS}"]`)
+            : [];
+        const isMonetaryRewardModal = Boolean(record) && record.gainedItems?.length > 0 && itemContainers.length > 0;
+
+        if (!isMonetaryRewardModal) {
+            this.clearOwnedDom(container);
+            return;
+        }
+
+        this.renderFooter(container, record);
+        this.renderItemValueLabels(container, record, itemContainers);
+    }
+
+    renderFooter(container, record) {
         const lifetimeAggregate = openableAnalyticsDataCollector.getLifetimeAggregate(record.containerHrid);
 
         let line = container.querySelector(`.${LINE_CLASS}`);
         if (!line) {
             line = document.createElement('div');
             line.className = LINE_CLASS;
-            line.style.cssText = 'font-size:12px;margin:4px 0;';
-            const headerChild = container.children[0] || null;
-            container.insertBefore(line, headerChild ? headerChild.nextSibling : container.firstChild);
+            line.style.cssText = 'font-size:12px;margin:6px 0;';
+            // Place after all native reward content, immediately above the native Close button,
+            // which the client always renders as the final child of modalContent.
+            const closeButton = container.lastElementChild;
+            if (closeButton) {
+                container.insertBefore(line, closeButton);
+            } else {
+                container.appendChild(line);
+            }
         }
 
-        line.innerHTML = buildLineContent(record, lifetimeAggregate);
+        line.innerHTML = buildFooterContent(record, lifetimeAggregate);
 
         const viewLink = line.querySelector('.toolasha-openable-analytics-view-link');
         if (viewLink && this.viewAnalyticsHandler) {
             viewLink.onclick = () => this.viewAnalyticsHandler(record.containerHrid);
         }
-
-        this.renderItemValueLabels(container, record);
     }
 
     /**
-     * Stamp a small value label onto each individual gained-item icon inside the native "You
-     * found:" list, matched positionally against `record.actualValueBreakdown` (both derive from
-     * the identical `gainedItems` array, so DOM order and breakdown order always agree). Skips
-     * labeling entirely - rather than risk mismatching values to the wrong item - if the icon
-     * count doesn't match the breakdown count (e.g. a rare special-cased item render).
+     * Stamp a small value annotation onto each individual gained-item icon, matched positionally
+     * against `record.actualValueBreakdown` (both derive from the identical `gainedItems` array,
+     * so DOM order and breakdown order always agree). Always clears any previously stamped labels
+     * first so a failed/mismatched re-render never leaves a stale value on the wrong item, then
+     * skips labeling entirely - rather than risk mismatching values - if the icon count doesn't
+     * match the breakdown count.
      * @param {HTMLElement} container - The modal's `Inventory_modalContent` root
      * @param {Object} record - Latest normalized opening record
+     * @param {NodeList} itemContainers - Item icon nodes inside the gained-items section
      */
-    renderItemValueLabels(container, record) {
-        const gainedItemsContainer = container.querySelector(`[class*="${GAINED_ITEMS_CLASS}"]`);
-        if (!gainedItemsContainer) return;
+    renderItemValueLabels(container, record, itemContainers) {
+        container.querySelectorAll(`.${ITEM_VALUE_LABEL_CLASS}`).forEach((label) => label.remove());
 
-        const itemContainers = gainedItemsContainer.querySelectorAll(`[class*="${ITEM_CONTAINER_CLASS}"]`);
         const breakdown = record.actualValueBreakdown || [];
         if (itemContainers.length !== breakdown.length) return;
 
         itemContainers.forEach((itemEl, index) => {
             const item = breakdown[index];
+            if (item.itemHrid === COIN_HRID) return; // native quantity already equals face value
+            if (!item.resolved) return; // no fabricated/placeholder label for an unpriced item
 
-            let label = itemEl.querySelector(`.${ITEM_VALUE_LABEL_CLASS}`);
-            if (!label) {
-                label = document.createElement('div');
-                label.className = ITEM_VALUE_LABEL_CLASS;
-                label.style.cssText = 'font-size:10px; text-align:center; opacity:0.85;';
-                itemEl.appendChild(label);
-            }
-
-            label.textContent = item.resolved ? formatValue(item.value) : 'N/A';
+            const label = document.createElement('div');
+            label.className = ITEM_VALUE_LABEL_CLASS;
+            label.style.cssText = 'font-size:10px; text-align:center; opacity:0.85;';
+            label.textContent = formatTinyItemValue(item.value);
+            itemEl.appendChild(label);
         });
+    }
+
+    /** Remove any OA-owned footer/labels from one modal container without touching native content. */
+    clearOwnedDom(container) {
+        container.querySelectorAll(`.${LINE_CLASS}, .${ITEM_VALUE_LABEL_CLASS}`).forEach((el) => el.remove());
     }
 
     cleanup() {
@@ -208,6 +269,11 @@ class OpenableAnalyticsModalInjector {
         }
         this.viewAnalyticsHandler = null;
         this.isInitialized = false;
+
+        // Remove any OA-owned DOM left in the document (e.g. a modal still open when the
+        // feature/character is toggled off), and guarantee a stale/queued observer callback
+        // cannot reinject after this point since isInitialized is now false.
+        document.querySelectorAll(`.${LINE_CLASS}, .${ITEM_VALUE_LABEL_CLASS}`).forEach((el) => el.remove());
     }
 }
 
@@ -215,12 +281,16 @@ const openableAnalyticsModalInjector = new OpenableAnalyticsModalInjector();
 
 export default openableAnalyticsModalInjector;
 export {
-    buildLineContent,
+    buildFooterContent,
     formatValue,
+    formatTinyItemValue,
+    formatLuckValue,
     formatLuckPercent,
+    luckColor,
     MODAL_CONTENT_CLASS,
     LINE_CLASS,
     GAINED_ITEMS_CLASS,
     ITEM_CONTAINER_CLASS,
     ITEM_VALUE_LABEL_CLASS,
+    COIN_HRID,
 };

--- a/src/features/inventory/openable-analytics/openable-analytics-modal-injector.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-modal-injector.js
@@ -42,15 +42,25 @@ function luckColor(luckValue) {
  * @returns {{html: string, containerHrid: string}}
  */
 function buildLineContent(record, lifetimeAggregate) {
-    const sessionLine = record.expectedValueAvailable
-        ? `${record.containerCount} opened · Actual ${formatValue(record.actualValue)} · Expected ${formatValue(
-              record.expectedValue
-          )} · Luck <span style="color:${luckColor(record.luckValue)}">${formatValue(
-              record.luckValue
-          )}${formatLuckPercent(record.luckPercent)}</span>`
-        : `${record.containerCount} opened · Actual ${formatValue(record.actualValue)} · Expected N/A`;
+    const actualText = `${formatValue(record.actualValue)}${record.actualValueComplete ? '' : ' (partial)'}`;
+    const expectedText = !record.expectedValueAvailable
+        ? 'N/A'
+        : `${formatValue(record.expectedValue)}${record.expectedValueComplete === false ? ' (partial)' : ''}`;
+    const luckAvailable = record.luckValue !== null && record.luckValue !== undefined;
+    const sessionLine = `${record.containerCount} opened · Actual ${actualText} · Expected ${expectedText}${
+        luckAvailable
+            ? ` · Luck <span style="color:${luckColor(record.luckValue)}">${formatValue(
+                  record.luckValue
+              )}${formatLuckPercent(record.luckPercent)}</span>`
+            : ''
+    }`;
 
-    const lifetimeLuckAvailable = lifetimeAggregate.expectedValueAvailableEvents > 0;
+    // Aggregate Luck must fail closed as a whole: it is only meaningful when every valuation
+    // component folded into this lifetime aggregate is itself Luck-eligible (section 3.2) -
+    // never subtract a partial/unavailable Expected subset from a superset Actual total.
+    const lifetimeLuckAvailable =
+        (lifetimeAggregate.valuationRecordCount || 0) > 0 &&
+        lifetimeAggregate.luckEligibleRecordCount === lifetimeAggregate.valuationRecordCount;
     const lifetimeLuckValue = lifetimeLuckAvailable
         ? lifetimeAggregate.actualValueTotal - lifetimeAggregate.expectedValueTotal
         : null;
@@ -65,11 +75,7 @@ function buildLineContent(record, lifetimeAggregate) {
           )}">${formatValue(lifetimeLuckValue)}${formatLuckPercent(lifetimeLuckPercent)}</span>`
         : `Lifetime: ${lifetimeAggregate.containersOpened} opened`;
 
-    const partialNote = record.actualValueComplete
-        ? ''
-        : ' <span title="One or more gained items could not be priced">(partial)</span>';
-
-    return `<div>${sessionLine}${partialNote}</div><div style="opacity:0.75">${lifetimeLine} · <span class="toolasha-openable-analytics-view-link" style="cursor:pointer;text-decoration:underline">View Analytics</span></div>`;
+    return `<div>${sessionLine}</div><div style="opacity:0.75">${lifetimeLine} · <span class="toolasha-openable-analytics-view-link" style="cursor:pointer;text-decoration:underline">View Analytics</span></div>`;
 }
 
 class OpenableAnalyticsModalInjector {

--- a/src/features/inventory/openable-analytics/openable-analytics-modal-injector.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-modal-injector.js
@@ -14,6 +14,9 @@ import { coinFormatter } from '../../../utils/formatters.js';
 
 const MODAL_CONTENT_CLASS = 'Inventory_modalContent';
 const LINE_CLASS = 'toolasha-openable-analytics-line';
+const GAINED_ITEMS_CLASS = 'Inventory_gainedItems';
+const ITEM_CONTAINER_CLASS = 'Item_itemContainer';
+const ITEM_VALUE_LABEL_CLASS = 'toolasha-openable-analytics-item-value';
 
 function formatValue(value) {
     if (value === null || value === undefined) return 'N/A';
@@ -73,6 +76,7 @@ class OpenableAnalyticsModalInjector {
     constructor() {
         this.isInitialized = false;
         this.unregisterObserver = null;
+        this.unregisterItemObserver = null;
         this.unsubscribeCollector = null;
         this.viewAnalyticsHandler = null;
     }
@@ -86,8 +90,25 @@ class OpenableAnalyticsModalInjector {
             this.tryInject(node)
         );
 
-        // Data-driven fallback: if the modal is already mounted when a new record arrives (the
-        // native component updates in place instead of remounting), refresh directly.
+        // Per-item labels need to react to the item icons themselves, not just the modal
+        // container: if the native modal stays mounted and updates in place for a new opening
+        // (rather than remounting), the modal-level observer above never fires again, but React
+        // still has to insert fresh Item_itemContainer nodes for the new gained items - this
+        // catches that update with the DOM already in its post-render state.
+        this.unregisterItemObserver = domObserver.onClass(
+            'openableAnalyticsModalItems',
+            ITEM_CONTAINER_CLASS,
+            (node) => {
+                const container = node.closest(`[class*="${MODAL_CONTENT_CLASS}"]`);
+                if (!container) return;
+                const record = openableAnalyticsDataCollector.getLatestRecord();
+                if (!record) return;
+                this.renderItemValueLabels(container, record);
+            }
+        );
+
+        // Data-driven fallback: covers the summary line (and opportunistically the per-item
+        // labels) as soon as new data arrives, ahead of any DOM mutation.
         this.unsubscribeCollector = openableAnalyticsDataCollector.onUpdate(() => this.refreshMountedModal());
     }
 
@@ -130,12 +151,50 @@ class OpenableAnalyticsModalInjector {
         if (viewLink && this.viewAnalyticsHandler) {
             viewLink.onclick = () => this.viewAnalyticsHandler(record.containerHrid);
         }
+
+        this.renderItemValueLabels(container, record);
+    }
+
+    /**
+     * Stamp a small value label onto each individual gained-item icon inside the native "You
+     * found:" list, matched positionally against `record.actualValueBreakdown` (both derive from
+     * the identical `gainedItems` array, so DOM order and breakdown order always agree). Skips
+     * labeling entirely - rather than risk mismatching values to the wrong item - if the icon
+     * count doesn't match the breakdown count (e.g. a rare special-cased item render).
+     * @param {HTMLElement} container - The modal's `Inventory_modalContent` root
+     * @param {Object} record - Latest normalized opening record
+     */
+    renderItemValueLabels(container, record) {
+        const gainedItemsContainer = container.querySelector(`[class*="${GAINED_ITEMS_CLASS}"]`);
+        if (!gainedItemsContainer) return;
+
+        const itemContainers = gainedItemsContainer.querySelectorAll(`[class*="${ITEM_CONTAINER_CLASS}"]`);
+        const breakdown = record.actualValueBreakdown || [];
+        if (itemContainers.length !== breakdown.length) return;
+
+        itemContainers.forEach((itemEl, index) => {
+            const item = breakdown[index];
+
+            let label = itemEl.querySelector(`.${ITEM_VALUE_LABEL_CLASS}`);
+            if (!label) {
+                label = document.createElement('div');
+                label.className = ITEM_VALUE_LABEL_CLASS;
+                label.style.cssText = 'font-size:10px; text-align:center; opacity:0.85;';
+                itemEl.appendChild(label);
+            }
+
+            label.textContent = item.resolved ? formatValue(item.value) : 'N/A';
+        });
     }
 
     cleanup() {
         if (this.unregisterObserver) {
             this.unregisterObserver();
             this.unregisterObserver = null;
+        }
+        if (this.unregisterItemObserver) {
+            this.unregisterItemObserver();
+            this.unregisterItemObserver = null;
         }
         if (this.unsubscribeCollector) {
             this.unsubscribeCollector();
@@ -149,4 +208,13 @@ class OpenableAnalyticsModalInjector {
 const openableAnalyticsModalInjector = new OpenableAnalyticsModalInjector();
 
 export default openableAnalyticsModalInjector;
-export { buildLineContent, formatValue, formatLuckPercent, MODAL_CONTENT_CLASS, LINE_CLASS };
+export {
+    buildLineContent,
+    formatValue,
+    formatLuckPercent,
+    MODAL_CONTENT_CLASS,
+    LINE_CLASS,
+    GAINED_ITEMS_CLASS,
+    ITEM_CONTAINER_CLASS,
+    ITEM_VALUE_LABEL_CLASS,
+};

--- a/src/features/inventory/openable-analytics/openable-analytics-modal-injector.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-modal-injector.js
@@ -1,0 +1,152 @@
+/**
+ * Openable Analytics Modal Injector
+ * Injects a compact Actual/Expected/Luck summary line into the native "Opened Loot" modal.
+ * Idempotent by design: the injected line is located by its own marker class and its content is
+ * replaced in place, so it self-corrects regardless of whether the modal remounts for a new
+ * opening or is updated in place while already displayed (both are possible depending on how the
+ * native inventory panel batches consecutive openings).
+ */
+
+import domObserver from '../../../core/dom-observer.js';
+import config from '../../../core/config.js';
+import openableAnalyticsDataCollector from './openable-analytics-data-collector.js';
+import { coinFormatter } from '../../../utils/formatters.js';
+
+const MODAL_CONTENT_CLASS = 'Inventory_modalContent';
+const LINE_CLASS = 'toolasha-openable-analytics-line';
+
+function formatValue(value) {
+    if (value === null || value === undefined) return 'N/A';
+    return coinFormatter(Math.round(value));
+}
+
+function formatLuckPercent(percent) {
+    if (percent === null || percent === undefined) return '';
+    const sign = percent >= 0 ? '+' : '';
+    return ` (${sign}${percent.toFixed(1)}%)`;
+}
+
+function luckColor(luckValue) {
+    if (luckValue === null || luckValue === undefined) return config.COLOR_TEXT_SECONDARY || '#888888';
+    return luckValue >= 0 ? config.COLOR_PROFIT : config.COLOR_LOSS;
+}
+
+/**
+ * Build the inner HTML for the injected summary line from the latest record + its lifetime
+ * aggregate. `openAnalyticsView` is invoked when the "View Analytics" affordance is clicked.
+ * @param {Object} record - Latest normalized opening record
+ * @param {Object} lifetimeAggregate - Lifetime aggregate for this container
+ * @returns {{html: string, containerHrid: string}}
+ */
+function buildLineContent(record, lifetimeAggregate) {
+    const sessionLine = record.expectedValueAvailable
+        ? `${record.containerCount} opened · Actual ${formatValue(record.actualValue)} · Expected ${formatValue(
+              record.expectedValue
+          )} · Luck <span style="color:${luckColor(record.luckValue)}">${formatValue(
+              record.luckValue
+          )}${formatLuckPercent(record.luckPercent)}</span>`
+        : `${record.containerCount} opened · Actual ${formatValue(record.actualValue)} · Expected N/A`;
+
+    const lifetimeLuckAvailable = lifetimeAggregate.expectedValueAvailableEvents > 0;
+    const lifetimeLuckValue = lifetimeLuckAvailable
+        ? lifetimeAggregate.actualValueTotal - lifetimeAggregate.expectedValueTotal
+        : null;
+    const lifetimeLuckPercent =
+        lifetimeLuckAvailable && lifetimeAggregate.expectedValueTotal > 0
+            ? (lifetimeLuckValue / lifetimeAggregate.expectedValueTotal) * 100
+            : null;
+
+    const lifetimeLine = lifetimeLuckAvailable
+        ? `Lifetime: ${lifetimeAggregate.containersOpened} opened · Luck <span style="color:${luckColor(
+              lifetimeLuckValue
+          )}">${formatValue(lifetimeLuckValue)}${formatLuckPercent(lifetimeLuckPercent)}</span>`
+        : `Lifetime: ${lifetimeAggregate.containersOpened} opened`;
+
+    const partialNote = record.actualValueComplete
+        ? ''
+        : ' <span title="One or more gained items could not be priced">(partial)</span>';
+
+    return `<div>${sessionLine}${partialNote}</div><div style="opacity:0.75">${lifetimeLine} · <span class="toolasha-openable-analytics-view-link" style="cursor:pointer;text-decoration:underline">View Analytics</span></div>`;
+}
+
+class OpenableAnalyticsModalInjector {
+    constructor() {
+        this.isInitialized = false;
+        this.unregisterObserver = null;
+        this.unsubscribeCollector = null;
+        this.viewAnalyticsHandler = null;
+    }
+
+    initialize({ onViewAnalytics } = {}) {
+        if (this.isInitialized) return;
+        this.isInitialized = true;
+        this.viewAnalyticsHandler = onViewAnalytics || null;
+
+        this.unregisterObserver = domObserver.onClass('openableAnalyticsModal', MODAL_CONTENT_CLASS, (node) =>
+            this.tryInject(node)
+        );
+
+        // Data-driven fallback: if the modal is already mounted when a new record arrives (the
+        // native component updates in place instead of remounting), refresh directly.
+        this.unsubscribeCollector = openableAnalyticsDataCollector.onUpdate(() => this.refreshMountedModal());
+    }
+
+    tryInject(container) {
+        if (!container?.classList) return;
+        const className = typeof container.className === 'string' ? container.className : '';
+        if (!className.includes(MODAL_CONTENT_CLASS)) return;
+
+        const record = openableAnalyticsDataCollector.getLatestRecord();
+        if (!record) return;
+
+        this.renderLine(container, record);
+    }
+
+    refreshMountedModal() {
+        const container = document.querySelector(`[class*="${MODAL_CONTENT_CLASS}"]`);
+        if (!container) return;
+
+        const record = openableAnalyticsDataCollector.getLatestRecord();
+        if (!record) return;
+
+        this.renderLine(container, record);
+    }
+
+    renderLine(container, record) {
+        const lifetimeAggregate = openableAnalyticsDataCollector.getLifetimeAggregate(record.containerHrid);
+
+        let line = container.querySelector(`.${LINE_CLASS}`);
+        if (!line) {
+            line = document.createElement('div');
+            line.className = LINE_CLASS;
+            line.style.cssText = 'font-size:12px;margin:4px 0;';
+            const headerChild = container.children[0] || null;
+            container.insertBefore(line, headerChild ? headerChild.nextSibling : container.firstChild);
+        }
+
+        line.innerHTML = buildLineContent(record, lifetimeAggregate);
+
+        const viewLink = line.querySelector('.toolasha-openable-analytics-view-link');
+        if (viewLink && this.viewAnalyticsHandler) {
+            viewLink.onclick = () => this.viewAnalyticsHandler(record.containerHrid);
+        }
+    }
+
+    cleanup() {
+        if (this.unregisterObserver) {
+            this.unregisterObserver();
+            this.unregisterObserver = null;
+        }
+        if (this.unsubscribeCollector) {
+            this.unsubscribeCollector();
+            this.unsubscribeCollector = null;
+        }
+        this.viewAnalyticsHandler = null;
+        this.isInitialized = false;
+    }
+}
+
+const openableAnalyticsModalInjector = new OpenableAnalyticsModalInjector();
+
+export default openableAnalyticsModalInjector;
+export { buildLineContent, formatValue, formatLuckPercent, MODAL_CONTENT_CLASS, LINE_CLASS };

--- a/src/features/inventory/openable-analytics/openable-analytics-modal-injector.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-modal-injector.test.js
@@ -9,7 +9,10 @@ const mocks = vi.hoisted(() => ({
         containersOpened: 0,
         actualValueTotal: 0,
         expectedValueTotal: 0,
-        expectedValueAvailableEvents: 0,
+        valuationRecordCount: 0,
+        luckEligibleRecordCount: 0,
+        eventsCount: 0,
+        hasImportedData: false,
     },
 }));
 
@@ -60,7 +63,10 @@ function buildModal(itemCount = 3) {
         { length: itemCount },
         (_, i) => `<div class="Item_itemContainer__x7kH1" data-index="${i}"></div>`
     ).join('');
-    container.innerHTML = `<div class="Inventory_header__1">Loot Gained!</div><div>item icon</div><div class="Inventory_gainedItems__abc">${itemsHtml}</div>`;
+    container.innerHTML =
+        itemCount > 0
+            ? `<div class="Inventory_header__1">Opened Loot</div><div class="Inventory_gainedItems__abc"><div class="Inventory_label__x">You found:</div>${itemsHtml}</div><button>Close</button>`
+            : `<div class="Inventory_header__1">Opened Loot</div><button>Close</button>`;
     document.body.appendChild(container);
     return container;
 }
@@ -69,12 +75,15 @@ function itemContainersOf(modal) {
     return modal.querySelectorAll(`[class*="${ITEM_CONTAINER_CLASS}"]`);
 }
 
-beforeEach(() => {
-    mocks.registrations = [];
-    mocks.unsubscribeCollectorCallbacks = [];
-    mocks.latestRecord = {
+function monetaryRecord(overrides = {}) {
+    return {
         containerHrid: '/items/chest',
         containerCount: 6,
+        gainedItems: [
+            { itemHrid: '/items/coin', enhancementLevel: 0, count: 42938 },
+            { itemHrid: '/items/shard_of_protection', enhancementLevel: 0, count: 8 },
+            { itemHrid: '/items/pearl', enhancementLevel: 0, count: 1 },
+        ],
         actualValue: 1470000,
         actualValueComplete: true,
         actualValueBreakdown: [
@@ -84,44 +93,40 @@ beforeEach(() => {
         ],
         expectedValue: 2190000,
         expectedValueAvailable: true,
+        expectedValueComplete: true,
         luckValue: -720000,
         luckPercent: -32.9,
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    mocks.registrations = [];
+    mocks.unsubscribeCollectorCallbacks = [];
+    mocks.latestRecord = monetaryRecord();
+    mocks.lifetimeAggregate = {
+        containersOpened: 10,
+        actualValueTotal: 5000000,
+        expectedValueTotal: 6300000,
+        valuationRecordCount: 4,
+        luckEligibleRecordCount: 4,
+        eventsCount: 4,
+        hasImportedData: false,
     };
     document.body.innerHTML = '';
     openableAnalyticsModalInjector.cleanup();
     openableAnalyticsModalInjector.initialize();
 });
 
-describe('idempotent modal injection', () => {
-    test('injects exactly one summary line on first mount', () => {
+describe('modal ownership (section 5)', () => {
+    test('proven monetary result modal: footer is inserted after native reward content, before the native Close button', () => {
         const modal = buildModal();
         modalCallbacks().forEach((cb) => cb(modal));
 
         expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(1);
-        expect(modal.textContent).toContain('6 opened');
-    });
-
-    test('remounting the modal for a second opening replaces the line in place rather than duplicating it', () => {
-        const modal = buildModal();
-        modalCallbacks().forEach((cb) => cb(modal));
-
-        mocks.latestRecord = { ...mocks.latestRecord, containerCount: 3, actualValue: 500000 };
-        modalCallbacks().forEach((cb) => cb(modal));
-
-        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(1);
-        expect(modal.textContent).toContain('3 opened');
-        expect(modal.textContent).not.toContain('6 opened');
-    });
-
-    test('a data-driven update to an already-mounted modal (no remount) updates the line in place', () => {
-        const modal = buildModal();
-        modalCallbacks().forEach((cb) => cb(modal));
-
-        mocks.latestRecord = { ...mocks.latestRecord, containerCount: 42 };
-        mocks.unsubscribeCollectorCallbacks.forEach((cb) => cb(mocks.latestRecord));
-
-        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(1);
-        expect(modal.textContent).toContain('42 opened');
+        const children = [...modal.children];
+        const lineIndex = children.findIndex((el) => el.classList.contains(LINE_CLASS));
+        expect(lineIndex).toBe(children.length - 2); // immediately before the trailing <button>Close</button>
     });
 
     test('does not touch a modalContent node from an unrelated class match', () => {
@@ -134,7 +139,15 @@ describe('idempotent modal injection', () => {
         expect(other.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
     });
 
-    test('never injects before any record exists (no crash, no line)', () => {
+    test('a real Inventory_modalContent that structurally has no gained-items section gets no OA footer', () => {
+        const modal = buildModal(0); // no Inventory_gainedItems section at all
+
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
+    });
+
+    test('never injects before any record exists (no crash, no footer)', () => {
         mocks.latestRecord = null;
         const modal = buildModal();
         modalCallbacks().forEach((cb) => cb(modal));
@@ -142,10 +155,11 @@ describe('idempotent modal injection', () => {
         expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
     });
 
-    test('shows Expected: N/A without a Luck value when EV is unavailable for the opened container', () => {
+    test('pure buff-only openable (no gained items) never gets a monetary OA footer', () => {
         mocks.latestRecord = {
             containerHrid: '/items/seal_of_rare_find',
             containerCount: 1,
+            gainedItems: [],
             actualValue: 0,
             actualValueComplete: true,
             actualValueBreakdown: [],
@@ -157,103 +171,203 @@ describe('idempotent modal injection', () => {
         const modal = buildModal(0);
         modalCallbacks().forEach((cb) => cb(modal));
 
-        expect(modal.textContent).toContain('Expected N/A');
-        expect(modal.textContent).not.toContain('Luck');
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
+        expect(modal.textContent).not.toContain('Actual');
     });
 
-    test('OA-7: shows Actual (partial) and no Luck value when the Actual subtotal is incomplete', () => {
+    test('monetary -> buff-only modal reuse removes the stale monetary footer/labels', () => {
+        const modal = buildModal(3);
+        modalCallbacks().forEach((cb) => cb(modal));
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(1);
+
+        // React reuses the same modalContent node for a later buff-only result.
+        modal.querySelector(`[class*="Inventory_gainedItems"]`)?.remove();
         mocks.latestRecord = {
-            ...mocks.latestRecord,
-            actualValueComplete: false,
+            containerHrid: '/items/seal_of_rare_find',
+            containerCount: 1,
+            gainedItems: [],
+            actualValue: 0,
+            actualValueComplete: true,
+            actualValueBreakdown: [],
+            expectedValue: null,
+            expectedValueAvailable: false,
             luckValue: null,
             luckPercent: null,
+        };
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
+        expect(modal.querySelectorAll(`.${ITEM_VALUE_LABEL_CLASS}`)).toHaveLength(0);
+    });
+});
+
+describe('footer UI contract (section 6)', () => {
+    test('normal monetary opening shows Actual/Expected/Luck without opened-count wording', () => {
+        const modal = buildModal();
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.textContent).toContain('Actual');
+        expect(modal.textContent).toContain('Expected');
+        expect(modal.textContent).toContain('Luck');
+        expect(modal.textContent).not.toMatch(/\d+ opened/);
+    });
+
+    test('negative Luck includes an explicit minus sign and percent', () => {
+        const modal = buildModal();
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.textContent).toContain('-720K');
+        expect(modal.textContent).toContain('-32.9%');
+    });
+
+    test('positive Luck includes an explicit plus sign in both value and percent', () => {
+        mocks.latestRecord = monetaryRecord({ luckValue: 720000, luckPercent: 32.9 });
+        const modal = buildModal();
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.textContent).toContain('+720K');
+        expect(modal.textContent).toContain('+32.9%');
+    });
+
+    test('rounded -0.0% luck percent is normalized to 0.0%, not shown as negative', () => {
+        mocks.latestRecord = monetaryRecord({ luckValue: 0, luckPercent: -0.02 });
+        const modal = buildModal();
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.textContent).not.toContain('-0.0%');
+        expect(modal.textContent).toContain('0.0%');
+    });
+
+    test('monetary incomplete valuation shows [Partial] and Luck as an explicit unavailable dash, not N/A', () => {
+        mocks.latestRecord = monetaryRecord({ actualValueComplete: false, luckValue: null, luckPercent: null });
+        const modal = buildModal();
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.textContent).toContain('[Partial]');
+        expect(modal.textContent).not.toContain('N/A');
+        expect(modal.querySelector(`.${LINE_CLASS}`).textContent).toMatch(/Luck\s*—/);
+    });
+
+    test('first tracked event with no other Lifetime history suppresses a redundant Lifetime row', () => {
+        mocks.lifetimeAggregate = {
+            containersOpened: 6,
+            actualValueTotal: 1470000,
+            expectedValueTotal: 2190000,
+            valuationRecordCount: 1,
+            luckEligibleRecordCount: 1,
+            eventsCount: 1,
+            hasImportedData: false,
         };
         const modal = buildModal();
         modalCallbacks().forEach((cb) => cb(modal));
 
-        expect(modal.textContent).toContain('(partial)');
-        expect(modal.textContent).not.toContain('Luck');
+        expect(modal.textContent).toContain('View Analytics');
+        expect(modal.textContent).not.toMatch(/Lifetime/);
     });
 
-    test('OA-8: shows Expected (partial) and no Luck value when the Expected breakdown is incomplete', () => {
-        mocks.latestRecord = {
-            ...mocks.latestRecord,
-            expectedValueComplete: false,
-            luckValue: null,
-            luckPercent: null,
+    test('prior live history still shows a Lifetime row', () => {
+        const modal = buildModal();
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.textContent).toMatch(/Lifetime ×10/);
+    });
+
+    test('imported-only Lifetime history (this is the first live event) still shows a Lifetime row', () => {
+        mocks.lifetimeAggregate = {
+            containersOpened: 501,
+            actualValueTotal: 1470000,
+            expectedValueTotal: 2190000,
+            valuationRecordCount: 2,
+            luckEligibleRecordCount: 2,
+            eventsCount: 1,
+            hasImportedData: true,
         };
         const modal = buildModal();
         modalCallbacks().forEach((cb) => cb(modal));
 
-        expect(modal.textContent).toContain('(partial)');
-        expect(modal.textContent).not.toContain('Luck');
+        expect(modal.textContent).toMatch(/Lifetime ×501/);
     });
 
-    test('AGG-1: Lifetime Luck is not shown when the lifetime aggregate has any non-eligible valuation record', () => {
+    test('AGG-1: Lifetime Luck is hidden when one folded valuation record is not Luck-eligible', () => {
         mocks.lifetimeAggregate = {
             containersOpened: 10,
             actualValueTotal: 500,
             expectedValueTotal: 400,
             valuationRecordCount: 3,
             luckEligibleRecordCount: 2,
+            eventsCount: 3,
+            hasImportedData: false,
         };
         const modal = buildModal();
         modalCallbacks().forEach((cb) => cb(modal));
 
-        expect(modal.textContent).toContain('Lifetime: 10 opened');
-        expect(modal.textContent).not.toMatch(/Lifetime:.*Luck/);
+        expect(modal.textContent).toMatch(/Lifetime ×10/);
+        expect(modal.textContent).not.toMatch(/Lifetime.*Luck/);
     });
 
-    test('Lifetime Luck is shown when every folded valuation record is Luck-eligible', () => {
-        mocks.lifetimeAggregate = {
-            containersOpened: 10,
-            actualValueTotal: 500,
-            expectedValueTotal: 400,
-            valuationRecordCount: 3,
-            luckEligibleRecordCount: 3,
-        };
+    test('Luck has an explanatory tooltip that does not claim to be profitability', () => {
         const modal = buildModal();
         modalCallbacks().forEach((cb) => cb(modal));
 
-        expect(modal.textContent).toMatch(/Lifetime:.*Luck/);
+        const luckSpan = [...modal.querySelectorAll('span')].find((el) => el.textContent === 'Luck');
+        expect(luckSpan.title.toLowerCase()).toContain('actual loot value minus expected loot value');
+        expect(luckSpan.title.toLowerCase()).toContain('is not opening profit');
     });
 });
 
-describe('per-item value labels', () => {
-    test('stamps a value label on each gained-item icon, matched positionally to the breakdown', () => {
+describe('per-item value labels (section 7)', () => {
+    test('normal resolved items get a compact approximate label; Coin never gets one', () => {
         const modal = buildModal(3);
         modalCallbacks().forEach((cb) => cb(modal));
 
         const items = itemContainersOf(modal);
-        expect(items[0].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('42K');
-        expect(items[1].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('400K');
-        expect(items[2].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('1,062');
+        expect(items[0].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`)).toBeNull(); // Coin
+        expect(items[1].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('≈400K');
+        expect(items[2].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('≈1.06K');
     });
 
-    test('shows N/A for an unresolved item instead of a fabricated value', () => {
-        mocks.latestRecord = {
-            ...mocks.latestRecord,
+    test('resolved value of exactly zero shows ≈0, not unavailable', () => {
+        mocks.latestRecord = monetaryRecord({
             actualValueBreakdown: [
-                { itemHrid: '/items/mystery', enhancementLevel: 0, count: 1, value: 0, resolved: false },
+                { itemHrid: '/items/worthless_item', enhancementLevel: 0, count: 1, value: 0, resolved: true },
             ],
-        };
+        });
         const modal = buildModal(1);
         modalCallbacks().forEach((cb) => cb(modal));
 
-        expect(itemContainersOf(modal)[0].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('N/A');
+        expect(itemContainersOf(modal)[0].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('≈0');
     });
 
-    test('re-rendering updates the same label in place rather than adding a second one', () => {
+    test('an unresolved item renders no tiny label at all (not a fabricated N/A)', () => {
+        mocks.latestRecord = monetaryRecord({
+            actualValueBreakdown: [
+                { itemHrid: '/items/mystery', enhancementLevel: 0, count: 1, value: 0, resolved: false },
+            ],
+        });
+        const modal = buildModal(1);
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(itemContainersOf(modal)[0].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`)).toBeNull();
+    });
+
+    test('re-rendering updates labels in place rather than adding a second one', () => {
         const modal = buildModal(3);
         modalCallbacks().forEach((cb) => cb(modal));
         modalCallbacks().forEach((cb) => cb(modal));
 
         const items = itemContainersOf(modal);
-        expect(items[0].querySelectorAll(`.${ITEM_VALUE_LABEL_CLASS}`)).toHaveLength(1);
+        expect(items[1].querySelectorAll(`.${ITEM_VALUE_LABEL_CLASS}`)).toHaveLength(1);
     });
 
-    test('skips labeling entirely (no crash, no mismatched values) when the icon count does not match the breakdown', () => {
-        const modal = buildModal(5); // 5 icons but the mocked record's breakdown has 3 entries
+    test('DOM item-count/breakdown mismatch clears any previously stamped labels before failing closed', () => {
+        const modal = buildModal(3);
+        modalCallbacks().forEach((cb) => cb(modal));
+        expect(itemContainersOf(modal)[1].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`)).not.toBeNull();
+
+        // A rare special-cased render adds a 4th icon the breakdown doesn't account for.
+        const extra = document.createElement('div');
+        extra.className = 'Item_itemContainer__extra';
+        modal.querySelector('[class*="Inventory_gainedItems"]').appendChild(extra);
 
         expect(() => modalCallbacks().forEach((cb) => cb(modal))).not.toThrow();
         itemContainersOf(modal).forEach((item) => {
@@ -263,13 +377,10 @@ describe('per-item value labels', () => {
 
     test('the item-level observer relabels using the current DOM state when new item icons are inserted directly', () => {
         const modal = buildModal(3);
-        // Simulate the "modal stays mounted, content updates in place" path: item icons are
-        // (re)inserted without the modal container itself being re-added, so only the
-        // item-level observer fires, not the modal-level one.
         itemCallbacks().forEach((cb) => cb(itemContainersOf(modal)[0]));
 
         const items = itemContainersOf(modal);
-        expect(items[0].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('42K');
+        expect(items[1].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('≈400K');
     });
 
     test('the item-level observer ignores an item icon outside any tracked Openable Analytics modal', () => {
@@ -279,6 +390,49 @@ describe('per-item value labels', () => {
 
         expect(() => itemCallbacks().forEach((cb) => cb(strayItem))).not.toThrow();
         expect(strayItem.querySelector(`.${ITEM_VALUE_LABEL_CLASS}`)).toBeNull();
+    });
+});
+
+describe('cleanup and stale callback safety (section 8)', () => {
+    test('cleanup removes the footer and all item labels from the DOM', () => {
+        const modal = buildModal(3);
+        modalCallbacks().forEach((cb) => cb(modal));
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(1);
+        expect(modal.querySelectorAll(`.${ITEM_VALUE_LABEL_CLASS}`).length).toBeGreaterThan(0);
+
+        openableAnalyticsModalInjector.cleanup();
+
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
+        expect(modal.querySelectorAll(`.${ITEM_VALUE_LABEL_CLASS}`)).toHaveLength(0);
+    });
+
+    test('a stale modal-observer callback captured before cleanup cannot reinject after cleanup', () => {
+        const staleModalCallback = modalCallbacks()[0];
+        openableAnalyticsModalInjector.cleanup();
+
+        const modal = buildModal(3);
+        expect(() => staleModalCallback(modal)).not.toThrow();
+
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
+    });
+
+    test('a stale item-observer callback captured before cleanup cannot reinject after cleanup', () => {
+        const staleItemCallback = itemCallbacks()[0];
+        openableAnalyticsModalInjector.cleanup();
+
+        const modal = buildModal(3);
+        expect(() => staleItemCallback(itemContainersOf(modal)[0])).not.toThrow();
+
+        expect(modal.querySelectorAll(`.${ITEM_VALUE_LABEL_CLASS}`)).toHaveLength(0);
+    });
+
+    test('a stale data-driven update captured before cleanup cannot reinject after cleanup', () => {
+        const modal = buildModal(3);
+        modalCallbacks().forEach((cb) => cb(modal));
+        openableAnalyticsModalInjector.cleanup();
+
+        expect(() => mocks.unsubscribeCollectorCallbacks.forEach((cb) => cb(mocks.latestRecord))).not.toThrow();
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
     });
 });
 

--- a/src/features/inventory/openable-analytics/openable-analytics-modal-injector.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-modal-injector.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-    onClassCallbacks: [],
+    registrations: [],
     unsubscribeCollectorCallbacks: [],
     latestRecord: null,
     lifetimeAggregate: {
@@ -15,8 +15,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../../../core/dom-observer.js', () => ({
     default: {
-        onClass: vi.fn((_name, _classNames, callback) => {
-            mocks.onClassCallbacks.push(callback);
+        onClass: vi.fn((_name, classNames, callback) => {
+            mocks.registrations.push({ classNames, callback });
             return vi.fn();
         }),
     },
@@ -41,24 +41,47 @@ const {
     default: openableAnalyticsModalInjector,
     MODAL_CONTENT_CLASS,
     LINE_CLASS,
+    ITEM_CONTAINER_CLASS,
+    ITEM_VALUE_LABEL_CLASS,
 } = await import('./openable-analytics-modal-injector.js');
 
-function buildModal() {
+function modalCallbacks() {
+    return mocks.registrations.filter((r) => r.classNames === MODAL_CONTENT_CLASS).map((r) => r.callback);
+}
+
+function itemCallbacks() {
+    return mocks.registrations.filter((r) => r.classNames === ITEM_CONTAINER_CLASS).map((r) => r.callback);
+}
+
+function buildModal(itemCount = 3) {
     const container = document.createElement('div');
     container.className = `Inventory_modalContent__3ObSx`;
-    container.innerHTML = `<div class="Inventory_header__1">Loot Gained!</div><div>item icon</div>`;
+    const itemsHtml = Array.from(
+        { length: itemCount },
+        (_, i) => `<div class="Item_itemContainer__x7kH1" data-index="${i}"></div>`
+    ).join('');
+    container.innerHTML = `<div class="Inventory_header__1">Loot Gained!</div><div>item icon</div><div class="Inventory_gainedItems__abc">${itemsHtml}</div>`;
     document.body.appendChild(container);
     return container;
 }
 
+function itemContainersOf(modal) {
+    return modal.querySelectorAll(`[class*="${ITEM_CONTAINER_CLASS}"]`);
+}
+
 beforeEach(() => {
-    mocks.onClassCallbacks = [];
+    mocks.registrations = [];
     mocks.unsubscribeCollectorCallbacks = [];
     mocks.latestRecord = {
         containerHrid: '/items/chest',
         containerCount: 6,
         actualValue: 1470000,
         actualValueComplete: true,
+        actualValueBreakdown: [
+            { itemHrid: '/items/coin', enhancementLevel: 0, count: 42938, value: 42938, resolved: true },
+            { itemHrid: '/items/shard_of_protection', enhancementLevel: 0, count: 8, value: 400000, resolved: true },
+            { itemHrid: '/items/pearl', enhancementLevel: 0, count: 1, value: 1062, resolved: true },
+        ],
         expectedValue: 2190000,
         expectedValueAvailable: true,
         luckValue: -720000,
@@ -72,7 +95,7 @@ beforeEach(() => {
 describe('idempotent modal injection', () => {
     test('injects exactly one summary line on first mount', () => {
         const modal = buildModal();
-        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+        modalCallbacks().forEach((cb) => cb(modal));
 
         expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(1);
         expect(modal.textContent).toContain('6 opened');
@@ -80,10 +103,10 @@ describe('idempotent modal injection', () => {
 
     test('remounting the modal for a second opening replaces the line in place rather than duplicating it', () => {
         const modal = buildModal();
-        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+        modalCallbacks().forEach((cb) => cb(modal));
 
         mocks.latestRecord = { ...mocks.latestRecord, containerCount: 3, actualValue: 500000 };
-        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+        modalCallbacks().forEach((cb) => cb(modal));
 
         expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(1);
         expect(modal.textContent).toContain('3 opened');
@@ -92,7 +115,7 @@ describe('idempotent modal injection', () => {
 
     test('a data-driven update to an already-mounted modal (no remount) updates the line in place', () => {
         const modal = buildModal();
-        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+        modalCallbacks().forEach((cb) => cb(modal));
 
         mocks.latestRecord = { ...mocks.latestRecord, containerCount: 42 };
         mocks.unsubscribeCollectorCallbacks.forEach((cb) => cb(mocks.latestRecord));
@@ -106,7 +129,7 @@ describe('idempotent modal injection', () => {
         other.className = 'SomeOtherPanel_modalContent__abc';
         document.body.appendChild(other);
 
-        mocks.onClassCallbacks.forEach((cb) => cb(other));
+        modalCallbacks().forEach((cb) => cb(other));
 
         expect(other.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
     });
@@ -114,7 +137,7 @@ describe('idempotent modal injection', () => {
     test('never injects before any record exists (no crash, no line)', () => {
         mocks.latestRecord = null;
         const modal = buildModal();
-        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+        modalCallbacks().forEach((cb) => cb(modal));
 
         expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
     });
@@ -125,16 +148,80 @@ describe('idempotent modal injection', () => {
             containerCount: 1,
             actualValue: 0,
             actualValueComplete: true,
+            actualValueBreakdown: [],
             expectedValue: null,
             expectedValueAvailable: false,
             luckValue: null,
             luckPercent: null,
         };
-        const modal = buildModal();
-        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+        const modal = buildModal(0);
+        modalCallbacks().forEach((cb) => cb(modal));
 
         expect(modal.textContent).toContain('Expected N/A');
         expect(modal.textContent).not.toContain('Luck');
+    });
+});
+
+describe('per-item value labels', () => {
+    test('stamps a value label on each gained-item icon, matched positionally to the breakdown', () => {
+        const modal = buildModal(3);
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        const items = itemContainersOf(modal);
+        expect(items[0].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('42K');
+        expect(items[1].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('400K');
+        expect(items[2].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('1,062');
+    });
+
+    test('shows N/A for an unresolved item instead of a fabricated value', () => {
+        mocks.latestRecord = {
+            ...mocks.latestRecord,
+            actualValueBreakdown: [
+                { itemHrid: '/items/mystery', enhancementLevel: 0, count: 1, value: 0, resolved: false },
+            ],
+        };
+        const modal = buildModal(1);
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(itemContainersOf(modal)[0].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('N/A');
+    });
+
+    test('re-rendering updates the same label in place rather than adding a second one', () => {
+        const modal = buildModal(3);
+        modalCallbacks().forEach((cb) => cb(modal));
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        const items = itemContainersOf(modal);
+        expect(items[0].querySelectorAll(`.${ITEM_VALUE_LABEL_CLASS}`)).toHaveLength(1);
+    });
+
+    test('skips labeling entirely (no crash, no mismatched values) when the icon count does not match the breakdown', () => {
+        const modal = buildModal(5); // 5 icons but the mocked record's breakdown has 3 entries
+
+        expect(() => modalCallbacks().forEach((cb) => cb(modal))).not.toThrow();
+        itemContainersOf(modal).forEach((item) => {
+            expect(item.querySelector(`.${ITEM_VALUE_LABEL_CLASS}`)).toBeNull();
+        });
+    });
+
+    test('the item-level observer relabels using the current DOM state when new item icons are inserted directly', () => {
+        const modal = buildModal(3);
+        // Simulate the "modal stays mounted, content updates in place" path: item icons are
+        // (re)inserted without the modal container itself being re-added, so only the
+        // item-level observer fires, not the modal-level one.
+        itemCallbacks().forEach((cb) => cb(itemContainersOf(modal)[0]));
+
+        const items = itemContainersOf(modal);
+        expect(items[0].querySelector(`.${ITEM_VALUE_LABEL_CLASS}`).textContent).toBe('42K');
+    });
+
+    test('the item-level observer ignores an item icon outside any tracked Openable Analytics modal', () => {
+        const strayItem = document.createElement('div');
+        strayItem.className = 'Item_itemContainer__x7kH1';
+        document.body.appendChild(strayItem);
+
+        expect(() => itemCallbacks().forEach((cb) => cb(strayItem))).not.toThrow();
+        expect(strayItem.querySelector(`.${ITEM_VALUE_LABEL_CLASS}`)).toBeNull();
     });
 });
 

--- a/src/features/inventory/openable-analytics/openable-analytics-modal-injector.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-modal-injector.test.js
@@ -160,6 +160,63 @@ describe('idempotent modal injection', () => {
         expect(modal.textContent).toContain('Expected N/A');
         expect(modal.textContent).not.toContain('Luck');
     });
+
+    test('OA-7: shows Actual (partial) and no Luck value when the Actual subtotal is incomplete', () => {
+        mocks.latestRecord = {
+            ...mocks.latestRecord,
+            actualValueComplete: false,
+            luckValue: null,
+            luckPercent: null,
+        };
+        const modal = buildModal();
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.textContent).toContain('(partial)');
+        expect(modal.textContent).not.toContain('Luck');
+    });
+
+    test('OA-8: shows Expected (partial) and no Luck value when the Expected breakdown is incomplete', () => {
+        mocks.latestRecord = {
+            ...mocks.latestRecord,
+            expectedValueComplete: false,
+            luckValue: null,
+            luckPercent: null,
+        };
+        const modal = buildModal();
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.textContent).toContain('(partial)');
+        expect(modal.textContent).not.toContain('Luck');
+    });
+
+    test('AGG-1: Lifetime Luck is not shown when the lifetime aggregate has any non-eligible valuation record', () => {
+        mocks.lifetimeAggregate = {
+            containersOpened: 10,
+            actualValueTotal: 500,
+            expectedValueTotal: 400,
+            valuationRecordCount: 3,
+            luckEligibleRecordCount: 2,
+        };
+        const modal = buildModal();
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.textContent).toContain('Lifetime: 10 opened');
+        expect(modal.textContent).not.toMatch(/Lifetime:.*Luck/);
+    });
+
+    test('Lifetime Luck is shown when every folded valuation record is Luck-eligible', () => {
+        mocks.lifetimeAggregate = {
+            containersOpened: 10,
+            actualValueTotal: 500,
+            expectedValueTotal: 400,
+            valuationRecordCount: 3,
+            luckEligibleRecordCount: 3,
+        };
+        const modal = buildModal();
+        modalCallbacks().forEach((cb) => cb(modal));
+
+        expect(modal.textContent).toMatch(/Lifetime:.*Luck/);
+    });
 });
 
 describe('per-item value labels', () => {

--- a/src/features/inventory/openable-analytics/openable-analytics-modal-injector.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-modal-injector.test.js
@@ -1,0 +1,143 @@
+/* @vitest-environment jsdom */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    onClassCallbacks: [],
+    unsubscribeCollectorCallbacks: [],
+    latestRecord: null,
+    lifetimeAggregate: {
+        containersOpened: 0,
+        actualValueTotal: 0,
+        expectedValueTotal: 0,
+        expectedValueAvailableEvents: 0,
+    },
+}));
+
+vi.mock('../../../core/dom-observer.js', () => ({
+    default: {
+        onClass: vi.fn((_name, _classNames, callback) => {
+            mocks.onClassCallbacks.push(callback);
+            return vi.fn();
+        }),
+    },
+}));
+
+vi.mock('../../../core/config.js', () => ({
+    default: { COLOR_PROFIT: '#047857', COLOR_LOSS: '#f87171', COLOR_TEXT_SECONDARY: '#888888' },
+}));
+
+vi.mock('./openable-analytics-data-collector.js', () => ({
+    default: {
+        getLatestRecord: vi.fn(() => mocks.latestRecord),
+        getLifetimeAggregate: vi.fn(() => mocks.lifetimeAggregate),
+        onUpdate: vi.fn((callback) => {
+            mocks.unsubscribeCollectorCallbacks.push(callback);
+            return vi.fn();
+        }),
+    },
+}));
+
+const {
+    default: openableAnalyticsModalInjector,
+    MODAL_CONTENT_CLASS,
+    LINE_CLASS,
+} = await import('./openable-analytics-modal-injector.js');
+
+function buildModal() {
+    const container = document.createElement('div');
+    container.className = `Inventory_modalContent__3ObSx`;
+    container.innerHTML = `<div class="Inventory_header__1">Loot Gained!</div><div>item icon</div>`;
+    document.body.appendChild(container);
+    return container;
+}
+
+beforeEach(() => {
+    mocks.onClassCallbacks = [];
+    mocks.unsubscribeCollectorCallbacks = [];
+    mocks.latestRecord = {
+        containerHrid: '/items/chest',
+        containerCount: 6,
+        actualValue: 1470000,
+        actualValueComplete: true,
+        expectedValue: 2190000,
+        expectedValueAvailable: true,
+        luckValue: -720000,
+        luckPercent: -32.9,
+    };
+    document.body.innerHTML = '';
+    openableAnalyticsModalInjector.cleanup();
+    openableAnalyticsModalInjector.initialize();
+});
+
+describe('idempotent modal injection', () => {
+    test('injects exactly one summary line on first mount', () => {
+        const modal = buildModal();
+        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(1);
+        expect(modal.textContent).toContain('6 opened');
+    });
+
+    test('remounting the modal for a second opening replaces the line in place rather than duplicating it', () => {
+        const modal = buildModal();
+        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+
+        mocks.latestRecord = { ...mocks.latestRecord, containerCount: 3, actualValue: 500000 };
+        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(1);
+        expect(modal.textContent).toContain('3 opened');
+        expect(modal.textContent).not.toContain('6 opened');
+    });
+
+    test('a data-driven update to an already-mounted modal (no remount) updates the line in place', () => {
+        const modal = buildModal();
+        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+
+        mocks.latestRecord = { ...mocks.latestRecord, containerCount: 42 };
+        mocks.unsubscribeCollectorCallbacks.forEach((cb) => cb(mocks.latestRecord));
+
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(1);
+        expect(modal.textContent).toContain('42 opened');
+    });
+
+    test('does not touch a modalContent node from an unrelated class match', () => {
+        const other = document.createElement('div');
+        other.className = 'SomeOtherPanel_modalContent__abc';
+        document.body.appendChild(other);
+
+        mocks.onClassCallbacks.forEach((cb) => cb(other));
+
+        expect(other.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
+    });
+
+    test('never injects before any record exists (no crash, no line)', () => {
+        mocks.latestRecord = null;
+        const modal = buildModal();
+        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+
+        expect(modal.querySelectorAll(`.${LINE_CLASS}`)).toHaveLength(0);
+    });
+
+    test('shows Expected: N/A without a Luck value when EV is unavailable for the opened container', () => {
+        mocks.latestRecord = {
+            containerHrid: '/items/seal_of_rare_find',
+            containerCount: 1,
+            actualValue: 0,
+            actualValueComplete: true,
+            expectedValue: null,
+            expectedValueAvailable: false,
+            luckValue: null,
+            luckPercent: null,
+        };
+        const modal = buildModal();
+        mocks.onClassCallbacks.forEach((cb) => cb(modal));
+
+        expect(modal.textContent).toContain('Expected N/A');
+        expect(modal.textContent).not.toContain('Luck');
+    });
+});
+
+test('MODAL_CONTENT_CLASS targets the Inventory panel modal content class', () => {
+    expect(MODAL_CONTENT_CLASS).toBe('Inventory_modalContent');
+});

--- a/src/features/inventory/openable-analytics/openable-analytics-storage.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-storage.js
@@ -1,0 +1,140 @@
+/**
+ * Openable Analytics Storage
+ * Character-scoped IndexedDB persistence for lifetime aggregates and bounded detailed history.
+ * Lifetime aggregates are updated incrementally at write time so pruning the detailed history
+ * array never changes lifetime totals.
+ */
+
+import storage from '../../../core/storage.js';
+
+const STORE_NAME = 'openableAnalytics';
+const MAX_HISTORY_EVENTS = 500;
+
+function lifetimeKey(characterId) {
+    return `lifetime:${characterId}`;
+}
+
+function historyKey(characterId) {
+    return `history:${characterId}`;
+}
+
+/**
+ * Load the lifetime aggregate map (containerHrid -> aggregate) for one character.
+ * @param {string} characterId
+ * @returns {Promise<Object>} Map of containerHrid -> aggregate object
+ */
+export async function loadLifetime(characterId) {
+    return storage.getJSON(lifetimeKey(characterId), STORE_NAME, {});
+}
+
+/**
+ * Persist the lifetime aggregate map for one character.
+ * @param {string} characterId
+ * @param {Object} lifetime
+ * @returns {Promise<boolean>}
+ */
+export async function saveLifetime(characterId, lifetime) {
+    return storage.setJSON(lifetimeKey(characterId), lifetime, STORE_NAME);
+}
+
+/**
+ * Load the bounded detailed opening history for one character (most recent last).
+ * @param {string} characterId
+ * @returns {Promise<Array>}
+ */
+export async function loadHistory(characterId) {
+    return storage.getJSON(historyKey(characterId), STORE_NAME, []);
+}
+
+/**
+ * Append one detailed opening record to a character's history, pruning the oldest entries
+ * beyond `MAX_HISTORY_EVENTS`. Does not touch the lifetime aggregate.
+ * @param {string} characterId
+ * @param {Array} history - Current in-memory history array
+ * @param {Object} record - New detailed record to append
+ * @returns {Promise<Array>} The updated (possibly pruned) history array
+ */
+export async function appendHistory(characterId, history, record) {
+    const updated = [...history, record];
+    const pruned = updated.length > MAX_HISTORY_EVENTS ? updated.slice(updated.length - MAX_HISTORY_EVENTS) : updated;
+    await storage.setJSON(historyKey(characterId), pruned, STORE_NAME);
+    return pruned;
+}
+
+/**
+ * Create an empty aggregate for a container that has never been recorded before.
+ * @returns {Object}
+ */
+export function createEmptyAggregate() {
+    return {
+        eventsCount: 0,
+        containersOpened: 0,
+        actualValueTotal: 0,
+        actualValueCompleteEvents: 0,
+        actualValuePartialEvents: 0,
+        expectedValueTotal: 0,
+        expectedValueAvailableEvents: 0,
+        expectedValueUnavailableEvents: 0,
+        grantedBuffEvents: 0,
+        itemTotals: {},
+    };
+}
+
+/**
+ * Fold one normalized opening record into an aggregate (lifetime or session), returning a new
+ * aggregate object. Never mutates the input.
+ * @param {Object} aggregate - Existing aggregate (or a fresh `createEmptyAggregate()`)
+ * @param {Object} record - Normalized opening record from `buildOpeningRecord`
+ * @returns {Object} New aggregate reflecting the folded-in record
+ */
+export function foldRecordIntoAggregate(aggregate, record) {
+    const base = aggregate || createEmptyAggregate();
+    const itemTotals = { ...base.itemTotals };
+    for (const item of record.gainedItems || []) {
+        itemTotals[item.itemHrid] = (itemTotals[item.itemHrid] || 0) + item.count;
+    }
+
+    return {
+        eventsCount: base.eventsCount + 1,
+        containersOpened: base.containersOpened + record.containerCount,
+        actualValueTotal: base.actualValueTotal + record.actualValue,
+        actualValueCompleteEvents: base.actualValueCompleteEvents + (record.actualValueComplete ? 1 : 0),
+        actualValuePartialEvents: base.actualValuePartialEvents + (record.actualValueComplete ? 0 : 1),
+        expectedValueTotal: base.expectedValueTotal + (record.expectedValueAvailable ? record.expectedValue : 0),
+        expectedValueAvailableEvents: base.expectedValueAvailableEvents + (record.expectedValueAvailable ? 1 : 0),
+        expectedValueUnavailableEvents: base.expectedValueUnavailableEvents + (record.expectedValueAvailable ? 0 : 1),
+        grantedBuffEvents: base.grantedBuffEvents + (record.grantedBuffs?.length > 0 ? 1 : 0),
+        itemTotals,
+    };
+}
+
+/**
+ * Reset (delete) lifetime + history data for one container for one character.
+ * @param {string} characterId
+ * @param {string} containerHrid
+ * @returns {Promise<{lifetime: Object, history: Array}>} The updated lifetime map and history
+ */
+export async function resetContainer(characterId, containerHrid) {
+    const lifetime = await loadLifetime(characterId);
+    delete lifetime[containerHrid];
+    await saveLifetime(characterId, lifetime);
+
+    const history = await loadHistory(characterId);
+    const filtered = history.filter((record) => record.containerHrid !== containerHrid);
+    await storage.setJSON(historyKey(characterId), filtered, STORE_NAME);
+
+    return { lifetime, history: filtered };
+}
+
+/**
+ * Reset (delete) all Openable Analytics data for one character.
+ * @param {string} characterId
+ * @returns {Promise<void>}
+ */
+export async function resetAll(characterId) {
+    await storage.delete(lifetimeKey(characterId), STORE_NAME);
+    await storage.delete(historyKey(characterId), STORE_NAME);
+}
+
+export const OPENABLE_ANALYTICS_STORE = STORE_NAME;
+export const OPENABLE_ANALYTICS_MAX_HISTORY_EVENTS = MAX_HISTORY_EVENTS;

--- a/src/features/inventory/openable-analytics/openable-analytics-storage.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-storage.js
@@ -38,7 +38,10 @@ export async function loadLifetime(characterId) {
  * @returns {Promise<boolean>}
  */
 export async function saveLifetime(characterId, lifetime) {
-    return storage.setJSON(lifetimeKey(characterId), lifetime, STORE_NAME);
+    // Analytics mutation ordering is owned by the collector's persistence queue; do not
+    // introduce a second Core Storage debounce that could coalesce distinct log snapshots or
+    // resolve after a later reset/opening has already run.
+    return storage.setJSON(lifetimeKey(characterId), lifetime, STORE_NAME, true);
 }
 
 /**
@@ -51,17 +54,44 @@ export async function loadHistory(characterId) {
 }
 
 /**
- * Append one detailed opening record to a character's history, pruning the oldest entries
- * beyond `MAX_HISTORY_EVENTS`. Does not touch the lifetime aggregate.
+ * Pure, synchronous append of one detailed opening record, pruning the oldest entries beyond
+ * `MAX_HISTORY_EVENTS`. Does not touch the lifetime aggregate or persistence - callers that need
+ * ordered/immediate persistence should follow with `saveHistory()` themselves (see the data
+ * collector's persistence queue), so two overlapping callers never both derive their next state
+ * from the same stale array.
+ * @param {Array} history - Current in-memory history array
+ * @param {Object} record - New detailed record to append
+ * @returns {Array} The updated (possibly pruned) history array
+ */
+export function appendHistoryRecord(history, record) {
+    const updated = [...history, record];
+    return updated.length > MAX_HISTORY_EVENTS ? updated.slice(updated.length - MAX_HISTORY_EVENTS) : updated;
+}
+
+/**
+ * Persist a character's detailed opening history immediately (not debounced) - reset must be
+ * able to order itself unambiguously against opening/import writes.
+ * @param {string} characterId
+ * @param {Array} history
+ * @returns {Promise<boolean>}
+ */
+export async function saveHistory(characterId, history) {
+    return storage.setJSON(historyKey(characterId), history, STORE_NAME, true);
+}
+
+/**
+ * Append one detailed opening record to a character's history and persist immediately. Kept as
+ * a convenience wrapper around `appendHistoryRecord` + `saveHistory` for simple/test callers;
+ * the data collector itself calls the two halves separately so it can commit in-memory state
+ * before awaiting persistence.
  * @param {string} characterId
  * @param {Array} history - Current in-memory history array
  * @param {Object} record - New detailed record to append
  * @returns {Promise<Array>} The updated (possibly pruned) history array
  */
 export async function appendHistory(characterId, history, record) {
-    const updated = [...history, record];
-    const pruned = updated.length > MAX_HISTORY_EVENTS ? updated.slice(updated.length - MAX_HISTORY_EVENTS) : updated;
-    await storage.setJSON(historyKey(characterId), pruned, STORE_NAME);
+    const pruned = appendHistoryRecord(history, record);
+    await saveHistory(characterId, pruned);
     return pruned;
 }
 
@@ -79,6 +109,10 @@ export function createEmptyAggregate() {
         expectedValueTotal: 0,
         expectedValueAvailableEvents: 0,
         expectedValueUnavailableEvents: 0,
+        expectedValuePartialEvents: 0,
+        valuationRecordCount: 0,
+        luckEligibleRecordCount: 0,
+        hasImportedData: false,
         grantedBuffEvents: 0,
         itemTotals: {},
         itemValueTotals: {},
@@ -107,8 +141,19 @@ export function foldRecordIntoAggregate(aggregate, record) {
         itemValueTotals[item.itemHrid] = (itemValueTotals[item.itemHrid] || 0) + item.value;
     }
 
+    // Imported sources expose a cumulative container total, not individual opening events - one
+    // imported record must not be counted as one "opening event" (section 3.1).
+    const isImported = typeof record.source === 'string' && record.source.startsWith('import:');
+    // A record only qualifies as Luck-eligible when Actual is complete and Expected is both
+    // available and complete - calculateLuck() already enforces this and reports it back as a
+    // non-null luckValue, so aggregate Luck can fail closed as a whole (section 3.2) without
+    // re-deriving the same completeness rules here.
+    const expectedPartial = record.expectedValueAvailable && record.expectedValueComplete === false;
+    const luckEligible = record.luckValue !== null && record.luckValue !== undefined;
+
     return {
-        eventsCount: base.eventsCount + 1,
+        // Imported sources expose cumulative container totals, not individual opening events.
+        eventsCount: base.eventsCount + (isImported ? 0 : 1),
         containersOpened: base.containersOpened + record.containerCount,
         actualValueTotal: base.actualValueTotal + record.actualValue,
         actualValueCompleteEvents: base.actualValueCompleteEvents + (record.actualValueComplete ? 1 : 0),
@@ -116,6 +161,10 @@ export function foldRecordIntoAggregate(aggregate, record) {
         expectedValueTotal: base.expectedValueTotal + (record.expectedValueAvailable ? record.expectedValue : 0),
         expectedValueAvailableEvents: base.expectedValueAvailableEvents + (record.expectedValueAvailable ? 1 : 0),
         expectedValueUnavailableEvents: base.expectedValueUnavailableEvents + (record.expectedValueAvailable ? 0 : 1),
+        expectedValuePartialEvents: (base.expectedValuePartialEvents || 0) + (expectedPartial ? 1 : 0),
+        valuationRecordCount: (base.valuationRecordCount || 0) + 1,
+        luckEligibleRecordCount: (base.luckEligibleRecordCount || 0) + (luckEligible ? 1 : 0),
+        hasImportedData: Boolean(base.hasImportedData || isImported),
         grantedBuffEvents: base.grantedBuffEvents + (record.grantedBuffs?.length > 0 ? 1 : 0),
         itemTotals,
         itemValueTotals,
@@ -139,7 +188,7 @@ export async function loadImports(characterId) {
  * @returns {Promise<boolean>}
  */
 export async function saveImports(characterId, imports) {
-    return storage.setJSON(importsKey(characterId), imports, STORE_NAME);
+    return storage.setJSON(importsKey(characterId), imports, STORE_NAME, true);
 }
 
 /**
@@ -160,6 +209,10 @@ export function mergeAggregates(...aggregates) {
         merged.expectedValueTotal += aggregate.expectedValueTotal;
         merged.expectedValueAvailableEvents += aggregate.expectedValueAvailableEvents;
         merged.expectedValueUnavailableEvents += aggregate.expectedValueUnavailableEvents;
+        merged.expectedValuePartialEvents += aggregate.expectedValuePartialEvents || 0;
+        merged.valuationRecordCount += aggregate.valuationRecordCount || 0;
+        merged.luckEligibleRecordCount += aggregate.luckEligibleRecordCount || 0;
+        merged.hasImportedData = Boolean(merged.hasImportedData || aggregate.hasImportedData);
         merged.grantedBuffEvents += aggregate.grantedBuffEvents;
         for (const [itemHrid, count] of Object.entries(aggregate.itemTotals || {})) {
             merged.itemTotals[itemHrid] = (merged.itemTotals[itemHrid] || 0) + count;
@@ -184,7 +237,7 @@ export async function resetContainer(characterId, containerHrid) {
 
     const history = await loadHistory(characterId);
     const filtered = history.filter((record) => record.containerHrid !== containerHrid);
-    await storage.setJSON(historyKey(characterId), filtered, STORE_NAME);
+    await saveHistory(characterId, filtered);
 
     const imports = await loadImports(characterId);
     for (const source of Object.keys(imports)) {

--- a/src/features/inventory/openable-analytics/openable-analytics-storage.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-storage.js
@@ -81,6 +81,7 @@ export function createEmptyAggregate() {
         expectedValueUnavailableEvents: 0,
         grantedBuffEvents: 0,
         itemTotals: {},
+        itemValueTotals: {},
     };
 }
 
@@ -94,8 +95,16 @@ export function createEmptyAggregate() {
 export function foldRecordIntoAggregate(aggregate, record) {
     const base = aggregate || createEmptyAggregate();
     const itemTotals = { ...base.itemTotals };
+    const itemValueTotals = { ...base.itemValueTotals };
+
     for (const item of record.gainedItems || []) {
         itemTotals[item.itemHrid] = (itemTotals[item.itemHrid] || 0) + item.count;
+    }
+    // actualValueBreakdown may be absent on records written before this field existed - those
+    // simply don't contribute a per-item value (their count is still reflected in itemTotals).
+    for (const item of record.actualValueBreakdown || []) {
+        if (!item.resolved) continue;
+        itemValueTotals[item.itemHrid] = (itemValueTotals[item.itemHrid] || 0) + item.value;
     }
 
     return {
@@ -109,6 +118,7 @@ export function foldRecordIntoAggregate(aggregate, record) {
         expectedValueUnavailableEvents: base.expectedValueUnavailableEvents + (record.expectedValueAvailable ? 0 : 1),
         grantedBuffEvents: base.grantedBuffEvents + (record.grantedBuffs?.length > 0 ? 1 : 0),
         itemTotals,
+        itemValueTotals,
     };
 }
 
@@ -153,6 +163,9 @@ export function mergeAggregates(...aggregates) {
         merged.grantedBuffEvents += aggregate.grantedBuffEvents;
         for (const [itemHrid, count] of Object.entries(aggregate.itemTotals || {})) {
             merged.itemTotals[itemHrid] = (merged.itemTotals[itemHrid] || 0) + count;
+        }
+        for (const [itemHrid, value] of Object.entries(aggregate.itemValueTotals || {})) {
+            merged.itemValueTotals[itemHrid] = (merged.itemValueTotals[itemHrid] || 0) + value;
         }
     }
     return merged;

--- a/src/features/inventory/openable-analytics/openable-analytics-storage.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-storage.js
@@ -18,6 +18,10 @@ function historyKey(characterId) {
     return `history:${characterId}`;
 }
 
+function importsKey(characterId) {
+    return `imports:${characterId}`;
+}
+
 /**
  * Load the lifetime aggregate map (containerHrid -> aggregate) for one character.
  * @param {string} characterId
@@ -109,6 +113,52 @@ export function foldRecordIntoAggregate(aggregate, record) {
 }
 
 /**
+ * Load bulk-imported aggregates (Edible Tools / MWI Combat Suite / future sources) for one
+ * character. Shape: `{ [source]: { [containerHrid]: aggregate } }`.
+ * @param {string} characterId
+ * @returns {Promise<Object>}
+ */
+export async function loadImports(characterId) {
+    return storage.getJSON(importsKey(characterId), STORE_NAME, {});
+}
+
+/**
+ * Persist bulk-imported aggregates for one character.
+ * @param {string} characterId
+ * @param {Object} imports
+ * @returns {Promise<boolean>}
+ */
+export async function saveImports(characterId, imports) {
+    return storage.setJSON(importsKey(characterId), imports, STORE_NAME);
+}
+
+/**
+ * Sum any number of aggregates (live + one or more imported sources) into one combined
+ * aggregate for display. Never mutates its inputs.
+ * @param {...Object} aggregates
+ * @returns {Object}
+ */
+export function mergeAggregates(...aggregates) {
+    const merged = createEmptyAggregate();
+    for (const aggregate of aggregates) {
+        if (!aggregate) continue;
+        merged.eventsCount += aggregate.eventsCount;
+        merged.containersOpened += aggregate.containersOpened;
+        merged.actualValueTotal += aggregate.actualValueTotal;
+        merged.actualValueCompleteEvents += aggregate.actualValueCompleteEvents;
+        merged.actualValuePartialEvents += aggregate.actualValuePartialEvents;
+        merged.expectedValueTotal += aggregate.expectedValueTotal;
+        merged.expectedValueAvailableEvents += aggregate.expectedValueAvailableEvents;
+        merged.expectedValueUnavailableEvents += aggregate.expectedValueUnavailableEvents;
+        merged.grantedBuffEvents += aggregate.grantedBuffEvents;
+        for (const [itemHrid, count] of Object.entries(aggregate.itemTotals || {})) {
+            merged.itemTotals[itemHrid] = (merged.itemTotals[itemHrid] || 0) + count;
+        }
+    }
+    return merged;
+}
+
+/**
  * Reset (delete) lifetime + history data for one container for one character.
  * @param {string} characterId
  * @param {string} containerHrid
@@ -123,7 +173,13 @@ export async function resetContainer(characterId, containerHrid) {
     const filtered = history.filter((record) => record.containerHrid !== containerHrid);
     await storage.setJSON(historyKey(characterId), filtered, STORE_NAME);
 
-    return { lifetime, history: filtered };
+    const imports = await loadImports(characterId);
+    for (const source of Object.keys(imports)) {
+        delete imports[source][containerHrid];
+    }
+    await saveImports(characterId, imports);
+
+    return { lifetime, history: filtered, imports };
 }
 
 /**
@@ -134,6 +190,7 @@ export async function resetContainer(characterId, containerHrid) {
 export async function resetAll(characterId) {
     await storage.delete(lifetimeKey(characterId), STORE_NAME);
     await storage.delete(historyKey(characterId), STORE_NAME);
+    await storage.delete(importsKey(characterId), STORE_NAME);
 }
 
 export const OPENABLE_ANALYTICS_STORE = STORE_NAME;

--- a/src/features/inventory/openable-analytics/openable-analytics-storage.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-storage.js
@@ -251,12 +251,13 @@ export async function resetContainer(characterId, containerHrid) {
 /**
  * Reset (delete) all Openable Analytics data for one character.
  * @param {string} characterId
- * @returns {Promise<void>}
+ * @returns {Promise<boolean>} Whether every delete succeeded
  */
 export async function resetAll(characterId) {
-    await storage.delete(lifetimeKey(characterId), STORE_NAME);
-    await storage.delete(historyKey(characterId), STORE_NAME);
-    await storage.delete(importsKey(characterId), STORE_NAME);
+    const lifetimeOk = await storage.delete(lifetimeKey(characterId), STORE_NAME);
+    const historyOk = await storage.delete(historyKey(characterId), STORE_NAME);
+    const importsOk = await storage.delete(importsKey(characterId), STORE_NAME);
+    return lifetimeOk && historyOk && importsOk;
 }
 
 export const OPENABLE_ANALYTICS_STORE = STORE_NAME;

--- a/src/features/inventory/openable-analytics/openable-analytics-storage.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-storage.test.js
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ values: new Map() }));
+
+vi.mock('../../../core/storage.js', () => ({
+    default: {
+        getJSON: vi.fn(async (key, _store, defaultValue = null) =>
+            mocks.values.has(key) ? mocks.values.get(key) : defaultValue
+        ),
+        setJSON: vi.fn(async (key, value) => {
+            mocks.values.set(key, value);
+            return true;
+        }),
+        delete: vi.fn(async (key) => {
+            mocks.values.delete(key);
+            return true;
+        }),
+    },
+}));
+
+const storageModule = await import('./openable-analytics-storage.js');
+const {
+    loadLifetime,
+    saveLifetime,
+    loadHistory,
+    appendHistory,
+    createEmptyAggregate,
+    foldRecordIntoAggregate,
+    resetContainer,
+    resetAll,
+    OPENABLE_ANALYTICS_MAX_HISTORY_EVENTS,
+} = storageModule;
+
+beforeEach(() => {
+    mocks.values.clear();
+});
+
+function makeRecord(overrides = {}) {
+    return {
+        containerHrid: '/items/chest',
+        containerCount: 1,
+        gainedItems: [{ itemHrid: '/items/coin', enhancementLevel: 0, count: 100 }],
+        grantedBuffs: [],
+        actualValue: 100,
+        actualValueComplete: true,
+        expectedValue: 90,
+        expectedValueAvailable: true,
+        ...overrides,
+    };
+}
+
+describe('character scoping', () => {
+    test('lifetime and history are stored under different keys for different characters', async () => {
+        await saveLifetime('char-a', { '/items/chest': createEmptyAggregate() });
+        await saveLifetime('char-b', {});
+
+        expect(await loadLifetime('char-a')).toEqual({ '/items/chest': createEmptyAggregate() });
+        expect(await loadLifetime('char-b')).toEqual({});
+    });
+
+    test('a character with no data yet loads defaults, not another character’s data', async () => {
+        await saveLifetime('char-a', { '/items/chest': createEmptyAggregate() });
+
+        expect(await loadLifetime('char-c')).toEqual({});
+        expect(await loadHistory('char-c')).toEqual([]);
+    });
+});
+
+describe('foldRecordIntoAggregate', () => {
+    test('accumulates events, containers, values, and item totals across records', () => {
+        let aggregate = createEmptyAggregate();
+        aggregate = foldRecordIntoAggregate(aggregate, makeRecord({ containerCount: 2 }));
+        aggregate = foldRecordIntoAggregate(
+            aggregate,
+            makeRecord({ containerCount: 3, actualValue: 50, expectedValue: 40 })
+        );
+
+        expect(aggregate.eventsCount).toBe(2);
+        expect(aggregate.containersOpened).toBe(5);
+        expect(aggregate.actualValueTotal).toBe(150);
+        expect(aggregate.expectedValueTotal).toBe(130);
+        expect(aggregate.itemTotals['/items/coin']).toBe(200);
+    });
+
+    test('does not mutate the input aggregate', () => {
+        const original = createEmptyAggregate();
+        const folded = foldRecordIntoAggregate(original, makeRecord());
+
+        expect(original.eventsCount).toBe(0);
+        expect(folded.eventsCount).toBe(1);
+    });
+
+    test('unavailable-EV records do not contribute to expectedValueTotal (never a fake zero counted as real)', () => {
+        let aggregate = createEmptyAggregate();
+        aggregate = foldRecordIntoAggregate(
+            aggregate,
+            makeRecord({ expectedValue: null, expectedValueAvailable: false })
+        );
+
+        expect(aggregate.expectedValueTotal).toBe(0);
+        expect(aggregate.expectedValueAvailableEvents).toBe(0);
+        expect(aggregate.expectedValueUnavailableEvents).toBe(1);
+    });
+
+    test('partial actual-value records are tracked separately from complete ones', () => {
+        let aggregate = createEmptyAggregate();
+        aggregate = foldRecordIntoAggregate(aggregate, makeRecord({ actualValueComplete: false }));
+
+        expect(aggregate.actualValuePartialEvents).toBe(1);
+        expect(aggregate.actualValueCompleteEvents).toBe(0);
+    });
+});
+
+describe('appendHistory bounding', () => {
+    test('history is capped at the configured max, dropping the oldest entries first', async () => {
+        let history = [];
+        for (let i = 0; i < OPENABLE_ANALYTICS_MAX_HISTORY_EVENTS + 10; i++) {
+            history = await appendHistory('char-a', history, makeRecord({ timestamp: i }));
+        }
+
+        expect(history).toHaveLength(OPENABLE_ANALYTICS_MAX_HISTORY_EVENTS);
+        expect(history[0].timestamp).toBe(10);
+        expect(history[history.length - 1].timestamp).toBe(OPENABLE_ANALYTICS_MAX_HISTORY_EVENTS + 9);
+    });
+
+    test('pruning detailed history does not change a separately-tracked lifetime aggregate', async () => {
+        let aggregate = createEmptyAggregate();
+        let history = [];
+        for (let i = 0; i < OPENABLE_ANALYTICS_MAX_HISTORY_EVENTS + 5; i++) {
+            const record = makeRecord({ timestamp: i });
+            aggregate = foldRecordIntoAggregate(aggregate, record);
+            history = await appendHistory('char-a', history, record);
+        }
+
+        expect(history).toHaveLength(OPENABLE_ANALYTICS_MAX_HISTORY_EVENTS);
+        expect(aggregate.eventsCount).toBe(OPENABLE_ANALYTICS_MAX_HISTORY_EVENTS + 5);
+        expect(aggregate.actualValueTotal).toBe((OPENABLE_ANALYTICS_MAX_HISTORY_EVENTS + 5) * 100);
+    });
+});
+
+describe('reset controls', () => {
+    test('resetContainer clears only the targeted container’s lifetime + history', async () => {
+        await saveLifetime('char-a', {
+            '/items/chest': createEmptyAggregate(),
+            '/items/crate': createEmptyAggregate(),
+        });
+        await appendHistory('char-a', [], makeRecord({ containerHrid: '/items/chest' }));
+        const historyAfterCrate = await appendHistory(
+            'char-a',
+            await loadHistory('char-a'),
+            makeRecord({ containerHrid: '/items/crate' })
+        );
+        // Persist the combined history exactly as the collector would.
+        mocks.values.set('history:char-a', historyAfterCrate);
+
+        const { lifetime, history } = await resetContainer('char-a', '/items/chest');
+
+        expect(lifetime).toEqual({ '/items/crate': createEmptyAggregate() });
+        expect(history.every((r) => r.containerHrid !== '/items/chest')).toBe(true);
+        expect(history.some((r) => r.containerHrid === '/items/crate')).toBe(true);
+    });
+
+    test('resetAll clears all Openable Analytics data for the character', async () => {
+        await saveLifetime('char-a', { '/items/chest': createEmptyAggregate() });
+        mocks.values.set('history:char-a', [makeRecord()]);
+
+        await resetAll('char-a');
+
+        expect(await loadLifetime('char-a')).toEqual({});
+        expect(await loadHistory('char-a')).toEqual([]);
+    });
+
+    test('resetAll for one character does not affect another character’s data', async () => {
+        await saveLifetime('char-a', { '/items/chest': createEmptyAggregate() });
+        await saveLifetime('char-b', { '/items/chest': createEmptyAggregate() });
+
+        await resetAll('char-a');
+
+        expect(await loadLifetime('char-a')).toEqual({});
+        expect(await loadLifetime('char-b')).toEqual({ '/items/chest': createEmptyAggregate() });
+    });
+});

--- a/src/features/inventory/openable-analytics/openable-analytics-storage.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-storage.test.js
@@ -112,6 +112,54 @@ describe('foldRecordIntoAggregate', () => {
         expect(aggregate.actualValuePartialEvents).toBe(1);
         expect(aggregate.actualValueCompleteEvents).toBe(0);
     });
+
+    test('accumulates per-item value totals from actualValueBreakdown across records', () => {
+        let aggregate = createEmptyAggregate();
+        aggregate = foldRecordIntoAggregate(
+            aggregate,
+            makeRecord({
+                actualValueBreakdown: [
+                    { itemHrid: '/items/coin', enhancementLevel: 0, count: 100, value: 100, resolved: true },
+                    { itemHrid: '/items/pearl', enhancementLevel: 0, count: 3, value: 300, resolved: true },
+                ],
+            })
+        );
+        aggregate = foldRecordIntoAggregate(
+            aggregate,
+            makeRecord({
+                actualValueBreakdown: [
+                    { itemHrid: '/items/coin', enhancementLevel: 0, count: 50, value: 50, resolved: true },
+                ],
+            })
+        );
+
+        expect(aggregate.itemValueTotals['/items/coin']).toBe(150);
+        expect(aggregate.itemValueTotals['/items/pearl']).toBe(300);
+    });
+
+    test('an unresolved item in the breakdown does not contribute a fake value to itemValueTotals', () => {
+        let aggregate = createEmptyAggregate();
+        aggregate = foldRecordIntoAggregate(
+            aggregate,
+            makeRecord({
+                actualValueBreakdown: [
+                    { itemHrid: '/items/mystery', enhancementLevel: 0, count: 1, value: 0, resolved: false },
+                ],
+            })
+        );
+
+        expect(aggregate.itemValueTotals['/items/mystery']).toBeUndefined();
+    });
+
+    test('a record with no actualValueBreakdown (written before this field existed) folds without crashing', () => {
+        const legacyRecord = makeRecord();
+        delete legacyRecord.actualValueBreakdown;
+
+        const aggregate = foldRecordIntoAggregate(createEmptyAggregate(), legacyRecord);
+
+        expect(aggregate.itemTotals['/items/coin']).toBe(100);
+        expect(aggregate.itemValueTotals).toEqual({});
+    });
 });
 
 describe('appendHistory bounding', () => {
@@ -236,6 +284,29 @@ describe('mergeAggregates', () => {
         expect(merged.actualValueTotal).toBe(5100);
         expect(merged.expectedValueTotal).toBe(4590);
         expect(merged.itemTotals['/items/coin']).toBe(1000);
+    });
+
+    test('merges per-item value totals across aggregates too', () => {
+        const live = foldRecordIntoAggregate(
+            createEmptyAggregate(),
+            makeRecord({
+                actualValueBreakdown: [
+                    { itemHrid: '/items/coin', enhancementLevel: 0, count: 100, value: 100, resolved: true },
+                ],
+            })
+        );
+        const imported = foldRecordIntoAggregate(
+            createEmptyAggregate(),
+            makeRecord({
+                actualValueBreakdown: [
+                    { itemHrid: '/items/coin', enhancementLevel: 0, count: 900, value: 900, resolved: true },
+                ],
+            })
+        );
+
+        const merged = mergeAggregates(live, imported);
+
+        expect(merged.itemValueTotals['/items/coin']).toBe(1000);
     });
 
     test('ignores null/undefined aggregates (e.g. no imports for this container)', () => {

--- a/src/features/inventory/openable-analytics/openable-analytics-storage.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-storage.test.js
@@ -219,10 +219,19 @@ describe('reset controls', () => {
         await saveLifetime('char-a', { '/items/chest': createEmptyAggregate() });
         mocks.values.set('history:char-a', [makeRecord()]);
 
-        await resetAll('char-a');
+        const succeeded = await resetAll('char-a');
 
+        expect(succeeded).toBe(true);
         expect(await loadLifetime('char-a')).toEqual({});
         expect(await loadHistory('char-a')).toEqual([]);
+    });
+
+    test('section 22: resetAll reports false when one delete fails, without throwing', async () => {
+        storageMock.delete.mockResolvedValueOnce(false);
+
+        const succeeded = await resetAll('char-a');
+
+        expect(succeeded).toBe(false);
     });
 
     test('resetAll for one character does not affect another character’s data', async () => {

--- a/src/features/inventory/openable-analytics/openable-analytics-storage.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-storage.test.js
@@ -24,6 +24,8 @@ const {
     saveLifetime,
     loadHistory,
     appendHistory,
+    appendHistoryRecord,
+    saveHistory,
     loadImports,
     saveImports,
     createEmptyAggregate,
@@ -33,6 +35,8 @@ const {
     resetAll,
     OPENABLE_ANALYTICS_MAX_HISTORY_EVENTS,
 } = storageModule;
+
+const storageMock = (await import('../../../core/storage.js')).default;
 
 beforeEach(() => {
     mocks.values.clear();
@@ -260,6 +264,107 @@ describe('imports persistence', () => {
             'import:mwi-combat-suite': { '/items/chest': createEmptyAggregate() },
         });
         expect(await loadLifetime('char-a')).toEqual({});
+    });
+});
+
+describe('OA-4: immediate persistence (no debounce that can race reset ordering)', () => {
+    test('saveLifetime, saveHistory, and saveImports all write immediately', async () => {
+        storageMock.setJSON.mockClear();
+
+        await saveLifetime('char-a', {});
+        await saveHistory('char-a', []);
+        await saveImports('char-a', {});
+
+        for (const call of storageMock.setJSON.mock.calls) {
+            expect(call[3]).toBe(true);
+        }
+        expect(storageMock.setJSON).toHaveBeenCalledTimes(3);
+    });
+});
+
+describe('appendHistoryRecord (pure, synchronous half of history append)', () => {
+    test('does not persist by itself - callers control ordering against saveHistory', async () => {
+        storageMock.setJSON.mockClear();
+
+        const updated = appendHistoryRecord([], makeRecord());
+
+        expect(updated).toHaveLength(1);
+        expect(storageMock.setJSON).not.toHaveBeenCalled();
+    });
+
+    test('two overlapping callers deriving from the same prior array both survive once each is committed in order (OA-3)', () => {
+        // Simulates two concurrent recordOpening() calls that both read `this.history` before
+        // either await resolves: each starts from the same base array, and the caller (the data
+        // collector) is responsible for committing both pure appends before persisting, rather
+        // than letting a debounced write silently coalesce them.
+        const base = [];
+        const afterFirst = appendHistoryRecord(base, makeRecord({ containerHrid: '/items/chest' }));
+        const afterSecond = appendHistoryRecord(afterFirst, makeRecord({ containerHrid: '/items/crate' }));
+
+        expect(afterSecond).toHaveLength(2);
+        expect(afterSecond.map((r) => r.containerHrid)).toEqual(['/items/chest', '/items/crate']);
+    });
+});
+
+describe('opening-event vs. imported-container counting (section 3.1)', () => {
+    test('a live loot_opened-sourced record increments eventsCount (Tracked opening events)', () => {
+        const aggregate = foldRecordIntoAggregate(createEmptyAggregate(), makeRecord({ source: 'loot_opened' }));
+
+        expect(aggregate.eventsCount).toBe(1);
+        expect(aggregate.containersOpened).toBe(1);
+    });
+
+    test('an imported cumulative snapshot does not increment eventsCount, only containersOpened (AGG-2)', () => {
+        const aggregate = foldRecordIntoAggregate(
+            createEmptyAggregate(),
+            makeRecord({ source: 'import:edible', containerCount: 500 })
+        );
+
+        expect(aggregate.eventsCount).toBe(0);
+        expect(aggregate.containersOpened).toBe(500);
+        expect(aggregate.hasImportedData).toBe(true);
+    });
+
+    test('mixing one live event and one imported snapshot only counts the live one as an opening event', () => {
+        let aggregate = createEmptyAggregate();
+        aggregate = foldRecordIntoAggregate(aggregate, makeRecord({ source: 'loot_opened' }));
+        aggregate = foldRecordIntoAggregate(aggregate, makeRecord({ source: 'import:mwi-combat-suite' }));
+
+        expect(aggregate.eventsCount).toBe(1);
+        expect(aggregate.containersOpened).toBe(2);
+        expect(aggregate.hasImportedData).toBe(true);
+    });
+});
+
+describe('aggregate Luck fail-closed as a whole (section 3.2)', () => {
+    test('every folded record Luck-eligible => luckEligibleRecordCount matches valuationRecordCount', () => {
+        let aggregate = createEmptyAggregate();
+        aggregate = foldRecordIntoAggregate(aggregate, makeRecord({ luckValue: 10 }));
+        aggregate = foldRecordIntoAggregate(aggregate, makeRecord({ luckValue: -5 }));
+
+        expect(aggregate.valuationRecordCount).toBe(2);
+        expect(aggregate.luckEligibleRecordCount).toBe(2);
+    });
+
+    test('one record with no eligible Luck (partial/unavailable) makes the aggregate fail closed (AGG-1)', () => {
+        let aggregate = createEmptyAggregate();
+        aggregate = foldRecordIntoAggregate(aggregate, makeRecord({ luckValue: 10 }));
+        aggregate = foldRecordIntoAggregate(aggregate, makeRecord({ luckValue: null }));
+
+        expect(aggregate.valuationRecordCount).toBe(2);
+        expect(aggregate.luckEligibleRecordCount).toBe(1);
+        // Consumers must treat luckEligibleRecordCount !== valuationRecordCount as "Luck N/A for
+        // the whole aggregate", never subtract a partial Expected from a superset Actual.
+    });
+
+    test('a partial-Expected record is tracked separately from a fully unavailable one', () => {
+        const aggregate = foldRecordIntoAggregate(
+            createEmptyAggregate(),
+            makeRecord({ expectedValueAvailable: true, expectedValueComplete: false, luckValue: null })
+        );
+
+        expect(aggregate.expectedValuePartialEvents).toBe(1);
+        expect(aggregate.expectedValueUnavailableEvents).toBe(0);
     });
 });
 

--- a/src/features/inventory/openable-analytics/openable-analytics-storage.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-storage.test.js
@@ -24,8 +24,11 @@ const {
     saveLifetime,
     loadHistory,
     appendHistory,
+    loadImports,
+    saveImports,
     createEmptyAggregate,
     foldRecordIntoAggregate,
+    mergeAggregates,
     resetContainer,
     resetAll,
     OPENABLE_ANALYTICS_MAX_HISTORY_EVENTS,
@@ -178,5 +181,72 @@ describe('reset controls', () => {
 
         expect(await loadLifetime('char-a')).toEqual({});
         expect(await loadLifetime('char-b')).toEqual({ '/items/chest': createEmptyAggregate() });
+    });
+
+    test('resetContainer clears only the targeted container’s imported data, leaving other sources/containers intact', async () => {
+        await saveImports('char-a', {
+            'import:edible': { '/items/chest': createEmptyAggregate(), '/items/crate': createEmptyAggregate() },
+        });
+
+        const { imports } = await resetContainer('char-a', '/items/chest');
+
+        expect(imports['import:edible']['/items/chest']).toBeUndefined();
+        expect(imports['import:edible']['/items/crate']).toEqual(createEmptyAggregate());
+    });
+
+    test('resetAll clears imported data too', async () => {
+        await saveImports('char-a', { 'import:edible': { '/items/chest': createEmptyAggregate() } });
+
+        await resetAll('char-a');
+
+        expect(await loadImports('char-a')).toEqual({});
+    });
+});
+
+describe('imports persistence', () => {
+    test('imports are stored under a character-scoped key, separate from live-tracked lifetime', async () => {
+        await saveImports('char-a', { 'import:mwi-combat-suite': { '/items/chest': createEmptyAggregate() } });
+        await saveLifetime('char-a', {});
+
+        expect(await loadImports('char-a')).toEqual({
+            'import:mwi-combat-suite': { '/items/chest': createEmptyAggregate() },
+        });
+        expect(await loadLifetime('char-a')).toEqual({});
+    });
+});
+
+describe('mergeAggregates', () => {
+    test('sums numeric fields and merges item totals across live + imported aggregates', () => {
+        const live = foldRecordIntoAggregate(
+            createEmptyAggregate(),
+            makeRecord({ actualValue: 100, expectedValue: 90 })
+        );
+        const imported = foldRecordIntoAggregate(
+            createEmptyAggregate(),
+            makeRecord({
+                actualValue: 5000,
+                expectedValue: 4500,
+                gainedItems: [{ itemHrid: '/items/coin', count: 900 }],
+            })
+        );
+
+        const merged = mergeAggregates(live, imported);
+
+        expect(merged.eventsCount).toBe(2);
+        expect(merged.actualValueTotal).toBe(5100);
+        expect(merged.expectedValueTotal).toBe(4590);
+        expect(merged.itemTotals['/items/coin']).toBe(1000);
+    });
+
+    test('ignores null/undefined aggregates (e.g. no imports for this container)', () => {
+        const live = foldRecordIntoAggregate(createEmptyAggregate(), makeRecord());
+
+        const merged = mergeAggregates(live, undefined, null);
+
+        expect(merged).toEqual(live);
+    });
+
+    test('returns an empty aggregate when called with no real aggregates', () => {
+        expect(mergeAggregates()).toEqual(createEmptyAggregate());
     });
 });

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.js
@@ -1,30 +1,26 @@
 /**
  * Openable Analytics UI
- * Character-scoped Analytics popup: container selector, Session/Lifetime toggle, Actual/Expected/
- * Luck summary, aggregated item outcomes, and destructive reset controls. Modeled on the existing
- * bespoke-overlay popup convention used by Combat Statistics (no shared modal utility exists in
- * Toolasha to build on top of).
+ * Character-scoped Analytics popup: Session/Lifetime toggle, single-open accordion of containers,
+ * per-container Actual/Expected/Luck + Loot table, and a collapsed Manage Data section for
+ * historical imports and destructive resets. One mounted shell is reused for all interactions -
+ * content is rebuilt in place rather than tearing down and recreating the whole popup.
  */
 
 import config from '../../../core/config.js';
 import dataManager from '../../../core/data-manager.js';
 import domObserver from '../../../core/dom-observer.js';
+import { formatLargeNumber } from '../../../utils/formatters.js';
 import openableAnalyticsDataCollector from './openable-analytics-data-collector.js';
-import openableAnalyticsModalInjector, { formatValue, formatLuckPercent } from './openable-analytics-modal-injector.js';
-import { parseEdibleExport, parseCombatSuiteExport } from './openable-analytics-import-parsers.js';
-
-const IMPORT_SOURCES = [
-    { key: 'edible', label: 'Edible Tools', prefixedSource: 'import:edible' },
-    { key: 'mwi-combat-suite', label: 'MWI Combat Suite', prefixedSource: 'import:mwi-combat-suite' },
-];
+import openableAnalyticsModalInjector, { formatLuckPercent, luckColor } from './openable-analytics-modal-injector.js';
+import { detectImportSource, parseEdibleExport, parseCombatSuiteExport } from './openable-analytics-import-parsers.js';
 
 const INVENTORY_FILTER_CONTAINER_CLASS = 'Inventory_itemFilterContainer';
 const INVENTORY_BUTTON_CLASS = 'toolasha-openable-analytics-inventory-button';
 
-function luckColor(luckValue) {
-    if (luckValue === null || luckValue === undefined) return config.COLOR_TEXT_SECONDARY || '#888888';
-    return luckValue >= 0 ? config.COLOR_PROFIT : config.COLOR_LOSS;
-}
+const IMPORT_SOURCE_LABELS = {
+    'import:edible': 'Edible Tools',
+    'import:mwi-combat-suite': 'MWI Combat Suite',
+};
 
 function containerLabel(containerHrid) {
     const details = dataManager.getItemDetails(containerHrid);
@@ -36,17 +32,52 @@ function itemLabel(itemHrid) {
     return details?.name || itemHrid;
 }
 
+/** Signed large-number formatting for Luck: explicit `+` on positive, native `-` on negative, neutral on exactly zero. */
+function formatSignedLargeNumber(value) {
+    const rounded = Math.round(value);
+    const sign = rounded > 0 ? '+' : '';
+    return sign + formatLargeNumber(rounded);
+}
+
+function readEdibleLocalStorage() {
+    try {
+        return localStorage.getItem('Edible_Tools');
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Sort Loot rows: positive known value descending, then known-zero rows, then unavailable-value
+ * rows, then alphabetically by display name as a tie-breaker. Uses property existence (not
+ * truthiness) so a legitimate resolved value of 0 is never treated the same as "unavailable".
+ */
+function sortLootEntries(entries, itemValueTotals) {
+    const rank = (itemHrid) => {
+        if (!(itemHrid in itemValueTotals)) return 2;
+        return itemValueTotals[itemHrid] > 0 ? 0 : 1;
+    };
+    return [...entries].sort(([hridA], [hridB]) => {
+        const rankA = rank(hridA);
+        const rankB = rank(hridB);
+        if (rankA !== rankB) return rankA - rankB;
+        if (rankA === 0) return itemValueTotals[hridB] - itemValueTotals[hridA];
+        return itemLabel(hridA).localeCompare(itemLabel(hridB));
+    });
+}
+
 class OpenableAnalyticsUI {
     constructor() {
         this.isInitialized = false;
-        this.popup = null;
-        this.selectedContainer = null;
-        this.selectedScope = 'session';
-        this.importSourceKey = 'mwi-combat-suite';
-        this.importStatus = null;
-        this.pendingEdiblePlayers = null;
-        this.pendingEdibleRawText = null;
+        this.popupOverlay = null;
+        this.popupBody = null;
+        this.scope = 'lifetime';
+        this.expandedContainer = null;
+        this.manageDataOpen = false;
+        this.pendingImport = null;
+        this.mutationInFlight = false;
         this.unregisterInventoryButtonObserver = null;
+        this.unsubscribeStateChange = null;
     }
 
     initialize() {
@@ -54,64 +85,88 @@ class OpenableAnalyticsUI {
         this.isInitialized = true;
 
         openableAnalyticsModalInjector.initialize({
-            onViewAnalytics: (containerHrid) => this.showPopup(containerHrid),
+            onViewAnalytics: (containerHrid) => this.showPopup({ containerHrid }),
         });
 
-        // Persistent entry point: the "View Analytics" link inside the Opened Loot modal only
+        // Persistent entry point: the "View Analytics" link inside the Opened Loot footer only
         // exists right after opening something. This button in the Inventory panel's always-
-        // rendered search bar row lets it be opened at any time.
+        // rendered search bar row lets it be opened at any time. Catch up on any matching
+        // container that already exists before this feature initialized (OA-RUNTIME-1), in
+        // addition to watching for future mounts.
         this.unregisterInventoryButtonObserver = domObserver.onClass(
             'openableAnalyticsInventoryButton',
             INVENTORY_FILTER_CONTAINER_CLASS,
             (node) => this.injectInventoryButton(node)
         );
+        document
+            .querySelectorAll(`[class*="${INVENTORY_FILTER_CONTAINER_CLASS}"]`)
+            .forEach((node) => this.injectInventoryButton(node));
+
+        this.unsubscribeStateChange = openableAnalyticsDataCollector.onStateChange(() => this.refreshIfMounted());
     }
 
     injectInventoryButton(container) {
         if (container.querySelector(`.${INVENTORY_BUTTON_CLASS}`)) return;
 
-        const button = document.createElement('div');
+        const button = document.createElement('button');
+        button.type = 'button';
         button.className = INVENTORY_BUTTON_CLASS;
         button.textContent = '📊';
         button.title = 'Openable Analytics';
+        button.setAttribute('aria-label', 'Openable Analytics');
         button.style.cssText =
-            'cursor:pointer; margin-left:8px; font-size:16px; display:inline-flex; align-items:center;';
+            'cursor:pointer; margin-left:8px; font-size:16px; display:inline-flex; align-items:center; background:none; border:none; padding:2px;';
         button.onclick = () => this.showPopup();
 
         container.appendChild(button);
     }
 
-    showPopup(containerHrid) {
-        const known = openableAnalyticsDataCollector.getKnownContainers();
-        this.selectedContainer = containerHrid || known[0] || null;
-        this.selectedScope = 'session';
-        this.importStatus = null;
-        this.pendingEdiblePlayers = null;
-        this.pendingEdibleRawText = null;
-        this.createPopup();
+    /**
+     * @param {Object} [options]
+     * @param {string} [options.containerHrid] - When provided (View Analytics from a footer),
+     *      opens Lifetime with this container expanded and scrolled into view. Without it
+     *      (persistent Inventory entry point), opens Lifetime with all rows collapsed.
+     */
+    showPopup({ containerHrid } = {}) {
+        this.scope = 'lifetime';
+        this.expandedContainer =
+            containerHrid && openableAnalyticsDataCollector.getKnownContainers().includes(containerHrid)
+                ? containerHrid
+                : null;
+        this.manageDataOpen = false;
+        this.pendingImport = null;
+
+        if (!this.popupOverlay) {
+            this.buildShell();
+        }
+        this.renderBody();
+
+        if (this.expandedContainer) {
+            const row = [...this.popupBody.querySelectorAll('[data-container-hrid]')].find(
+                (el) => el.dataset.containerHrid === this.expandedContainer
+            );
+            row?.scrollIntoView?.({ block: 'nearest' });
+        }
     }
 
     closePopup() {
-        if (this.popup) {
-            this.popup.remove();
-            this.popup = null;
+        if (this.popupOverlay) {
+            this.popupOverlay.remove();
+            this.popupOverlay = null;
+            this.popupBody = null;
         }
     }
 
-    getActiveAggregate() {
-        if (!this.selectedContainer) return null;
-        return this.selectedScope === 'lifetime'
-            ? openableAnalyticsDataCollector.getLifetimeAggregate(this.selectedContainer)
-            : openableAnalyticsDataCollector.getSessionAggregate(this.selectedContainer);
+    /** Refresh in-place content only while the popup is currently mounted; never opens/recreates it. */
+    refreshIfMounted() {
+        if (!this.popupOverlay) return;
+        const scrollTop = this.popupBody.scrollTop;
+        this.renderBody();
+        this.popupBody.scrollTop = scrollTop;
     }
 
-    createPopup() {
-        if (this.popup) {
-            this.closePopup();
-        }
-
+    buildShell() {
         const textColor = config.COLOR_TEXT_PRIMARY;
-        const known = openableAnalyticsDataCollector.getKnownContainers();
 
         const overlay = document.createElement('div');
         overlay.className = 'toolasha-openable-analytics-overlay';
@@ -125,43 +180,41 @@ class OpenableAnalyticsUI {
         popup.className = 'toolasha-openable-analytics-popup';
         popup.style.cssText = `
             background: #1a1a1a; border: 2px solid #3a3a3a; border-radius: 8px;
-            padding: 20px; max-width: 90%; max-height: 90%; overflow-y: auto;
-            color: ${textColor}; min-width: 480px;
+            color: ${textColor}; width: min(560px, 92vw); max-height: 85vh;
+            display: flex; flex-direction: column; box-sizing: border-box; min-width: 0;
         `;
 
         const header = document.createElement('div');
         header.style.cssText = `
             display: flex; justify-content: space-between; align-items: center;
-            margin-bottom: 16px; border-bottom: 2px solid #3a3a3a; padding-bottom: 10px;
+            padding: 16px 20px; border-bottom: 2px solid #3a3a3a; flex-shrink: 0;
         `;
 
+        const titleWrap = document.createElement('div');
         const title = document.createElement('h2');
         title.textContent = 'Openable Analytics';
-        title.style.cssText = `margin: 0; color: ${textColor}; font-size: 22px;`;
+        title.style.cssText = `margin: 0; color: ${textColor}; font-size: 20px;`;
+        const characterName = document.createElement('div');
+        characterName.style.cssText = 'font-size:12px; opacity:0.7; margin-top:2px;';
+        characterName.textContent = dataManager.getCurrentCharacterName() || '';
+        titleWrap.appendChild(title);
+        titleWrap.appendChild(characterName);
 
         const closeButton = document.createElement('button');
+        closeButton.type = 'button';
         closeButton.textContent = '×';
-        closeButton.style.cssText = `background: none; border: none; color: ${textColor}; font-size: 32px; cursor: pointer; padding: 0; line-height: 1;`;
+        closeButton.setAttribute('aria-label', 'Close');
+        closeButton.style.cssText = `background: none; border: none; color: ${textColor}; font-size: 28px; cursor: pointer; padding: 0; line-height: 1;`;
         closeButton.onclick = () => this.closePopup();
 
-        header.appendChild(title);
+        header.appendChild(titleWrap);
         header.appendChild(closeButton);
         popup.appendChild(header);
 
-        if (known.length === 0) {
-            const empty = document.createElement('div');
-            empty.textContent = 'No openings recorded yet for this character.';
-            empty.style.opacity = '0.75';
-            empty.style.marginBottom = '16px';
-            popup.appendChild(empty);
-        } else {
-            popup.appendChild(this.buildControls(known));
-            popup.appendChild(this.buildSummary());
-            popup.appendChild(this.buildItemOutcomes());
-            popup.appendChild(this.buildResetControls());
-        }
-
-        popup.appendChild(this.buildImportPanel());
+        const body = document.createElement('div');
+        body.className = 'toolasha-openable-analytics-body';
+        body.style.cssText = 'padding: 16px 20px; overflow-y: auto; min-width: 0;';
+        popup.appendChild(body);
 
         overlay.appendChild(popup);
         document.body.appendChild(overlay);
@@ -170,268 +223,544 @@ class OpenableAnalyticsUI {
             if (e.target === overlay) this.closePopup();
         };
 
-        this.popup = overlay;
+        this.popupOverlay = overlay;
+        this.popupBody = body;
     }
 
-    buildControls(known) {
-        const container = document.createElement('div');
-        container.style.cssText = 'display:flex; gap:12px; margin-bottom:16px; align-items:center;';
-
-        const containerSelect = document.createElement('select');
-        containerSelect.style.cssText =
-            'background:#2a2a2a; color:#fff; border:1px solid #4a4a4a; padding:4px 8px; border-radius:4px;';
-        for (const hrid of known) {
-            const option = document.createElement('option');
-            option.value = hrid;
-            option.textContent = containerLabel(hrid);
-            if (hrid === this.selectedContainer) option.selected = true;
-            containerSelect.appendChild(option);
-        }
-        containerSelect.onchange = () => {
-            this.selectedContainer = containerSelect.value;
-            this.createPopup();
-        };
-
-        const scopeSelect = document.createElement('select');
-        scopeSelect.style.cssText =
-            'background:#2a2a2a; color:#fff; border:1px solid #4a4a4a; padding:4px 8px; border-radius:4px;';
-        for (const scope of ['session', 'lifetime']) {
-            const option = document.createElement('option');
-            option.value = scope;
-            option.textContent = scope === 'session' ? 'Session' : 'Lifetime';
-            if (scope === this.selectedScope) option.selected = true;
-            scopeSelect.appendChild(option);
-        }
-        scopeSelect.onchange = () => {
-            this.selectedScope = scopeSelect.value;
-            this.createPopup();
-        };
-
-        container.appendChild(containerSelect);
-        container.appendChild(scopeSelect);
-        return container;
+    getContainersForScope() {
+        return this.scope === 'session'
+            ? openableAnalyticsDataCollector.getSessionContainers()
+            : openableAnalyticsDataCollector.getKnownContainers();
     }
 
-    buildSummary() {
-        const aggregate = this.getActiveAggregate();
+    getAggregate(containerHrid) {
+        return this.scope === 'session'
+            ? openableAnalyticsDataCollector.getSessionAggregate(containerHrid)
+            : openableAnalyticsDataCollector.getLifetimeAggregate(containerHrid);
+    }
+
+    setScope(scope) {
+        if (scope === this.scope) return;
+        this.scope = scope;
+        const stillExists = this.getContainersForScope().includes(this.expandedContainer);
+        if (!stillExists) this.expandedContainer = null;
+        this.renderBody();
+    }
+
+    toggleContainer(containerHrid) {
+        this.expandedContainer = this.expandedContainer === containerHrid ? null : containerHrid;
+        this.renderBody();
+    }
+
+    renderBody() {
+        if (!this.popupBody) return;
+        this.popupBody.innerHTML = '';
+
+        this.popupBody.appendChild(this.buildScopeToggle());
+
+        const containers = this.getContainersForScope();
+        if (!this.getContainersForScope().includes(this.expandedContainer)) {
+            this.expandedContainer = null;
+        }
+
+        if (containers.length === 0) {
+            this.popupBody.appendChild(this.buildEmptyState());
+        } else {
+            this.popupBody.appendChild(this.buildAccordion(containers));
+        }
+
+        this.popupBody.appendChild(this.buildManageData());
+    }
+
+    buildScopeToggle() {
         const wrapper = document.createElement('div');
-        wrapper.style.cssText =
-            'background:#2a2a2a; border:1px solid #4a4a4a; border-radius:6px; padding:12px; margin-bottom:16px;';
+        wrapper.style.cssText = 'display:flex; gap:6px; margin-bottom:14px;';
 
-        // Aggregate Luck must fail closed as a whole (section 3.2): only available when every
-        // valuation record folded into this aggregate is itself Luck-eligible, never a
-        // subtraction of a partial/unavailable Expected subset from a superset Actual total.
-        const luckAvailable =
-            (aggregate.valuationRecordCount || 0) > 0 &&
-            aggregate.luckEligibleRecordCount === aggregate.valuationRecordCount;
-        const luckValue = luckAvailable ? aggregate.actualValueTotal - aggregate.expectedValueTotal : null;
-        const luckPercent =
-            luckAvailable && aggregate.expectedValueTotal > 0 ? (luckValue / aggregate.expectedValueTotal) * 100 : null;
-
-        const actualText = `${formatValue(aggregate.actualValueTotal)}${
-            aggregate.actualValuePartialEvents > 0 ? ' (partial)' : ''
-        }`;
-        const expectedHasAny = aggregate.expectedValueAvailableEvents > 0;
-        const expectedIsPartial =
-            aggregate.expectedValueUnavailableEvents > 0 || (aggregate.expectedValuePartialEvents || 0) > 0;
-        const expectedText = expectedHasAny
-            ? `${formatValue(aggregate.expectedValueTotal)}${expectedIsPartial ? ' (partial)' : ''}`
-            : 'N/A';
-
-        const rows = [
-            // Tracked opening events counts only real live loot_opened records - an imported
-            // cumulative snapshot represents many containers but only one synthetic Toolasha
-            // record, and must not be counted as one opening event (section 3.1).
-            ['Tracked opening events', aggregate.eventsCount],
-            ['Containers opened', aggregate.containersOpened],
-            ['Actual Value', actualText],
-            ['Expected Value', expectedText],
-            [
-                'Luck',
-                luckAvailable ? `${formatValue(luckValue)}${formatLuckPercent(luckPercent)}` : 'N/A',
-                luckAvailable ? luckColor(luckValue) : undefined,
-            ],
-        ];
-
-        if (aggregate.actualValuePartialEvents > 0) {
-            rows.push(['Partial-data events', aggregate.actualValuePartialEvents]);
+        for (const scope of ['session', 'lifetime']) {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = scope === 'session' ? 'Session' : 'Lifetime';
+            const active = scope === this.scope;
+            button.style.cssText = `
+                flex:1; padding:6px 10px; border-radius:4px; cursor:pointer; font-size:13px;
+                border:1px solid ${active ? config.COLOR_ACCENT : '#4a4a4a'};
+                background:${active ? config.COLOR_ACCENT : '#2a2a2a'};
+                color:${active ? '#0a0a0a' : '#fff'};
+            `;
+            button.onclick = () => this.setScope(scope);
+            wrapper.appendChild(button);
         }
-
-        for (const [label, value, color] of rows) {
-            const row = document.createElement('div');
-            row.style.cssText = 'display:flex; justify-content:space-between; padding:2px 0;';
-            const labelEl = document.createElement('span');
-            labelEl.textContent = label;
-            const valueEl = document.createElement('span');
-            valueEl.textContent = value;
-            if (color) valueEl.style.color = color;
-            row.appendChild(labelEl);
-            row.appendChild(valueEl);
-            wrapper.appendChild(row);
-        }
-
-        // Live and imported valuations are different concepts (section 3.3/3.4): live openings
-        // are event-time snapshots, while imported cumulative totals are necessarily revalued at
-        // import time and can double-count against an overlapping live/imported period.
-        const valuationNote = document.createElement('div');
-        valuationNote.style.cssText = 'margin-top:8px; font-size:11px; opacity:0.7; line-height:1.35;';
-        valuationNote.textContent =
-            this.selectedScope === 'lifetime' && aggregate.hasImportedData
-                ? 'Live values are event-time snapshots. Imported totals are revalued at import time. Imported sources are additive; overlapping periods/sources can double-count.'
-                : 'Live values are snapshotted using Toolasha pricing at the opening event.';
-        wrapper.appendChild(valuationNote);
 
         return wrapper;
     }
 
-    buildItemOutcomes() {
-        const aggregate = this.getActiveAggregate();
+    buildEmptyState() {
+        const wrapper = document.createElement('div');
+        wrapper.style.cssText = 'opacity:0.75; padding:12px 0; font-size:13px; line-height:1.5;';
+
+        if (this.scope === 'session') {
+            wrapper.textContent = 'No tracked chest, crate, or cache openings this session.';
+            return wrapper;
+        }
+
+        wrapper.innerHTML = 'No chest, crate, or cache history yet.<br>Open one to start tracking.<br>';
+        const importLink = document.createElement('span');
+        importLink.textContent = 'Import History';
+        importLink.style.cssText = 'cursor:pointer; text-decoration:underline;';
+        importLink.onclick = () => {
+            this.manageDataOpen = true;
+            this.renderBody();
+            this.popupBody.querySelector('.toolasha-openable-analytics-manage-data')?.scrollIntoView();
+        };
+        wrapper.appendChild(importLink);
+        return wrapper;
+    }
+
+    buildAccordion(containers) {
         const wrapper = document.createElement('div');
         wrapper.style.cssText = 'margin-bottom:16px;';
 
+        // Stable alphabetical order - never reordered by Luck/value/count/recent activity.
+        const sorted = [...containers].sort((a, b) => containerLabel(a).localeCompare(containerLabel(b)));
+
+        for (const containerHrid of sorted) {
+            wrapper.appendChild(this.buildAccordionRow(containerHrid));
+        }
+
+        return wrapper;
+    }
+
+    buildAccordionRow(containerHrid) {
+        const aggregate = this.getAggregate(containerHrid);
+        const isOpen = this.expandedContainer === containerHrid;
+
+        const details = document.createElement('details');
+        details.dataset.containerHrid = containerHrid;
+        details.open = isOpen;
+        details.style.cssText = 'border-bottom:1px solid #2a2a2a; padding:6px 0;';
+
+        const summary = document.createElement('summary');
+        summary.style.cssText =
+            'cursor:pointer; display:flex; align-items:center; gap:8px; list-style:none; font-size:13px;';
+        summary.onclick = (e) => {
+            e.preventDefault();
+            this.toggleContainer(containerHrid);
+        };
+
+        const name = document.createElement('span');
+        name.textContent = containerLabel(containerHrid);
+        name.style.cssText = 'flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;';
+
+        const count = document.createElement('span');
+        count.textContent = `×${aggregate.containersOpened}`;
+        count.style.cssText = 'flex-shrink:0; opacity:0.8;';
+
+        if (aggregate.hasImportedData) {
+            const infoMark = document.createElement('span');
+            infoMark.textContent = 'ⓘ';
+            infoMark.title = 'Includes imported historical data';
+            infoMark.style.cssText = `flex-shrink:0; color:${config.COLOR_INFO};`;
+            count.appendChild(document.createTextNode(' '));
+            count.appendChild(infoMark);
+        }
+
+        const luckEligible =
+            (aggregate.valuationRecordCount || 0) > 0 &&
+            aggregate.luckEligibleRecordCount === aggregate.valuationRecordCount;
+        const luckValue = luckEligible ? aggregate.actualValueTotal - aggregate.expectedValueTotal : null;
+        const luckPercent =
+            luckEligible && aggregate.expectedValueTotal > 0 ? (luckValue / aggregate.expectedValueTotal) * 100 : null;
+
+        const luck = document.createElement('span');
+        luck.style.cssText = 'flex-shrink:0; min-width:56px; text-align:right;';
+        if (!luckEligible) {
+            luck.textContent = '—';
+        } else if (luckPercent !== null) {
+            luck.textContent = formatLuckPercent(luckPercent)
+                .trim()
+                .replace(/^\(|\)$/g, '');
+            luck.style.color = luckColor(luckValue);
+        } else {
+            // Complete Expected of exactly zero: percent is meaningless, but the absolute Luck
+            // value is still valid - show that instead of making the row look unavailable.
+            luck.textContent = formatSignedLargeNumber(luckValue);
+            luck.style.color = luckColor(luckValue);
+        }
+
+        summary.appendChild(name);
+        summary.appendChild(count);
+        summary.appendChild(luck);
+        details.appendChild(summary);
+
+        if (isOpen) {
+            details.appendChild(this.buildExpandedDetails(containerHrid, aggregate));
+        }
+
+        return details;
+    }
+
+    buildExpandedDetails(containerHrid, aggregate) {
+        const wrapper = document.createElement('div');
+        wrapper.style.cssText = 'padding:10px 4px 4px 4px;';
+
+        const luckEligible =
+            (aggregate.valuationRecordCount || 0) > 0 &&
+            aggregate.luckEligibleRecordCount === aggregate.valuationRecordCount;
+        const luckValue = luckEligible ? aggregate.actualValueTotal - aggregate.expectedValueTotal : null;
+        const luckPercent =
+            luckEligible && aggregate.expectedValueTotal > 0 ? (luckValue / aggregate.expectedValueTotal) * 100 : null;
+
+        const summaryRow = document.createElement('div');
+        summaryRow.style.cssText = 'display:flex; justify-content:space-between; margin-bottom:10px; font-size:13px;';
+
+        const actualCol = document.createElement('div');
+        actualCol.innerHTML = `<div style="opacity:0.7; font-size:11px;">Actual</div>${formatLargeNumber(aggregate.actualValueTotal)}${aggregate.actualValuePartialEvents > 0 ? ' <span title="One or more openings/imports could not be fully priced">[Partial]</span>' : ''}`;
+
+        const expectedCol = document.createElement('div');
+        const expectedHasAny = aggregate.expectedValueAvailableEvents > 0;
+        expectedCol.innerHTML = `<div style="opacity:0.7; font-size:11px;">Expected</div>${expectedHasAny ? formatLargeNumber(aggregate.expectedValueTotal) : '—'}`;
+
+        const luckCol = document.createElement('div');
+        luckCol.style.textAlign = 'right';
+        const luckHeader = document.createElement('div');
+        luckHeader.style.cssText = 'opacity:0.7; font-size:11px;';
+        const luckInfo = document.createElement('span');
+        luckInfo.textContent = 'Luck ⓘ';
+        luckInfo.title =
+            'Luck is Actual loot value minus Expected loot value. It does not include the container/key cost and is not opening profit.';
+        luckHeader.appendChild(luckInfo);
+        const luckValueEl = document.createElement('div');
+        if (!luckEligible) {
+            luckValueEl.textContent = '—';
+        } else {
+            luckValueEl.textContent =
+                formatSignedLargeNumber(luckValue) + (luckPercent !== null ? formatLuckPercent(luckPercent) : '');
+            luckValueEl.style.color = luckColor(luckValue);
+        }
+        luckCol.appendChild(luckHeader);
+        luckCol.appendChild(luckValueEl);
+
+        summaryRow.appendChild(actualCol);
+        summaryRow.appendChild(expectedCol);
+        summaryRow.appendChild(luckCol);
+        wrapper.appendChild(summaryRow);
+
+        if (aggregate.hasImportedData) {
+            const note = document.createElement('div');
+            note.style.cssText = 'font-size:11px; opacity:0.7; margin-bottom:10px; line-height:1.35;';
+            note.textContent =
+                'Includes imported historical data: imported raw counts are recalculated using current Toolasha prices/loot model at import time, and imported/live periods may overlap.';
+            wrapper.appendChild(note);
+        }
+
+        wrapper.appendChild(this.buildLootTable(aggregate));
+
+        if (this.expandedContainer) {
+            const deleteRow = document.createElement('div');
+            deleteRow.style.cssText = 'margin-top:10px;';
+            const deleteButton = document.createElement('button');
+            deleteButton.type = 'button';
+            deleteButton.textContent = `Delete ${containerLabel(containerHrid)} Data…`;
+            deleteButton.disabled = this.mutationInFlight;
+            deleteButton.style.cssText = this.destructiveButtonStyle();
+            deleteButton.onclick = () => this.handleDeleteContainer(containerHrid);
+            deleteRow.appendChild(deleteButton);
+            wrapper.appendChild(deleteRow);
+        }
+
+        return wrapper;
+    }
+
+    buildLootTable(aggregate) {
+        const wrapper = document.createElement('div');
+
         const heading = document.createElement('div');
-        heading.textContent = 'Aggregated Item Outcomes';
-        heading.style.cssText = 'font-weight:600; margin-bottom:6px;';
+        heading.textContent = 'Loot';
+        heading.style.cssText = 'font-weight:600; margin-bottom:6px; font-size:13px;';
         wrapper.appendChild(heading);
 
-        const entries = Object.entries(aggregate.itemTotals || {}).sort((a, b) => b[1] - a[1]);
+        const entries = Object.entries(aggregate.itemTotals || {});
         if (entries.length === 0) {
             const empty = document.createElement('div');
             empty.textContent = 'No items gained in this scope.';
-            empty.style.opacity = '0.75';
+            empty.style.cssText = 'opacity:0.75; font-size:12px;';
             wrapper.appendChild(empty);
             return wrapper;
         }
 
-        for (const [itemHrid, count] of entries) {
+        const itemValueTotals = aggregate.itemValueTotals || {};
+        const sorted = sortLootEntries(entries, itemValueTotals);
+
+        const table = document.createElement('table');
+        table.style.cssText = 'width:100%; border-collapse:collapse; font-size:12px;';
+
+        const headerRow = document.createElement('tr');
+        headerRow.style.cssText = 'opacity:0.7; text-align:left;';
+        headerRow.innerHTML = `<th style="font-weight:400; padding:2px 0;">Item</th><th style="font-weight:400; text-align:right; padding:2px 0;">Qty</th><th style="font-weight:400; text-align:right; padding:2px 0;">Value <span title="Values are the amounts recorded at each opening/import, not current market value.">ⓘ</span></th>`;
+        table.appendChild(headerRow);
+
+        for (const [itemHrid, count] of sorted) {
+            const row = document.createElement('tr');
+            const hasValue = itemHrid in itemValueTotals;
+            const valueText = hasValue ? formatLargeNumber(itemValueTotals[itemHrid]) : '—';
+            row.innerHTML = `<td style="padding:2px 0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; max-width:0;">${itemLabel(itemHrid)}</td><td style="text-align:right; padding:2px 0;">${formatLargeNumber(count)}</td><td style="text-align:right; padding:2px 0;">${valueText}</td>`;
+            table.appendChild(row);
+        }
+
+        wrapper.appendChild(table);
+        return wrapper;
+    }
+
+    destructiveButtonStyle() {
+        return 'background:#4a2a2a; border:1px solid #5a3a3a; color:#fff; font-size:12px; cursor:pointer; padding:6px 12px; border-radius:4px;';
+    }
+
+    buildManageData() {
+        const details = document.createElement('details');
+        details.className = 'toolasha-openable-analytics-manage-data';
+        details.open = this.manageDataOpen;
+        details.style.cssText = 'margin-top:8px; border-top:1px solid #3a3a3a; padding-top:10px;';
+
+        const summary = document.createElement('summary');
+        summary.textContent = 'Manage Data';
+        summary.style.cssText = 'cursor:pointer; font-weight:600; font-size:13px; list-style:none;';
+        summary.onclick = (e) => {
+            e.preventDefault();
+            this.manageDataOpen = !this.manageDataOpen;
+            this.renderBody();
+        };
+        details.appendChild(summary);
+
+        if (this.manageDataOpen) {
+            const content = document.createElement('div');
+            content.style.cssText = 'padding-top:10px;';
+            content.appendChild(this.buildImportSourceList());
+            content.appendChild(this.buildImportControls());
+            content.appendChild(this.buildDeleteAllControl());
+            details.appendChild(content);
+        }
+
+        return details;
+    }
+
+    buildImportSourceList() {
+        const wrapper = document.createElement('div');
+        wrapper.style.cssText = 'margin-bottom:12px;';
+
+        const heading = document.createElement('div');
+        heading.textContent = 'Historical Imports';
+        heading.style.cssText = 'font-weight:600; font-size:12px; margin-bottom:6px;';
+        wrapper.appendChild(heading);
+
+        const sources = openableAnalyticsDataCollector.getImportSourceKeys();
+        if (sources.length === 0) {
+            const empty = document.createElement('div');
+            empty.textContent = 'No imported sources.';
+            empty.style.cssText = 'opacity:0.7; font-size:12px;';
+            wrapper.appendChild(empty);
+            return wrapper;
+        }
+
+        for (const source of sources) {
             const row = document.createElement('div');
-            row.style.cssText = 'display:flex; justify-content:space-between; padding:2px 0; font-size:13px;';
-            const labelEl = document.createElement('span');
-            labelEl.textContent = itemLabel(itemHrid);
-            const valueEl = document.createElement('span');
-            const itemValue = aggregate.itemValueTotals?.[itemHrid];
-            valueEl.textContent = itemValue !== undefined ? `${count} (${formatValue(itemValue)})` : `${count} (N/A)`;
-            row.appendChild(labelEl);
-            row.appendChild(valueEl);
+            row.style.cssText = 'display:flex; justify-content:space-between; align-items:center; padding:4px 0;';
+
+            const label = document.createElement('span');
+            label.textContent = IMPORT_SOURCE_LABELS[source] || source;
+            label.style.cssText = 'font-size:12px;';
+
+            const removeButton = document.createElement('button');
+            removeButton.type = 'button';
+            removeButton.textContent = 'Remove Import';
+            removeButton.disabled = this.mutationInFlight;
+            removeButton.style.cssText =
+                'background:#3a3a3a; border:1px solid #4a4a4a; color:#fff; font-size:11px; cursor:pointer; padding:4px 8px; border-radius:4px;';
+            removeButton.onclick = () => this.handleRemoveImport(source);
+
+            row.appendChild(label);
+            row.appendChild(removeButton);
             wrapper.appendChild(row);
         }
 
         return wrapper;
     }
 
-    buildResetControls() {
+    buildImportControls() {
         const wrapper = document.createElement('div');
-        wrapper.style.cssText = 'display:flex; gap:10px; padding-top:10px; border-top:1px solid #3a3a3a;';
-
-        const resetContainerButton = document.createElement('button');
-        resetContainerButton.textContent = 'Reset This Container';
-        resetContainerButton.style.cssText =
-            'background:#4a4a4a; border:1px solid #5a5a5a; color:#fff; font-size:12px; cursor:pointer; padding:6px 12px; border-radius:4px;';
-        resetContainerButton.onclick = async () => {
-            if (
-                confirm(
-                    `Reset all Openable Analytics history for ${containerLabel(this.selectedContainer)}? This cannot be undone.`
-                )
-            ) {
-                await openableAnalyticsDataCollector.resetContainer(this.selectedContainer);
-                this.showPopup();
-            }
-        };
-
-        const resetAllButton = document.createElement('button');
-        resetAllButton.textContent = 'Reset All Openable Analytics';
-        resetAllButton.style.cssText =
-            'background:#4a4a4a; border:1px solid #5a5a5a; color:#fff; font-size:12px; cursor:pointer; padding:6px 12px; border-radius:4px;';
-        resetAllButton.onclick = async () => {
-            if (confirm('Reset ALL Openable Analytics history for this character? This cannot be undone.')) {
-                await openableAnalyticsDataCollector.resetAll();
-                this.closePopup();
-            }
-        };
-
-        wrapper.appendChild(resetContainerButton);
-        wrapper.appendChild(resetAllButton);
-        return wrapper;
-    }
-
-    buildImportPanel() {
-        const wrapper = document.createElement('div');
-        wrapper.style.cssText = 'padding-top:16px; border-top:1px solid #3a3a3a;';
+        wrapper.style.cssText = 'margin-bottom:12px; padding-top:10px; border-top:1px solid #2a2a2a;';
 
         const heading = document.createElement('div');
-        heading.textContent = 'Import Historical Data';
-        heading.style.cssText = 'font-weight:600; margin-bottom:6px;';
+        heading.textContent = 'Import History';
+        heading.style.cssText = 'font-weight:600; font-size:12px; margin-bottom:6px;';
         wrapper.appendChild(heading);
 
-        const help = document.createElement('div');
-        help.style.cssText = 'font-size:12px; opacity:0.75; margin-bottom:8px;';
-        help.textContent =
-            "Adds a cumulative source snapshot to Lifetime and revalues it at import time using Toolasha's current pricing. It does not add individual opening events (these sources only keep running totals, not per-opening history). Re-importing the same source replaces that entire source snapshot. Different sources are additive; importing overlapping periods/sources can double-count because the source data has no per-opening timestamps/IDs for reliable deduplication.";
-        wrapper.appendChild(help);
-
-        if (this.pendingEdiblePlayers) {
+        if (this.pendingImport?.needsPlayerSelection) {
             wrapper.appendChild(this.buildEdiblePlayerPicker());
             return wrapper;
         }
 
-        const controls = document.createElement('div');
-        controls.style.cssText = 'display:flex; gap:8px; align-items:center; margin-bottom:8px; flex-wrap:wrap;';
-
-        const sourceSelect = document.createElement('select');
-        sourceSelect.style.cssText =
-            'background:#2a2a2a; color:#fff; border:1px solid #4a4a4a; padding:4px 8px; border-radius:4px;';
-        for (const { key, label } of IMPORT_SOURCES) {
-            const option = document.createElement('option');
-            option.value = key;
-            option.textContent = label;
-            if (key === this.importSourceKey) option.selected = true;
-            sourceSelect.appendChild(option);
+        if (this.pendingImport?.preflight) {
+            wrapper.appendChild(this.buildImportPreflight());
+            return wrapper;
         }
-        sourceSelect.onchange = () => {
-            this.importSourceKey = sourceSelect.value;
-        };
 
+        const controls = document.createElement('div');
+        controls.style.cssText = 'display:flex; gap:8px; flex-wrap:wrap; margin-bottom:8px;';
+
+        if (readEdibleLocalStorage() !== null) {
+            const edibleButton = document.createElement('button');
+            edibleButton.type = 'button';
+            edibleButton.textContent = 'Import from Edible Tools';
+            edibleButton.style.cssText = this.controlButtonStyle();
+            edibleButton.onclick = () => this.beginImport(readEdibleLocalStorage(), 'edible');
+            controls.appendChild(edibleButton);
+        }
+
+        const fileButtonWrap = document.createElement('div');
+        fileButtonWrap.style.cssText = 'position:relative; overflow:hidden; display:inline-block;';
+        const fileButton = document.createElement('button');
+        fileButton.type = 'button';
+        fileButton.textContent = 'Choose JSON File';
+        fileButton.style.cssText = this.controlButtonStyle();
         const fileInput = document.createElement('input');
         fileInput.type = 'file';
         fileInput.accept = '.json,application/json,text/plain';
-        fileInput.style.cssText = 'font-size:12px; max-width:180px;';
-
-        controls.appendChild(sourceSelect);
-        controls.appendChild(fileInput);
-        wrapper.appendChild(controls);
-
-        const textarea = document.createElement('textarea');
-        textarea.placeholder =
-            "Paste exported/copied data here (MWI Combat Suite: paste the exported .json file contents. Edible Tools: paste the value of localStorage.getItem('Edible_Tools') from your browser devtools).";
-        textarea.style.cssText =
-            'width:100%; height:70px; background:#2a2a2a; color:#fff; border:1px solid #4a4a4a; border-radius:4px; padding:6px; font-size:12px; box-sizing:border-box; resize:vertical;';
-        wrapper.appendChild(textarea);
-
+        fileInput.style.cssText = 'position:absolute; inset:0; opacity:0; cursor:pointer; width:100%; height:100%;';
         fileInput.onchange = () => {
             const file = fileInput.files?.[0];
             if (!file) return;
             const reader = new FileReader();
-            reader.onload = () => {
-                textarea.value = String(reader.result || '');
+            reader.onload = () => this.beginImport(String(reader.result || ''));
+            reader.onerror = () => {
+                this.pendingImport = { errorMessage: 'Could not read the selected file.' };
+                this.renderBody();
             };
             reader.readAsText(file);
         };
+        fileButtonWrap.appendChild(fileButton);
+        fileButtonWrap.appendChild(fileInput);
+        controls.appendChild(fileButtonWrap);
 
-        const importButton = document.createElement('button');
-        importButton.textContent = 'Import';
-        importButton.style.cssText =
-            'margin-top:8px; background:#4a4a4a; border:1px solid #5a5a5a; color:#fff; font-size:12px; cursor:pointer; padding:6px 12px; border-radius:4px;';
-        importButton.onclick = () => this.handleImportSubmit(textarea.value);
-        wrapper.appendChild(importButton);
+        const pasteLink = document.createElement('span');
+        pasteLink.textContent = 'Paste JSON Instead';
+        pasteLink.style.cssText = 'cursor:pointer; text-decoration:underline; font-size:12px; align-self:center;';
+        pasteLink.onclick = () => {
+            this.showPasteArea = true;
+            this.renderBody();
+        };
+        wrapper.appendChild(controls);
 
-        if (this.importStatus) {
+        if (this.showPasteArea) {
+            const textarea = document.createElement('textarea');
+            textarea.placeholder = 'Paste exported JSON here (Edible Tools or MWI Combat Suite).';
+            textarea.style.cssText =
+                'width:100%; height:70px; background:#2a2a2a; color:#fff; border:1px solid #4a4a4a; border-radius:4px; padding:6px; font-size:12px; box-sizing:border-box; resize:vertical; margin-bottom:6px;';
+            wrapper.appendChild(textarea);
+
+            const submitButton = document.createElement('button');
+            submitButton.type = 'button';
+            submitButton.textContent = 'Preview Import';
+            submitButton.style.cssText = this.controlButtonStyle();
+            submitButton.onclick = () => this.beginImport(textarea.value);
+            wrapper.appendChild(submitButton);
+        } else {
+            wrapper.appendChild(pasteLink);
+        }
+
+        if (this.pendingImport?.errorMessage) {
+            const error = document.createElement('div');
+            error.style.cssText = `margin-top:8px; font-size:12px; color:${config.COLOR_WARNING};`;
+            error.textContent = this.pendingImport.errorMessage;
+            wrapper.appendChild(error);
+        }
+
+        if (this.pendingImport?.statusMessage) {
             const status = document.createElement('div');
             status.style.cssText = 'margin-top:8px; font-size:12px; opacity:0.9;';
-            status.textContent = this.importStatus;
+            status.textContent = this.pendingImport.statusMessage;
             wrapper.appendChild(status);
         }
 
         return wrapper;
+    }
+
+    controlButtonStyle() {
+        return 'background:#3a3a3a; border:1px solid #4a4a4a; color:#fff; font-size:12px; cursor:pointer; padding:6px 10px; border-radius:4px;';
+    }
+
+    /** Parse pasted/uploaded/one-click text, auto-detecting the source unless explicitly known (Edible one-click). */
+    beginImport(rawText, knownSource) {
+        if (!rawText?.trim()) {
+            this.pendingImport = { errorMessage: 'No data found to import.' };
+            this.renderBody();
+            return;
+        }
+
+        let source = knownSource;
+        if (!source) {
+            const detected = detectImportSource(rawText);
+            if (!detected.source) {
+                this.pendingImport = { errorMessage: detected.error };
+                this.renderBody();
+                return;
+            }
+            source = detected.source;
+        }
+
+        const result = source === 'edible' ? parseEdibleExport(rawText) : parseCombatSuiteExport(rawText);
+        this.applyParseResult(source, rawText, result);
+    }
+
+    applyParseResult(source, rawText, result) {
+        if (result.needsPlayerSelection) {
+            this.pendingImport = { needsPlayerSelection: true, players: result.players, rawText, source };
+            this.renderBody();
+            return;
+        }
+
+        if (result.status === 'invalid') {
+            this.pendingImport = { errorMessage: result.message };
+            this.renderBody();
+            return;
+        }
+
+        if (result.status === 'empty') {
+            this.pendingImport = { statusMessage: result.message };
+            this.renderBody();
+            return;
+        }
+
+        const prefixedSource = `import:${source}`;
+        const alreadyExists = openableAnalyticsDataCollector.getImportSourceKeys().includes(prefixedSource);
+        const overlaps = this.detectOverlap(prefixedSource, result.containers);
+
+        this.pendingImport = {
+            source,
+            prefixedSource,
+            containers: result.containers,
+            warnings: result.warnings,
+            alreadyExists,
+            overlaps,
+            ownerMismatch: result.ownerMismatch,
+            ownerName: result.ownerName,
+            preflight: true,
+        };
+        this.renderBody();
+    }
+
+    detectOverlap(prefixedSource, containers) {
+        const otherImportedHrids = new Set();
+        for (const source of openableAnalyticsDataCollector.getImportSourceKeys()) {
+            if (source === prefixedSource) continue;
+            for (const hrid of openableAnalyticsDataCollector.getImportedContainerHrids(source)) {
+                otherImportedHrids.add(hrid);
+            }
+        }
+
+        return containers.some(({ containerHrid }) => {
+            const hasLive = openableAnalyticsDataCollector.getLiveLifetimeAggregate(containerHrid).eventsCount > 0;
+            return hasLive || otherImportedHrids.has(containerHrid);
+        });
     }
 
     buildEdiblePlayerPicker() {
@@ -445,7 +774,7 @@ class OpenableAnalyticsUI {
         const select = document.createElement('select');
         select.style.cssText =
             'background:#2a2a2a; color:#fff; border:1px solid #4a4a4a; padding:4px 8px; border-radius:4px; margin-right:8px;';
-        for (const player of this.pendingEdiblePlayers) {
+        for (const player of this.pendingImport.players) {
             const option = document.createElement('option');
             option.value = player.id;
             option.textContent = player.name;
@@ -454,59 +783,176 @@ class OpenableAnalyticsUI {
         wrapper.appendChild(select);
 
         const confirmButton = document.createElement('button');
-        confirmButton.textContent = 'Import for this player';
-        confirmButton.style.cssText =
-            'background:#4a4a4a; border:1px solid #5a5a5a; color:#fff; font-size:12px; cursor:pointer; padding:6px 12px; border-radius:4px;';
-        confirmButton.onclick = () => this.handleEdiblePlayerSelected(select.value);
-        wrapper.appendChild(confirmButton);
+        confirmButton.type = 'button';
+        confirmButton.textContent = 'Continue';
+        confirmButton.style.cssText = this.controlButtonStyle();
+        confirmButton.onclick = () => {
+            const result = parseEdibleExport(this.pendingImport.rawText, { playerId: select.value });
+            this.applyParseResult('edible', this.pendingImport.rawText, result);
+        };
 
+        const cancelButton = document.createElement('button');
+        cancelButton.type = 'button';
+        cancelButton.textContent = 'Cancel';
+        cancelButton.style.cssText = this.controlButtonStyle() + 'margin-left:6px;';
+        cancelButton.onclick = () => {
+            this.pendingImport = null;
+            this.renderBody();
+        };
+
+        wrapper.appendChild(confirmButton);
+        wrapper.appendChild(cancelButton);
         return wrapper;
     }
 
-    async handleImportSubmit(rawText) {
-        if (!rawText?.trim()) {
-            this.importStatus = 'Paste or upload some data first.';
-            this.createPopup();
+    buildImportPreflight() {
+        const { source, containers, warnings, alreadyExists, overlaps, ownerMismatch, ownerName } = this.pendingImport;
+        const wrapper = document.createElement('div');
+
+        const summary = document.createElement('div');
+        const totalOpenings = containers.reduce((sum, c) => sum + c.containerCount, 0);
+        summary.style.cssText = 'font-size:12px; margin-bottom:6px;';
+        summary.textContent = `${IMPORT_SOURCE_LABELS[`import:${source}`]}: ${formatLargeNumber(totalOpenings)} openings across ${containers.length} container(s) ready to import.`;
+        wrapper.appendChild(summary);
+
+        if (ownerMismatch === true) {
+            const warn = document.createElement('div');
+            warn.style.cssText = `font-size:12px; color:${config.COLOR_WARNING}; margin-bottom:6px;`;
+            warn.textContent = `This export's recorded player ("${ownerName}") does not match the current character.`;
+            wrapper.appendChild(warn);
+        } else if (ownerMismatch === null) {
+            const warn = document.createElement('div');
+            warn.style.cssText = `font-size:12px; color:${config.COLOR_WARNING}; margin-bottom:6px;`;
+            warn.textContent = 'This export does not record which character it belongs to - please verify ownership.';
+            wrapper.appendChild(warn);
+        }
+
+        if (overlaps) {
+            const warn = document.createElement('div');
+            warn.style.cssText = `font-size:12px; color:${config.COLOR_INFO}; margin-bottom:6px;`;
+            warn.textContent =
+                'These cumulative histories may cover the same openings and cannot be reliably deduplicated.';
+            wrapper.appendChild(warn);
+        }
+
+        if (warnings?.length > 0) {
+            const warn = document.createElement('div');
+            warn.style.cssText = 'font-size:11px; opacity:0.75; margin-bottom:6px;';
+            warn.textContent = warnings.join(' ');
+            wrapper.appendChild(warn);
+        }
+
+        const confirmButton = document.createElement('button');
+        confirmButton.type = 'button';
+        confirmButton.textContent = this.mutationInFlight ? 'Importing…' : alreadyExists ? 'Replace Import…' : 'Import';
+        confirmButton.disabled = this.mutationInFlight;
+        confirmButton.style.cssText = this.controlButtonStyle();
+        confirmButton.onclick = () => this.handleConfirmImport();
+
+        const cancelButton = document.createElement('button');
+        cancelButton.type = 'button';
+        cancelButton.textContent = 'Cancel';
+        cancelButton.disabled = this.mutationInFlight;
+        cancelButton.style.cssText = this.controlButtonStyle() + 'margin-left:6px;';
+        cancelButton.onclick = () => {
+            this.pendingImport = null;
+            this.renderBody();
+        };
+
+        wrapper.appendChild(confirmButton);
+        wrapper.appendChild(cancelButton);
+        return wrapper;
+    }
+
+    async handleConfirmImport() {
+        const { prefixedSource, containers, alreadyExists } = this.pendingImport;
+        this.mutationInFlight = true;
+        this.renderBody();
+
+        const { persisted } = await openableAnalyticsDataCollector.importContainers(prefixedSource, containers);
+
+        // The popup may have been closed while this awaited - never resurrect/recreate it.
+        this.mutationInFlight = false;
+        if (!this.popupOverlay) return;
+
+        const totalOpenings = containers.reduce((sum, c) => sum + c.containerCount, 0);
+        this.pendingImport = persisted
+            ? {
+                  statusMessage: `${alreadyExists ? 'Replaced' : 'Imported'} ${IMPORT_SOURCE_LABELS[prefixedSource]} import: ${formatLargeNumber(totalOpenings)} openings across ${containers.length} container(s).`,
+              }
+            : { errorMessage: 'Could not save Openable Analytics data. Current changes may not persist after reload.' };
+        this.showPasteArea = false;
+        this.renderBody();
+    }
+
+    async handleRemoveImport(source) {
+        this.mutationInFlight = true;
+        this.renderBody();
+
+        const persisted = await openableAnalyticsDataCollector.removeImport(source);
+
+        this.mutationInFlight = false;
+        if (!this.popupOverlay) return;
+
+        if (!persisted) {
+            this.pendingImport = { errorMessage: 'Could not remove the imported data. It may reappear after reload.' };
+        } else {
+            this.pendingImport = {
+                statusMessage: `Removed ${IMPORT_SOURCE_LABELS[source]} import. Live Toolasha history was kept.`,
+            };
+        }
+        this.renderBody();
+    }
+
+    async handleDeleteContainer(containerHrid) {
+        if (
+            !confirm(
+                `Delete all Openable Analytics data for ${containerLabel(containerHrid)} on this character? This cannot be undone.`
+            )
+        ) {
             return;
         }
 
-        const result = this.importSourceKey === 'edible' ? parseEdibleExport(rawText) : parseCombatSuiteExport(rawText);
+        this.mutationInFlight = true;
+        this.renderBody();
 
-        if (result.needsPlayerSelection) {
-            this.pendingEdiblePlayers = result.players;
-            this.pendingEdibleRawText = rawText;
-            this.createPopup();
+        await openableAnalyticsDataCollector.resetContainer(containerHrid);
+
+        this.mutationInFlight = false;
+        if (!this.popupOverlay) return;
+        this.renderBody();
+    }
+
+    buildDeleteAllControl() {
+        const wrapper = document.createElement('div');
+        wrapper.style.cssText = 'padding-top:10px; border-top:1px solid #2a2a2a;';
+
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = 'Delete All Analytics Data…';
+        button.disabled = this.mutationInFlight;
+        button.style.cssText = this.destructiveButtonStyle();
+        button.onclick = () => this.handleDeleteAll();
+
+        wrapper.appendChild(button);
+        return wrapper;
+    }
+
+    async handleDeleteAll() {
+        const characterName = dataManager.getCurrentCharacterName() || 'this character';
+        if (!confirm(`Delete ALL Openable Analytics data for ${characterName}? This cannot be undone.`)) {
             return;
         }
 
-        const sourceEntry = IMPORT_SOURCES.find((entry) => entry.key === this.importSourceKey);
-        await this.applyImportResult(sourceEntry.prefixedSource, result);
-    }
+        this.mutationInFlight = true;
+        this.renderBody();
 
-    async handleEdiblePlayerSelected(playerId) {
-        const result = parseEdibleExport(this.pendingEdibleRawText, { playerId });
-        this.pendingEdiblePlayers = null;
-        this.pendingEdibleRawText = null;
-        await this.applyImportResult('import:edible', result);
-    }
+        await openableAnalyticsDataCollector.resetAll();
 
-    async applyImportResult(source, result) {
-        if (result.containers.length > 0) {
-            await openableAnalyticsDataCollector.importContainers(source, result.containers);
-        }
-
-        const importedCount = result.containers.length;
-        const warningsText = result.warnings.length > 0 ? ` ${result.warnings.join(' ')}` : '';
-        this.importStatus =
-            importedCount > 0
-                ? `Imported ${importedCount} container(s).${warningsText}`
-                : `Nothing imported.${warningsText}`;
-
-        if (!this.selectedContainer && result.containers[0]) {
-            this.selectedContainer = result.containers[0].containerHrid;
-        }
-
-        this.createPopup();
+        this.mutationInFlight = false;
+        if (!this.popupOverlay) return;
+        // Delete All does not silently close the popup - show the resulting empty state in place.
+        this.renderBody();
     }
 
     cleanup() {
@@ -516,7 +962,12 @@ class OpenableAnalyticsUI {
             this.unregisterInventoryButtonObserver();
             this.unregisterInventoryButtonObserver = null;
         }
+        if (this.unsubscribeStateChange) {
+            this.unsubscribeStateChange();
+            this.unsubscribeStateChange = null;
+        }
         this.isInitialized = false;
+        this.showPasteArea = false;
     }
 }
 

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.js
@@ -218,16 +218,34 @@ class OpenableAnalyticsUI {
         wrapper.style.cssText =
             'background:#2a2a2a; border:1px solid #4a4a4a; border-radius:6px; padding:12px; margin-bottom:16px;';
 
-        const luckAvailable = aggregate.expectedValueAvailableEvents > 0;
+        // Aggregate Luck must fail closed as a whole (section 3.2): only available when every
+        // valuation record folded into this aggregate is itself Luck-eligible, never a
+        // subtraction of a partial/unavailable Expected subset from a superset Actual total.
+        const luckAvailable =
+            (aggregate.valuationRecordCount || 0) > 0 &&
+            aggregate.luckEligibleRecordCount === aggregate.valuationRecordCount;
         const luckValue = luckAvailable ? aggregate.actualValueTotal - aggregate.expectedValueTotal : null;
         const luckPercent =
             luckAvailable && aggregate.expectedValueTotal > 0 ? (luckValue / aggregate.expectedValueTotal) * 100 : null;
 
+        const actualText = `${formatValue(aggregate.actualValueTotal)}${
+            aggregate.actualValuePartialEvents > 0 ? ' (partial)' : ''
+        }`;
+        const expectedHasAny = aggregate.expectedValueAvailableEvents > 0;
+        const expectedIsPartial =
+            aggregate.expectedValueUnavailableEvents > 0 || (aggregate.expectedValuePartialEvents || 0) > 0;
+        const expectedText = expectedHasAny
+            ? `${formatValue(aggregate.expectedValueTotal)}${expectedIsPartial ? ' (partial)' : ''}`
+            : 'N/A';
+
         const rows = [
-            ['Opening events', aggregate.eventsCount],
+            // Tracked opening events counts only real live loot_opened records - an imported
+            // cumulative snapshot represents many containers but only one synthetic Toolasha
+            // record, and must not be counted as one opening event (section 3.1).
+            ['Tracked opening events', aggregate.eventsCount],
             ['Containers opened', aggregate.containersOpened],
-            ['Actual Value', formatValue(aggregate.actualValueTotal)],
-            ['Expected Value', luckAvailable ? formatValue(aggregate.expectedValueTotal) : 'N/A'],
+            ['Actual Value', actualText],
+            ['Expected Value', expectedText],
             [
                 'Luck',
                 luckAvailable ? `${formatValue(luckValue)}${formatLuckPercent(luckPercent)}` : 'N/A',
@@ -251,6 +269,17 @@ class OpenableAnalyticsUI {
             row.appendChild(valueEl);
             wrapper.appendChild(row);
         }
+
+        // Live and imported valuations are different concepts (section 3.3/3.4): live openings
+        // are event-time snapshots, while imported cumulative totals are necessarily revalued at
+        // import time and can double-count against an overlapping live/imported period.
+        const valuationNote = document.createElement('div');
+        valuationNote.style.cssText = 'margin-top:8px; font-size:11px; opacity:0.7; line-height:1.35;';
+        valuationNote.textContent =
+            this.selectedScope === 'lifetime' && aggregate.hasImportedData
+                ? 'Live values are event-time snapshots. Imported totals are revalued at import time. Imported sources are additive; overlapping periods/sources can double-count.'
+                : 'Live values are snapshotted using Toolasha pricing at the opening event.';
+        wrapper.appendChild(valuationNote);
 
         return wrapper;
     }
@@ -337,7 +366,7 @@ class OpenableAnalyticsUI {
         const help = document.createElement('div');
         help.style.cssText = 'font-size:12px; opacity:0.75; margin-bottom:8px;';
         help.textContent =
-            "Adds a one-time bulk total to your Lifetime totals, revalued using Toolasha's own pricing. Does not add individual opening events (these sources only keep running totals, not per-opening history). Re-importing the same source replaces its previous total rather than adding to it.";
+            "Adds a cumulative source snapshot to Lifetime and revalues it at import time using Toolasha's current pricing. It does not add individual opening events (these sources only keep running totals, not per-opening history). Re-importing the same source replaces that entire source snapshot. Different sources are additive; importing overlapping periods/sources can double-count because the source data has no per-opening timestamps/IDs for reliable deduplication.";
         wrapper.appendChild(help);
 
         if (this.pendingEdiblePlayers) {

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.js
@@ -1,0 +1,292 @@
+/**
+ * Openable Analytics UI
+ * Character-scoped Analytics popup: container selector, Session/Lifetime toggle, Actual/Expected/
+ * Luck summary, aggregated item outcomes, and destructive reset controls. Modeled on the existing
+ * bespoke-overlay popup convention used by Combat Statistics (no shared modal utility exists in
+ * Toolasha to build on top of).
+ */
+
+import config from '../../../core/config.js';
+import dataManager from '../../../core/data-manager.js';
+import openableAnalyticsDataCollector from './openable-analytics-data-collector.js';
+import openableAnalyticsModalInjector, { formatValue, formatLuckPercent } from './openable-analytics-modal-injector.js';
+
+function luckColor(luckValue) {
+    if (luckValue === null || luckValue === undefined) return config.COLOR_TEXT_SECONDARY || '#888888';
+    return luckValue >= 0 ? config.COLOR_PROFIT : config.COLOR_LOSS;
+}
+
+function containerLabel(containerHrid) {
+    const details = dataManager.getItemDetails(containerHrid);
+    return details?.name || containerHrid;
+}
+
+function itemLabel(itemHrid) {
+    const details = dataManager.getItemDetails(itemHrid);
+    return details?.name || itemHrid;
+}
+
+class OpenableAnalyticsUI {
+    constructor() {
+        this.isInitialized = false;
+        this.popup = null;
+        this.selectedContainer = null;
+        this.selectedScope = 'session';
+    }
+
+    initialize() {
+        if (this.isInitialized) return;
+        this.isInitialized = true;
+
+        openableAnalyticsModalInjector.initialize({
+            onViewAnalytics: (containerHrid) => this.showPopup(containerHrid),
+        });
+    }
+
+    showPopup(containerHrid) {
+        const known = openableAnalyticsDataCollector.getKnownContainers();
+        this.selectedContainer = containerHrid || known[0] || null;
+        this.selectedScope = 'session';
+        this.createPopup();
+    }
+
+    closePopup() {
+        if (this.popup) {
+            this.popup.remove();
+            this.popup = null;
+        }
+    }
+
+    getActiveAggregate() {
+        if (!this.selectedContainer) return null;
+        return this.selectedScope === 'lifetime'
+            ? openableAnalyticsDataCollector.getLifetimeAggregate(this.selectedContainer)
+            : openableAnalyticsDataCollector.getSessionAggregate(this.selectedContainer);
+    }
+
+    createPopup() {
+        if (this.popup) {
+            this.closePopup();
+        }
+
+        const textColor = config.COLOR_TEXT_PRIMARY;
+        const known = openableAnalyticsDataCollector.getKnownContainers();
+
+        const overlay = document.createElement('div');
+        overlay.className = 'toolasha-openable-analytics-overlay';
+        overlay.style.cssText = `
+            position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+            background: rgba(0, 0, 0, 0.7); z-index: 10000;
+            display: flex; align-items: center; justify-content: center;
+        `;
+
+        const popup = document.createElement('div');
+        popup.className = 'toolasha-openable-analytics-popup';
+        popup.style.cssText = `
+            background: #1a1a1a; border: 2px solid #3a3a3a; border-radius: 8px;
+            padding: 20px; max-width: 90%; max-height: 90%; overflow-y: auto;
+            color: ${textColor}; min-width: 480px;
+        `;
+
+        const header = document.createElement('div');
+        header.style.cssText = `
+            display: flex; justify-content: space-between; align-items: center;
+            margin-bottom: 16px; border-bottom: 2px solid #3a3a3a; padding-bottom: 10px;
+        `;
+
+        const title = document.createElement('h2');
+        title.textContent = 'Openable Analytics';
+        title.style.cssText = `margin: 0; color: ${textColor}; font-size: 22px;`;
+
+        const closeButton = document.createElement('button');
+        closeButton.textContent = '×';
+        closeButton.style.cssText = `background: none; border: none; color: ${textColor}; font-size: 32px; cursor: pointer; padding: 0; line-height: 1;`;
+        closeButton.onclick = () => this.closePopup();
+
+        header.appendChild(title);
+        header.appendChild(closeButton);
+        popup.appendChild(header);
+
+        if (known.length === 0) {
+            const empty = document.createElement('div');
+            empty.textContent = 'No openings recorded yet for this character.';
+            empty.style.opacity = '0.75';
+            popup.appendChild(empty);
+        } else {
+            popup.appendChild(this.buildControls(known));
+            popup.appendChild(this.buildSummary());
+            popup.appendChild(this.buildItemOutcomes());
+            popup.appendChild(this.buildResetControls());
+        }
+
+        overlay.appendChild(popup);
+        document.body.appendChild(overlay);
+
+        overlay.onclick = (e) => {
+            if (e.target === overlay) this.closePopup();
+        };
+
+        this.popup = overlay;
+    }
+
+    buildControls(known) {
+        const container = document.createElement('div');
+        container.style.cssText = 'display:flex; gap:12px; margin-bottom:16px; align-items:center;';
+
+        const containerSelect = document.createElement('select');
+        containerSelect.style.cssText =
+            'background:#2a2a2a; color:#fff; border:1px solid #4a4a4a; padding:4px 8px; border-radius:4px;';
+        for (const hrid of known) {
+            const option = document.createElement('option');
+            option.value = hrid;
+            option.textContent = containerLabel(hrid);
+            if (hrid === this.selectedContainer) option.selected = true;
+            containerSelect.appendChild(option);
+        }
+        containerSelect.onchange = () => {
+            this.selectedContainer = containerSelect.value;
+            this.createPopup();
+        };
+
+        const scopeSelect = document.createElement('select');
+        scopeSelect.style.cssText =
+            'background:#2a2a2a; color:#fff; border:1px solid #4a4a4a; padding:4px 8px; border-radius:4px;';
+        for (const scope of ['session', 'lifetime']) {
+            const option = document.createElement('option');
+            option.value = scope;
+            option.textContent = scope === 'session' ? 'Session' : 'Lifetime';
+            if (scope === this.selectedScope) option.selected = true;
+            scopeSelect.appendChild(option);
+        }
+        scopeSelect.onchange = () => {
+            this.selectedScope = scopeSelect.value;
+            this.createPopup();
+        };
+
+        container.appendChild(containerSelect);
+        container.appendChild(scopeSelect);
+        return container;
+    }
+
+    buildSummary() {
+        const aggregate = this.getActiveAggregate();
+        const wrapper = document.createElement('div');
+        wrapper.style.cssText =
+            'background:#2a2a2a; border:1px solid #4a4a4a; border-radius:6px; padding:12px; margin-bottom:16px;';
+
+        const luckAvailable = aggregate.expectedValueAvailableEvents > 0;
+        const luckValue = luckAvailable ? aggregate.actualValueTotal - aggregate.expectedValueTotal : null;
+        const luckPercent =
+            luckAvailable && aggregate.expectedValueTotal > 0 ? (luckValue / aggregate.expectedValueTotal) * 100 : null;
+
+        const rows = [
+            ['Opening events', aggregate.eventsCount],
+            ['Containers opened', aggregate.containersOpened],
+            ['Actual Value', formatValue(aggregate.actualValueTotal)],
+            ['Expected Value', luckAvailable ? formatValue(aggregate.expectedValueTotal) : 'N/A'],
+            [
+                'Luck',
+                luckAvailable ? `${formatValue(luckValue)}${formatLuckPercent(luckPercent)}` : 'N/A',
+                luckAvailable ? luckColor(luckValue) : undefined,
+            ],
+        ];
+
+        if (aggregate.actualValuePartialEvents > 0) {
+            rows.push(['Partial-data events', aggregate.actualValuePartialEvents]);
+        }
+
+        for (const [label, value, color] of rows) {
+            const row = document.createElement('div');
+            row.style.cssText = 'display:flex; justify-content:space-between; padding:2px 0;';
+            const labelEl = document.createElement('span');
+            labelEl.textContent = label;
+            const valueEl = document.createElement('span');
+            valueEl.textContent = value;
+            if (color) valueEl.style.color = color;
+            row.appendChild(labelEl);
+            row.appendChild(valueEl);
+            wrapper.appendChild(row);
+        }
+
+        return wrapper;
+    }
+
+    buildItemOutcomes() {
+        const aggregate = this.getActiveAggregate();
+        const wrapper = document.createElement('div');
+        wrapper.style.cssText = 'margin-bottom:16px;';
+
+        const heading = document.createElement('div');
+        heading.textContent = 'Aggregated Item Outcomes';
+        heading.style.cssText = 'font-weight:600; margin-bottom:6px;';
+        wrapper.appendChild(heading);
+
+        const entries = Object.entries(aggregate.itemTotals || {}).sort((a, b) => b[1] - a[1]);
+        if (entries.length === 0) {
+            const empty = document.createElement('div');
+            empty.textContent = 'No items gained in this scope.';
+            empty.style.opacity = '0.75';
+            wrapper.appendChild(empty);
+            return wrapper;
+        }
+
+        for (const [itemHrid, count] of entries) {
+            const row = document.createElement('div');
+            row.style.cssText = 'display:flex; justify-content:space-between; padding:2px 0; font-size:13px;';
+            const labelEl = document.createElement('span');
+            labelEl.textContent = itemLabel(itemHrid);
+            const valueEl = document.createElement('span');
+            valueEl.textContent = count;
+            row.appendChild(labelEl);
+            row.appendChild(valueEl);
+            wrapper.appendChild(row);
+        }
+
+        return wrapper;
+    }
+
+    buildResetControls() {
+        const wrapper = document.createElement('div');
+        wrapper.style.cssText = 'display:flex; gap:10px; padding-top:10px; border-top:1px solid #3a3a3a;';
+
+        const resetContainerButton = document.createElement('button');
+        resetContainerButton.textContent = 'Reset This Container';
+        resetContainerButton.style.cssText =
+            'background:#4a4a4a; border:1px solid #5a5a5a; color:#fff; font-size:12px; cursor:pointer; padding:6px 12px; border-radius:4px;';
+        resetContainerButton.onclick = async () => {
+            if (
+                confirm(
+                    `Reset all Openable Analytics history for ${containerLabel(this.selectedContainer)}? This cannot be undone.`
+                )
+            ) {
+                await openableAnalyticsDataCollector.resetContainer(this.selectedContainer);
+                this.showPopup();
+            }
+        };
+
+        const resetAllButton = document.createElement('button');
+        resetAllButton.textContent = 'Reset All Openable Analytics';
+        resetAllButton.style.cssText =
+            'background:#4a4a4a; border:1px solid #5a5a5a; color:#fff; font-size:12px; cursor:pointer; padding:6px 12px; border-radius:4px;';
+        resetAllButton.onclick = async () => {
+            if (confirm('Reset ALL Openable Analytics history for this character? This cannot be undone.')) {
+                await openableAnalyticsDataCollector.resetAll();
+                this.closePopup();
+            }
+        };
+
+        wrapper.appendChild(resetContainerButton);
+        wrapper.appendChild(resetAllButton);
+        return wrapper;
+    }
+
+    cleanup() {
+        this.closePopup();
+        openableAnalyticsModalInjector.cleanup();
+        this.isInitialized = false;
+    }
+}
+
+const openableAnalyticsUI = new OpenableAnalyticsUI();
+
+export default openableAnalyticsUI;

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.js
@@ -8,6 +8,7 @@
 
 import config from '../../../core/config.js';
 import dataManager from '../../../core/data-manager.js';
+import domObserver from '../../../core/dom-observer.js';
 import openableAnalyticsDataCollector from './openable-analytics-data-collector.js';
 import openableAnalyticsModalInjector, { formatValue, formatLuckPercent } from './openable-analytics-modal-injector.js';
 import { parseEdibleExport, parseCombatSuiteExport } from './openable-analytics-import-parsers.js';
@@ -16,6 +17,9 @@ const IMPORT_SOURCES = [
     { key: 'edible', label: 'Edible Tools', prefixedSource: 'import:edible' },
     { key: 'mwi-combat-suite', label: 'MWI Combat Suite', prefixedSource: 'import:mwi-combat-suite' },
 ];
+
+const INVENTORY_FILTER_CONTAINER_CLASS = 'Inventory_itemFilterContainer';
+const INVENTORY_BUTTON_CLASS = 'toolasha-openable-analytics-inventory-button';
 
 function luckColor(luckValue) {
     if (luckValue === null || luckValue === undefined) return config.COLOR_TEXT_SECONDARY || '#888888';
@@ -42,6 +46,7 @@ class OpenableAnalyticsUI {
         this.importStatus = null;
         this.pendingEdiblePlayers = null;
         this.pendingEdibleRawText = null;
+        this.unregisterInventoryButtonObserver = null;
     }
 
     initialize() {
@@ -51,6 +56,29 @@ class OpenableAnalyticsUI {
         openableAnalyticsModalInjector.initialize({
             onViewAnalytics: (containerHrid) => this.showPopup(containerHrid),
         });
+
+        // Persistent entry point: the "View Analytics" link inside the Opened Loot modal only
+        // exists right after opening something. This button in the Inventory panel's always-
+        // rendered search bar row lets it be opened at any time.
+        this.unregisterInventoryButtonObserver = domObserver.onClass(
+            'openableAnalyticsInventoryButton',
+            INVENTORY_FILTER_CONTAINER_CLASS,
+            (node) => this.injectInventoryButton(node)
+        );
+    }
+
+    injectInventoryButton(container) {
+        if (container.querySelector(`.${INVENTORY_BUTTON_CLASS}`)) return;
+
+        const button = document.createElement('div');
+        button.className = INVENTORY_BUTTON_CLASS;
+        button.textContent = '📊';
+        button.title = 'Openable Analytics';
+        button.style.cssText =
+            'cursor:pointer; margin-left:8px; font-size:16px; display:inline-flex; align-items:center;';
+        button.onclick = () => this.showPopup();
+
+        container.appendChild(button);
     }
 
     showPopup(containerHrid) {
@@ -455,6 +483,10 @@ class OpenableAnalyticsUI {
     cleanup() {
         this.closePopup();
         openableAnalyticsModalInjector.cleanup();
+        if (this.unregisterInventoryButtonObserver) {
+            this.unregisterInventoryButtonObserver();
+            this.unregisterInventoryButtonObserver = null;
+        }
         this.isInitialized = false;
     }
 }
@@ -462,3 +494,4 @@ class OpenableAnalyticsUI {
 const openableAnalyticsUI = new OpenableAnalyticsUI();
 
 export default openableAnalyticsUI;
+export { INVENTORY_FILTER_CONTAINER_CLASS, INVENTORY_BUTTON_CLASS };

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.js
@@ -76,6 +76,8 @@ class OpenableAnalyticsUI {
         this.manageDataOpen = false;
         this.pendingImport = null;
         this.mutationInFlight = false;
+        this.deleteContainerError = null;
+        this.deleteAllError = null;
         this.unregisterInventoryButtonObserver = null;
         this.unsubscribeStateChange = null;
     }
@@ -106,6 +108,9 @@ class OpenableAnalyticsUI {
     }
 
     injectInventoryButton(container) {
+        // Fail closed against a stale/captured observer callback firing after cleanup() has
+        // already torn down this feature's lifecycle.
+        if (!this.isInitialized) return;
         if (container.querySelector(`.${INVENTORY_BUTTON_CLASS}`)) return;
 
         const button = document.createElement('button');
@@ -465,6 +470,14 @@ class OpenableAnalyticsUI {
             deleteButton.style.cssText = this.destructiveButtonStyle();
             deleteButton.onclick = () => this.handleDeleteContainer(containerHrid);
             deleteRow.appendChild(deleteButton);
+
+            if (this.deleteContainerError?.containerHrid === containerHrid) {
+                const error = document.createElement('div');
+                error.style.cssText = `margin-top:6px; font-size:12px; color:${config.COLOR_WARNING};`;
+                error.textContent = this.deleteContainerError.message;
+                deleteRow.appendChild(error);
+            }
+
             wrapper.appendChild(deleteRow);
         }
 
@@ -914,12 +927,16 @@ class OpenableAnalyticsUI {
         }
 
         this.mutationInFlight = true;
+        this.deleteContainerError = null;
         this.renderBody();
 
-        await openableAnalyticsDataCollector.resetContainer(containerHrid);
+        const persisted = await openableAnalyticsDataCollector.resetContainer(containerHrid);
 
         this.mutationInFlight = false;
         if (!this.popupOverlay) return;
+        this.deleteContainerError = persisted
+            ? null
+            : { containerHrid, message: 'Could not save this deletion. It may reappear after reload.' };
         this.renderBody();
     }
 
@@ -935,6 +952,14 @@ class OpenableAnalyticsUI {
         button.onclick = () => this.handleDeleteAll();
 
         wrapper.appendChild(button);
+
+        if (this.deleteAllError) {
+            const error = document.createElement('div');
+            error.style.cssText = `margin-top:6px; font-size:12px; color:${config.COLOR_WARNING};`;
+            error.textContent = this.deleteAllError;
+            wrapper.appendChild(error);
+        }
+
         return wrapper;
     }
 
@@ -945,12 +970,14 @@ class OpenableAnalyticsUI {
         }
 
         this.mutationInFlight = true;
+        this.deleteAllError = null;
         this.renderBody();
 
-        await openableAnalyticsDataCollector.resetAll();
+        const persisted = await openableAnalyticsDataCollector.resetAll();
 
         this.mutationInFlight = false;
         if (!this.popupOverlay) return;
+        this.deleteAllError = persisted ? null : 'Could not save this deletion. It may reappear after reload.';
         // Delete All does not silently close the popup - show the resulting empty state in place.
         this.renderBody();
     }
@@ -958,6 +985,7 @@ class OpenableAnalyticsUI {
     cleanup() {
         this.closePopup();
         openableAnalyticsModalInjector.cleanup();
+        document.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`).forEach((button) => button.remove());
         if (this.unregisterInventoryButtonObserver) {
             this.unregisterInventoryButtonObserver();
             this.unregisterInventoryButtonObserver = null;
@@ -968,6 +996,8 @@ class OpenableAnalyticsUI {
         }
         this.isInitialized = false;
         this.showPasteArea = false;
+        this.deleteContainerError = null;
+        this.deleteAllError = null;
     }
 }
 

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.js
@@ -252,7 +252,8 @@ class OpenableAnalyticsUI {
             const labelEl = document.createElement('span');
             labelEl.textContent = itemLabel(itemHrid);
             const valueEl = document.createElement('span');
-            valueEl.textContent = count;
+            const itemValue = aggregate.itemValueTotals?.[itemHrid];
+            valueEl.textContent = itemValue !== undefined ? `${count} (${formatValue(itemValue)})` : `${count} (N/A)`;
             row.appendChild(labelEl);
             row.appendChild(valueEl);
             wrapper.appendChild(row);

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.js
@@ -10,6 +10,12 @@ import config from '../../../core/config.js';
 import dataManager from '../../../core/data-manager.js';
 import openableAnalyticsDataCollector from './openable-analytics-data-collector.js';
 import openableAnalyticsModalInjector, { formatValue, formatLuckPercent } from './openable-analytics-modal-injector.js';
+import { parseEdibleExport, parseCombatSuiteExport } from './openable-analytics-import-parsers.js';
+
+const IMPORT_SOURCES = [
+    { key: 'edible', label: 'Edible Tools', prefixedSource: 'import:edible' },
+    { key: 'mwi-combat-suite', label: 'MWI Combat Suite', prefixedSource: 'import:mwi-combat-suite' },
+];
 
 function luckColor(luckValue) {
     if (luckValue === null || luckValue === undefined) return config.COLOR_TEXT_SECONDARY || '#888888';
@@ -32,6 +38,10 @@ class OpenableAnalyticsUI {
         this.popup = null;
         this.selectedContainer = null;
         this.selectedScope = 'session';
+        this.importSourceKey = 'mwi-combat-suite';
+        this.importStatus = null;
+        this.pendingEdiblePlayers = null;
+        this.pendingEdibleRawText = null;
     }
 
     initialize() {
@@ -47,6 +57,9 @@ class OpenableAnalyticsUI {
         const known = openableAnalyticsDataCollector.getKnownContainers();
         this.selectedContainer = containerHrid || known[0] || null;
         this.selectedScope = 'session';
+        this.importStatus = null;
+        this.pendingEdiblePlayers = null;
+        this.pendingEdibleRawText = null;
         this.createPopup();
     }
 
@@ -111,6 +124,7 @@ class OpenableAnalyticsUI {
             const empty = document.createElement('div');
             empty.textContent = 'No openings recorded yet for this character.';
             empty.style.opacity = '0.75';
+            empty.style.marginBottom = '16px';
             popup.appendChild(empty);
         } else {
             popup.appendChild(this.buildControls(known));
@@ -118,6 +132,8 @@ class OpenableAnalyticsUI {
             popup.appendChild(this.buildItemOutcomes());
             popup.appendChild(this.buildResetControls());
         }
+
+        popup.appendChild(this.buildImportPanel());
 
         overlay.appendChild(popup);
         document.body.appendChild(overlay);
@@ -278,6 +294,161 @@ class OpenableAnalyticsUI {
         wrapper.appendChild(resetContainerButton);
         wrapper.appendChild(resetAllButton);
         return wrapper;
+    }
+
+    buildImportPanel() {
+        const wrapper = document.createElement('div');
+        wrapper.style.cssText = 'padding-top:16px; border-top:1px solid #3a3a3a;';
+
+        const heading = document.createElement('div');
+        heading.textContent = 'Import Historical Data';
+        heading.style.cssText = 'font-weight:600; margin-bottom:6px;';
+        wrapper.appendChild(heading);
+
+        const help = document.createElement('div');
+        help.style.cssText = 'font-size:12px; opacity:0.75; margin-bottom:8px;';
+        help.textContent =
+            "Adds a one-time bulk total to your Lifetime totals, revalued using Toolasha's own pricing. Does not add individual opening events (these sources only keep running totals, not per-opening history). Re-importing the same source replaces its previous total rather than adding to it.";
+        wrapper.appendChild(help);
+
+        if (this.pendingEdiblePlayers) {
+            wrapper.appendChild(this.buildEdiblePlayerPicker());
+            return wrapper;
+        }
+
+        const controls = document.createElement('div');
+        controls.style.cssText = 'display:flex; gap:8px; align-items:center; margin-bottom:8px; flex-wrap:wrap;';
+
+        const sourceSelect = document.createElement('select');
+        sourceSelect.style.cssText =
+            'background:#2a2a2a; color:#fff; border:1px solid #4a4a4a; padding:4px 8px; border-radius:4px;';
+        for (const { key, label } of IMPORT_SOURCES) {
+            const option = document.createElement('option');
+            option.value = key;
+            option.textContent = label;
+            if (key === this.importSourceKey) option.selected = true;
+            sourceSelect.appendChild(option);
+        }
+        sourceSelect.onchange = () => {
+            this.importSourceKey = sourceSelect.value;
+        };
+
+        const fileInput = document.createElement('input');
+        fileInput.type = 'file';
+        fileInput.accept = '.json,application/json,text/plain';
+        fileInput.style.cssText = 'font-size:12px; max-width:180px;';
+
+        controls.appendChild(sourceSelect);
+        controls.appendChild(fileInput);
+        wrapper.appendChild(controls);
+
+        const textarea = document.createElement('textarea');
+        textarea.placeholder =
+            "Paste exported/copied data here (MWI Combat Suite: paste the exported .json file contents. Edible Tools: paste the value of localStorage.getItem('Edible_Tools') from your browser devtools).";
+        textarea.style.cssText =
+            'width:100%; height:70px; background:#2a2a2a; color:#fff; border:1px solid #4a4a4a; border-radius:4px; padding:6px; font-size:12px; box-sizing:border-box; resize:vertical;';
+        wrapper.appendChild(textarea);
+
+        fileInput.onchange = () => {
+            const file = fileInput.files?.[0];
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = () => {
+                textarea.value = String(reader.result || '');
+            };
+            reader.readAsText(file);
+        };
+
+        const importButton = document.createElement('button');
+        importButton.textContent = 'Import';
+        importButton.style.cssText =
+            'margin-top:8px; background:#4a4a4a; border:1px solid #5a5a5a; color:#fff; font-size:12px; cursor:pointer; padding:6px 12px; border-radius:4px;';
+        importButton.onclick = () => this.handleImportSubmit(textarea.value);
+        wrapper.appendChild(importButton);
+
+        if (this.importStatus) {
+            const status = document.createElement('div');
+            status.style.cssText = 'margin-top:8px; font-size:12px; opacity:0.9;';
+            status.textContent = this.importStatus;
+            wrapper.appendChild(status);
+        }
+
+        return wrapper;
+    }
+
+    buildEdiblePlayerPicker() {
+        const wrapper = document.createElement('div');
+
+        const label = document.createElement('div');
+        label.textContent = 'This Edible Tools data has more than one player - which one is this character?';
+        label.style.cssText = 'font-size:12px; margin-bottom:6px;';
+        wrapper.appendChild(label);
+
+        const select = document.createElement('select');
+        select.style.cssText =
+            'background:#2a2a2a; color:#fff; border:1px solid #4a4a4a; padding:4px 8px; border-radius:4px; margin-right:8px;';
+        for (const player of this.pendingEdiblePlayers) {
+            const option = document.createElement('option');
+            option.value = player.id;
+            option.textContent = player.name;
+            select.appendChild(option);
+        }
+        wrapper.appendChild(select);
+
+        const confirmButton = document.createElement('button');
+        confirmButton.textContent = 'Import for this player';
+        confirmButton.style.cssText =
+            'background:#4a4a4a; border:1px solid #5a5a5a; color:#fff; font-size:12px; cursor:pointer; padding:6px 12px; border-radius:4px;';
+        confirmButton.onclick = () => this.handleEdiblePlayerSelected(select.value);
+        wrapper.appendChild(confirmButton);
+
+        return wrapper;
+    }
+
+    async handleImportSubmit(rawText) {
+        if (!rawText?.trim()) {
+            this.importStatus = 'Paste or upload some data first.';
+            this.createPopup();
+            return;
+        }
+
+        const result = this.importSourceKey === 'edible' ? parseEdibleExport(rawText) : parseCombatSuiteExport(rawText);
+
+        if (result.needsPlayerSelection) {
+            this.pendingEdiblePlayers = result.players;
+            this.pendingEdibleRawText = rawText;
+            this.createPopup();
+            return;
+        }
+
+        const sourceEntry = IMPORT_SOURCES.find((entry) => entry.key === this.importSourceKey);
+        await this.applyImportResult(sourceEntry.prefixedSource, result);
+    }
+
+    async handleEdiblePlayerSelected(playerId) {
+        const result = parseEdibleExport(this.pendingEdibleRawText, { playerId });
+        this.pendingEdiblePlayers = null;
+        this.pendingEdibleRawText = null;
+        await this.applyImportResult('import:edible', result);
+    }
+
+    async applyImportResult(source, result) {
+        if (result.containers.length > 0) {
+            await openableAnalyticsDataCollector.importContainers(source, result.containers);
+        }
+
+        const importedCount = result.containers.length;
+        const warningsText = result.warnings.length > 0 ? ` ${result.warnings.join(' ')}` : '';
+        this.importStatus =
+            importedCount > 0
+                ? `Imported ${importedCount} container(s).${warningsText}`
+                : `Nothing imported.${warningsText}`;
+
+        if (!this.selectedContainer && result.containers[0]) {
+            this.selectedContainer = result.containers[0].containerHrid;
+        }
+
+        this.createPopup();
     }
 
     cleanup() {

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.test.js
@@ -1,0 +1,89 @@
+/* @vitest-environment jsdom */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    aggregate: {
+        eventsCount: 0,
+        containersOpened: 0,
+        actualValueTotal: 0,
+        actualValuePartialEvents: 0,
+        expectedValueTotal: 0,
+        expectedValueAvailableEvents: 0,
+        itemTotals: {},
+        itemValueTotals: {},
+    },
+    knownContainers: ['/items/chest'],
+}));
+
+vi.mock('../../../core/config.js', () => ({
+    default: { COLOR_PROFIT: '#047857', COLOR_LOSS: '#f87171', COLOR_TEXT_PRIMARY: '#fff' },
+}));
+
+vi.mock('../../../core/data-manager.js', () => ({
+    default: {
+        getItemDetails: vi.fn((hrid) => ({ name: hrid.split('/').pop() })),
+    },
+}));
+
+vi.mock('../../../core/dom-observer.js', () => ({
+    default: { onClass: vi.fn(() => vi.fn()) },
+}));
+
+vi.mock('./openable-analytics-data-collector.js', () => ({
+    default: {
+        getKnownContainers: vi.fn(() => mocks.knownContainers),
+        getSessionAggregate: vi.fn(() => mocks.aggregate),
+        getLifetimeAggregate: vi.fn(() => mocks.aggregate),
+        onUpdate: vi.fn(() => vi.fn()),
+        getLatestRecord: vi.fn(() => null),
+    },
+}));
+
+const { default: openableAnalyticsUI } = await import('./openable-analytics-ui.js');
+
+beforeEach(() => {
+    mocks.aggregate = {
+        eventsCount: 1,
+        containersOpened: 1,
+        actualValueTotal: 489000,
+        actualValuePartialEvents: 0,
+        expectedValueTotal: 725000,
+        expectedValueAvailableEvents: 1,
+        itemTotals: { '/items/coin': 42938, '/items/shard_of_protection': 8, '/items/pearl': 1 },
+        itemValueTotals: { '/items/coin': 42938, '/items/shard_of_protection': 400000 },
+    };
+    mocks.knownContainers = ['/items/chest'];
+    openableAnalyticsUI.selectedContainer = '/items/chest';
+    openableAnalyticsUI.selectedScope = 'session';
+});
+
+describe('buildItemOutcomes', () => {
+    test('shows each item’s count alongside its cumulative value', () => {
+        const wrapper = openableAnalyticsUI.buildItemOutcomes();
+
+        expect(wrapper.textContent).toContain('42938 (42K)');
+        expect(wrapper.textContent).toContain('8 (400K)');
+    });
+
+    test('shows N/A for an item with a count but no resolved cumulative value', () => {
+        const wrapper = openableAnalyticsUI.buildItemOutcomes();
+
+        expect(wrapper.textContent).toContain('1 (N/A)');
+    });
+
+    test('sorts by count descending, unchanged from before this feature', () => {
+        const wrapper = openableAnalyticsUI.buildItemOutcomes();
+        const rows = [...wrapper.querySelectorAll('div')].filter((el) => el.children.length === 2);
+
+        expect(rows[0].textContent).toContain('coin');
+        expect(rows[1].textContent).toContain('shard_of_protection');
+    });
+
+    test('shows an empty-state message when there are no items in scope', () => {
+        mocks.aggregate = { ...mocks.aggregate, itemTotals: {}, itemValueTotals: {} };
+
+        const wrapper = openableAnalyticsUI.buildItemOutcomes();
+
+        expect(wrapper.textContent).toContain('No items gained in this scope.');
+    });
+});

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.test.js
@@ -71,6 +71,78 @@ beforeEach(() => {
     openableAnalyticsUI.selectedScope = 'session';
 });
 
+describe('buildSummary', () => {
+    test('labels the live opening-event count as "Tracked opening events" (section 3.1)', () => {
+        const wrapper = openableAnalyticsUI.buildSummary();
+
+        expect(wrapper.textContent).toContain('Tracked opening events');
+        expect(wrapper.textContent).not.toContain('Opening events1');
+    });
+
+    test('shows a real Luck value when every valuation record folded into the aggregate is Luck-eligible', () => {
+        mocks.aggregate = {
+            ...mocks.aggregate,
+            valuationRecordCount: 1,
+            luckEligibleRecordCount: 1,
+        };
+
+        const wrapper = openableAnalyticsUI.buildSummary();
+
+        expect(wrapper.textContent).not.toContain('LuckN/A');
+    });
+
+    test('AGG-1: shows Luck N/A when one folded valuation record is partial/unavailable, even though others are eligible', () => {
+        mocks.aggregate = {
+            ...mocks.aggregate,
+            valuationRecordCount: 3,
+            luckEligibleRecordCount: 2,
+        };
+
+        const wrapper = openableAnalyticsUI.buildSummary();
+        const rows = [...wrapper.querySelectorAll('div')].filter((el) => el.children.length === 2);
+        const luckRow = rows.find((row) => row.textContent.startsWith('Luck'));
+
+        expect(luckRow.textContent).toBe('LuckN/A');
+    });
+
+    test('marks Actual Value (partial) when the aggregate has any partial-actual events', () => {
+        mocks.aggregate = { ...mocks.aggregate, actualValuePartialEvents: 1 };
+
+        const wrapper = openableAnalyticsUI.buildSummary();
+
+        expect(wrapper.textContent).toContain('(partial)');
+    });
+
+    test('AGG-2: shows Expected Value as N/A rather than a fabricated total when no record has Expected available', () => {
+        mocks.aggregate = { ...mocks.aggregate, expectedValueAvailableEvents: 0, expectedValueTotal: 0 };
+
+        const wrapper = openableAnalyticsUI.buildSummary();
+        const rows = [...wrapper.querySelectorAll('div')].filter((el) => el.children.length === 2);
+        const expectedRow = rows.find((row) => row.textContent.startsWith('Expected Value'));
+
+        expect(expectedRow.textContent).toBe('Expected ValueN/A');
+    });
+
+    test('section 3.3/3.4: notes imported-vs-live valuation timing and overlap risk only for a Lifetime scope with imported data', () => {
+        openableAnalyticsUI.selectedScope = 'lifetime';
+        mocks.aggregate = { ...mocks.aggregate, hasImportedData: true };
+
+        const wrapper = openableAnalyticsUI.buildSummary();
+
+        expect(wrapper.textContent).toContain('additive');
+        expect(wrapper.textContent).toContain('double-count');
+    });
+
+    test('shows the plain event-time note for a Session scope (no import ambiguity)', () => {
+        openableAnalyticsUI.selectedScope = 'session';
+
+        const wrapper = openableAnalyticsUI.buildSummary();
+
+        expect(wrapper.textContent).toContain('snapshotted using Toolasha pricing');
+        expect(wrapper.textContent).not.toContain('double-count');
+    });
+});
+
 describe('buildItemOutcomes', () => {
     test('shows each item’s count alongside its cumulative value', () => {
         const wrapper = openableAnalyticsUI.buildItemOutcomes();

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.test.js
@@ -234,6 +234,45 @@ describe('persistent Inventory panel entry point (OA-RUNTIME-1)', () => {
     });
 });
 
+describe('PR667-FINAL-1: Inventory button lifecycle', () => {
+    test('cleanup removes an already-injected Inventory button', () => {
+        const filterContainer = document.createElement('div');
+        document.body.appendChild(filterContainer);
+        filterContainerCallbacks().forEach((cb) => cb(filterContainer));
+        expect(filterContainer.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`)).toHaveLength(1);
+
+        openableAnalyticsUI.cleanup();
+
+        expect(filterContainer.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`)).toHaveLength(0);
+    });
+
+    test('a stale/captured observer callback invoked after cleanup cannot inject a button', () => {
+        const filterContainer = document.createElement('div');
+        document.body.appendChild(filterContainer);
+        const staleCallbacks = filterContainerCallbacks();
+
+        openableAnalyticsUI.cleanup();
+        staleCallbacks.forEach((cb) => cb(filterContainer));
+
+        expect(filterContainer.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`)).toHaveLength(0);
+    });
+
+    test('initialize -> cleanup -> initialize produces exactly one working button, not zero and not duplicates', () => {
+        const filterContainer = document.createElement('div');
+        filterContainer.className = INVENTORY_FILTER_CONTAINER_CLASS;
+        document.body.appendChild(filterContainer);
+
+        openableAnalyticsUI.cleanup();
+        openableAnalyticsUI.initialize();
+        openableAnalyticsUI.cleanup();
+        openableAnalyticsUI.initialize();
+
+        const buttons = filterContainer.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`);
+        expect(buttons).toHaveLength(1);
+        expect(() => buttons[0].onclick()).not.toThrow();
+    });
+});
+
 describe('View Analytics entry point (section 9)', () => {
     test('opens Lifetime with the requested container expanded and brought into view', () => {
         openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
@@ -455,6 +494,107 @@ describe('Manage Data (section 14)', () => {
         await openableAnalyticsUI.handleDeleteAll();
 
         expect(openableAnalyticsDataCollector.resetAll).not.toHaveBeenCalled();
+    });
+});
+
+describe('PR667-FINAL-2: destructive reset failure visibility', () => {
+    test('resetContainer() returning false produces a visible failure state', async () => {
+        mocks.resetContainerResult = false;
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        await openableAnalyticsUI.handleDeleteContainer('/items/chest');
+
+        expect(popup().textContent).toContain('Could not save this deletion');
+    });
+
+    test('resetAll() returning false produces a visible failure state', async () => {
+        mocks.resetAllResult = false;
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.manageDataOpen = true;
+        openableAnalyticsUI.renderBody();
+
+        await openableAnalyticsUI.handleDeleteAll();
+
+        expect(popup().textContent).toContain('Could not save this deletion');
+    });
+
+    test('a successful container deletion does not show a false error', async () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        await openableAnalyticsUI.handleDeleteContainer('/items/chest');
+
+        expect(popup().textContent).not.toContain('Could not save this deletion');
+    });
+
+    test('a successful Delete All does not show a false error', async () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.manageDataOpen = true;
+        openableAnalyticsUI.renderBody();
+
+        await openableAnalyticsUI.handleDeleteAll();
+
+        expect(popup().textContent).not.toContain('Could not save this deletion');
+    });
+
+    test('closing the popup during a failed async container delete does not recreate/reopen it', async () => {
+        let resolvePersist;
+        mocks.resetContainerResult = false;
+        openableAnalyticsDataCollector.resetContainer.mockReturnValueOnce(
+            new Promise((resolve) => {
+                resolvePersist = resolve;
+            })
+        );
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        const pending = openableAnalyticsUI.handleDeleteContainer('/items/chest');
+        openableAnalyticsUI.closePopup();
+        resolvePersist(false);
+        await pending;
+
+        expect(popup()).toBeNull();
+    });
+
+    test('closing the popup during a failed async Delete All does not recreate/reopen it', async () => {
+        let resolvePersist;
+        openableAnalyticsDataCollector.resetAll.mockReturnValueOnce(
+            new Promise((resolve) => {
+                resolvePersist = resolve;
+            })
+        );
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+        openableAnalyticsUI.showPopup();
+
+        const pending = openableAnalyticsUI.handleDeleteAll();
+        openableAnalyticsUI.closePopup();
+        resolvePersist(false);
+        await pending;
+
+        expect(popup()).toBeNull();
+    });
+});
+
+describe('PR667-FINAL-3: Edible ownership mismatch is shown in the UI, not only Combat Suite', () => {
+    test('an Edible import with ownerMismatch: true shows the same warning wording as Combat Suite', () => {
+        detectImportSource.mockReturnValue({ source: 'edible' });
+        parseEdibleExport.mockReturnValue({
+            status: 'ready',
+            containers: [{ containerHrid: '/items/chest', containerCount: 5, itemTotals: {} }],
+            warnings: [],
+            ownerName: 'SomeoneElse',
+            ownerMismatch: true,
+        });
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.manageDataOpen = true;
+        openableAnalyticsUI.renderBody();
+
+        openableAnalyticsUI.beginImport('{"Chest_Open_Data":{}}', 'edible');
+
+        expect(popup().textContent).toContain('does not match the current character');
     });
 });
 

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.test.js
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
         itemValueTotals: {},
     },
     knownContainers: ['/items/chest'],
+    domObserverRegistrations: [],
 }));
 
 vi.mock('../../../core/config.js', () => ({
@@ -26,7 +27,12 @@ vi.mock('../../../core/data-manager.js', () => ({
 }));
 
 vi.mock('../../../core/dom-observer.js', () => ({
-    default: { onClass: vi.fn(() => vi.fn()) },
+    default: {
+        onClass: vi.fn((_name, classNames, callback) => {
+            mocks.domObserverRegistrations.push({ classNames, callback });
+            return vi.fn();
+        }),
+    },
 }));
 
 vi.mock('./openable-analytics-data-collector.js', () => ({
@@ -39,7 +45,11 @@ vi.mock('./openable-analytics-data-collector.js', () => ({
     },
 }));
 
-const { default: openableAnalyticsUI } = await import('./openable-analytics-ui.js');
+const {
+    default: openableAnalyticsUI,
+    INVENTORY_FILTER_CONTAINER_CLASS,
+    INVENTORY_BUTTON_CLASS,
+} = await import('./openable-analytics-ui.js');
 
 beforeEach(() => {
     mocks.aggregate = {
@@ -53,6 +63,10 @@ beforeEach(() => {
         itemValueTotals: { '/items/coin': 42938, '/items/shard_of_protection': 400000 },
     };
     mocks.knownContainers = ['/items/chest'];
+    mocks.domObserverRegistrations = [];
+    document.body.innerHTML = '';
+    openableAnalyticsUI.cleanup();
+    openableAnalyticsUI.initialize();
     openableAnalyticsUI.selectedContainer = '/items/chest';
     openableAnalyticsUI.selectedScope = 'session';
 });
@@ -85,5 +99,50 @@ describe('buildItemOutcomes', () => {
         const wrapper = openableAnalyticsUI.buildItemOutcomes();
 
         expect(wrapper.textContent).toContain('No items gained in this scope.');
+    });
+});
+
+describe('persistent Inventory panel entry point', () => {
+    function filterContainerCallbacks() {
+        return mocks.domObserverRegistrations
+            .filter((r) => r.classNames === INVENTORY_FILTER_CONTAINER_CLASS)
+            .map((r) => r.callback);
+    }
+
+    test('injects a button into the Inventory panel search bar row', () => {
+        const filterContainer = document.createElement('div');
+        document.body.appendChild(filterContainer);
+
+        filterContainerCallbacks().forEach((cb) => cb(filterContainer));
+
+        expect(filterContainer.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`)).toHaveLength(1);
+    });
+
+    test('does not inject a second button if one is already present (idempotent on re-render)', () => {
+        const filterContainer = document.createElement('div');
+        document.body.appendChild(filterContainer);
+
+        filterContainerCallbacks().forEach((cb) => cb(filterContainer));
+        filterContainerCallbacks().forEach((cb) => cb(filterContainer));
+
+        expect(filterContainer.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`)).toHaveLength(1);
+    });
+
+    test('clicking the button opens the Analytics popup even with no specific opening context', () => {
+        const filterContainer = document.createElement('div');
+        document.body.appendChild(filterContainer);
+        filterContainerCallbacks().forEach((cb) => cb(filterContainer));
+
+        filterContainer.querySelector(`.${INVENTORY_BUTTON_CLASS}`).onclick();
+
+        expect(document.querySelector('.toolasha-openable-analytics-popup')).not.toBeNull();
+    });
+
+    test('cleanup unregisters the observer so a later re-initialize does not double-register', () => {
+        openableAnalyticsUI.cleanup();
+        mocks.domObserverRegistrations = [];
+        openableAnalyticsUI.initialize();
+
+        expect(filterContainerCallbacks()).toHaveLength(1);
     });
 });

--- a/src/features/inventory/openable-analytics/openable-analytics-ui.test.js
+++ b/src/features/inventory/openable-analytics/openable-analytics-ui.test.js
@@ -1,28 +1,54 @@
 /* @vitest-environment jsdom */
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({
-    aggregate: {
+function emptyAggregate() {
+    return {
         eventsCount: 0,
         containersOpened: 0,
         actualValueTotal: 0,
         actualValuePartialEvents: 0,
         expectedValueTotal: 0,
         expectedValueAvailableEvents: 0,
+        valuationRecordCount: 0,
+        luckEligibleRecordCount: 0,
+        hasImportedData: false,
         itemTotals: {},
         itemValueTotals: {},
-    },
-    knownContainers: ['/items/chest'],
+    };
+}
+
+const mocks = vi.hoisted(() => ({
+    aggregates: {},
+    knownContainers: [],
+    sessionContainers: [],
+    importSourceKeys: [],
+    importedContainerHrids: {},
     domObserverRegistrations: [],
+    stateChangeCallbacks: [],
+    currentCharacterName: 'Vovchigus',
+    importContainersResult: { results: [], persisted: true },
+    removeImportResult: true,
+    resetContainerResult: true,
+    resetAllResult: true,
 }));
 
 vi.mock('../../../core/config.js', () => ({
-    default: { COLOR_PROFIT: '#047857', COLOR_LOSS: '#f87171', COLOR_TEXT_PRIMARY: '#fff' },
+    default: {
+        COLOR_PROFIT: '#047857',
+        COLOR_LOSS: '#f87171',
+        COLOR_TEXT_PRIMARY: '#fff',
+        COLOR_TEXT_SECONDARY: '#888',
+        COLOR_ACCENT: '#22c55e',
+        COLOR_INFO: '#60a5fa',
+        COLOR_WARNING: '#ffa500',
+        getSettingValue: vi.fn((key, defaultValue) => defaultValue),
+    },
 }));
 
 vi.mock('../../../core/data-manager.js', () => ({
     default: {
         getItemDetails: vi.fn((hrid) => ({ name: hrid.split('/').pop() })),
+        getCurrentCharacterName: vi.fn(() => mocks.currentCharacterName),
     },
 }));
 
@@ -35,159 +61,137 @@ vi.mock('../../../core/dom-observer.js', () => ({
     },
 }));
 
+vi.mock('./openable-analytics-modal-injector.js', async () => {
+    const actual = await vi.importActual('./openable-analytics-modal-injector.js');
+    return {
+        default: { initialize: vi.fn(), cleanup: vi.fn() },
+        formatLuckPercent: actual.formatLuckPercent,
+        luckColor: actual.luckColor,
+    };
+});
+
+vi.mock('./openable-analytics-import-parsers.js', () => ({
+    detectImportSource: vi.fn(),
+    parseEdibleExport: vi.fn(),
+    parseCombatSuiteExport: vi.fn(),
+}));
+
 vi.mock('./openable-analytics-data-collector.js', () => ({
     default: {
         getKnownContainers: vi.fn(() => mocks.knownContainers),
-        getSessionAggregate: vi.fn(() => mocks.aggregate),
-        getLifetimeAggregate: vi.fn(() => mocks.aggregate),
-        onUpdate: vi.fn(() => vi.fn()),
-        getLatestRecord: vi.fn(() => null),
+        getSessionContainers: vi.fn(() => mocks.sessionContainers),
+        getSessionAggregate: vi.fn((hrid) => mocks.aggregates[hrid] || emptyAggregate()),
+        getLifetimeAggregate: vi.fn((hrid) => mocks.aggregates[hrid] || emptyAggregate()),
+        getLiveLifetimeAggregate: vi.fn((hrid) => mocks.aggregates[hrid] || emptyAggregate()),
+        getImportSourceKeys: vi.fn(() => mocks.importSourceKeys),
+        getImportedContainerHrids: vi.fn((source) => mocks.importedContainerHrids[source] || new Set()),
+        onStateChange: vi.fn((cb) => {
+            mocks.stateChangeCallbacks.push(cb);
+            return () => {
+                mocks.stateChangeCallbacks = mocks.stateChangeCallbacks.filter((c) => c !== cb);
+            };
+        }),
+        importContainers: vi.fn(async () => mocks.importContainersResult),
+        removeImport: vi.fn(async () => mocks.removeImportResult),
+        resetContainer: vi.fn(async () => mocks.resetContainerResult),
+        resetAll: vi.fn(async () => mocks.resetAllResult),
     },
 }));
 
+const { default: openableAnalyticsDataCollector } = await import('./openable-analytics-data-collector.js');
+const { detectImportSource, parseEdibleExport, parseCombatSuiteExport } =
+    await import('./openable-analytics-import-parsers.js');
 const {
     default: openableAnalyticsUI,
     INVENTORY_FILTER_CONTAINER_CLASS,
     INVENTORY_BUTTON_CLASS,
 } = await import('./openable-analytics-ui.js');
 
+function filterContainerCallbacks() {
+    return mocks.domObserverRegistrations
+        .filter((r) => r.classNames === INVENTORY_FILTER_CONTAINER_CLASS)
+        .map((r) => r.callback);
+}
+
 beforeEach(() => {
-    mocks.aggregate = {
-        eventsCount: 1,
-        containersOpened: 1,
-        actualValueTotal: 489000,
-        actualValuePartialEvents: 0,
-        expectedValueTotal: 725000,
-        expectedValueAvailableEvents: 1,
-        itemTotals: { '/items/coin': 42938, '/items/shard_of_protection': 8, '/items/pearl': 1 },
-        itemValueTotals: { '/items/coin': 42938, '/items/shard_of_protection': 400000 },
-    };
-    mocks.knownContainers = ['/items/chest'];
-    mocks.domObserverRegistrations = [];
-    document.body.innerHTML = '';
-    openableAnalyticsUI.cleanup();
-    openableAnalyticsUI.initialize();
-    openableAnalyticsUI.selectedContainer = '/items/chest';
-    openableAnalyticsUI.selectedScope = 'session';
-});
-
-describe('buildSummary', () => {
-    test('labels the live opening-event count as "Tracked opening events" (section 3.1)', () => {
-        const wrapper = openableAnalyticsUI.buildSummary();
-
-        expect(wrapper.textContent).toContain('Tracked opening events');
-        expect(wrapper.textContent).not.toContain('Opening events1');
-    });
-
-    test('shows a real Luck value when every valuation record folded into the aggregate is Luck-eligible', () => {
-        mocks.aggregate = {
-            ...mocks.aggregate,
+    mocks.aggregates = {
+        '/items/chest': {
+            eventsCount: 1,
+            containersOpened: 6,
+            actualValueTotal: 489000,
+            actualValuePartialEvents: 0,
+            expectedValueTotal: 725000,
+            expectedValueAvailableEvents: 1,
             valuationRecordCount: 1,
             luckEligibleRecordCount: 1,
-        };
-
-        const wrapper = openableAnalyticsUI.buildSummary();
-
-        expect(wrapper.textContent).not.toContain('LuckN/A');
-    });
-
-    test('AGG-1: shows Luck N/A when one folded valuation record is partial/unavailable, even though others are eligible', () => {
-        mocks.aggregate = {
-            ...mocks.aggregate,
-            valuationRecordCount: 3,
-            luckEligibleRecordCount: 2,
-        };
-
-        const wrapper = openableAnalyticsUI.buildSummary();
-        const rows = [...wrapper.querySelectorAll('div')].filter((el) => el.children.length === 2);
-        const luckRow = rows.find((row) => row.textContent.startsWith('Luck'));
-
-        expect(luckRow.textContent).toBe('LuckN/A');
-    });
-
-    test('marks Actual Value (partial) when the aggregate has any partial-actual events', () => {
-        mocks.aggregate = { ...mocks.aggregate, actualValuePartialEvents: 1 };
-
-        const wrapper = openableAnalyticsUI.buildSummary();
-
-        expect(wrapper.textContent).toContain('(partial)');
-    });
-
-    test('AGG-2: shows Expected Value as N/A rather than a fabricated total when no record has Expected available', () => {
-        mocks.aggregate = { ...mocks.aggregate, expectedValueAvailableEvents: 0, expectedValueTotal: 0 };
-
-        const wrapper = openableAnalyticsUI.buildSummary();
-        const rows = [...wrapper.querySelectorAll('div')].filter((el) => el.children.length === 2);
-        const expectedRow = rows.find((row) => row.textContent.startsWith('Expected Value'));
-
-        expect(expectedRow.textContent).toBe('Expected ValueN/A');
-    });
-
-    test('section 3.3/3.4: notes imported-vs-live valuation timing and overlap risk only for a Lifetime scope with imported data', () => {
-        openableAnalyticsUI.selectedScope = 'lifetime';
-        mocks.aggregate = { ...mocks.aggregate, hasImportedData: true };
-
-        const wrapper = openableAnalyticsUI.buildSummary();
-
-        expect(wrapper.textContent).toContain('additive');
-        expect(wrapper.textContent).toContain('double-count');
-    });
-
-    test('shows the plain event-time note for a Session scope (no import ambiguity)', () => {
-        openableAnalyticsUI.selectedScope = 'session';
-
-        const wrapper = openableAnalyticsUI.buildSummary();
-
-        expect(wrapper.textContent).toContain('snapshotted using Toolasha pricing');
-        expect(wrapper.textContent).not.toContain('double-count');
-    });
+            hasImportedData: false,
+            itemTotals: { '/items/coin': 42938, '/items/shard_of_protection': 8, '/items/pearl': 1 },
+            itemValueTotals: { '/items/coin': 42938, '/items/shard_of_protection': 400000 },
+        },
+    };
+    mocks.knownContainers = ['/items/chest'];
+    mocks.sessionContainers = [];
+    mocks.importSourceKeys = [];
+    mocks.importedContainerHrids = {};
+    mocks.domObserverRegistrations = [];
+    mocks.stateChangeCallbacks = [];
+    mocks.currentCharacterName = 'Vovchigus';
+    mocks.importContainersResult = { results: [], persisted: true };
+    mocks.removeImportResult = true;
+    mocks.resetContainerResult = true;
+    mocks.resetAllResult = true;
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+    // Original Storage getter (localStorage) is jsdom-provided; clear between tests.
+    localStorage.clear();
+    openableAnalyticsUI.cleanup();
+    openableAnalyticsUI.initialize();
 });
 
-describe('buildItemOutcomes', () => {
-    test('shows each item’s count alongside its cumulative value', () => {
-        const wrapper = openableAnalyticsUI.buildItemOutcomes();
+function popup() {
+    return document.querySelector('.toolasha-openable-analytics-popup');
+}
 
-        expect(wrapper.textContent).toContain('42938 (42K)');
-        expect(wrapper.textContent).toContain('8 (400K)');
+function accordionRow(containerHrid) {
+    return [...popup().querySelectorAll('[data-container-hrid]')].find(
+        (el) => el.dataset.containerHrid === containerHrid
+    );
+}
+
+describe('persistent Inventory panel entry point (OA-RUNTIME-1)', () => {
+    test('catches up on a target that already exists before initialize', () => {
+        openableAnalyticsUI.cleanup();
+        const preExisting = document.createElement('div');
+        preExisting.className = INVENTORY_FILTER_CONTAINER_CLASS;
+        document.body.appendChild(preExisting);
+
+        openableAnalyticsUI.initialize();
+
+        expect(preExisting.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`)).toHaveLength(1);
     });
 
-    test('shows N/A for an item with a count but no resolved cumulative value', () => {
-        const wrapper = openableAnalyticsUI.buildItemOutcomes();
-
-        expect(wrapper.textContent).toContain('1 (N/A)');
-    });
-
-    test('sorts by count descending, unchanged from before this feature', () => {
-        const wrapper = openableAnalyticsUI.buildItemOutcomes();
-        const rows = [...wrapper.querySelectorAll('div')].filter((el) => el.children.length === 2);
-
-        expect(rows[0].textContent).toContain('coin');
-        expect(rows[1].textContent).toContain('shard_of_protection');
-    });
-
-    test('shows an empty-state message when there are no items in scope', () => {
-        mocks.aggregate = { ...mocks.aggregate, itemTotals: {}, itemValueTotals: {} };
-
-        const wrapper = openableAnalyticsUI.buildItemOutcomes();
-
-        expect(wrapper.textContent).toContain('No items gained in this scope.');
-    });
-});
-
-describe('persistent Inventory panel entry point', () => {
-    function filterContainerCallbacks() {
-        return mocks.domObserverRegistrations
-            .filter((r) => r.classNames === INVENTORY_FILTER_CONTAINER_CLASS)
-            .map((r) => r.callback);
-    }
-
-    test('injects a button into the Inventory panel search bar row', () => {
+    test('injects a button into a target that mounts later', () => {
         const filterContainer = document.createElement('div');
         document.body.appendChild(filterContainer);
 
         filterContainerCallbacks().forEach((cb) => cb(filterContainer));
 
         expect(filterContainer.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`)).toHaveLength(1);
+    });
+
+    test('multiple existing matching targets each get exactly one control', () => {
+        openableAnalyticsUI.cleanup();
+        const a = document.createElement('div');
+        const b = document.createElement('div');
+        a.className = INVENTORY_FILTER_CONTAINER_CLASS;
+        b.className = INVENTORY_FILTER_CONTAINER_CLASS;
+        document.body.appendChild(a);
+        document.body.appendChild(b);
+
+        openableAnalyticsUI.initialize();
+
+        expect(a.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`)).toHaveLength(1);
+        expect(b.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`)).toHaveLength(1);
     });
 
     test('does not inject a second button if one is already present (idempotent on re-render)', () => {
@@ -200,14 +204,25 @@ describe('persistent Inventory panel entry point', () => {
         expect(filterContainer.querySelectorAll(`.${INVENTORY_BUTTON_CLASS}`)).toHaveLength(1);
     });
 
-    test('clicking the button opens the Analytics popup even with no specific opening context', () => {
+    test('is a real <button> with an accessible label', () => {
+        const filterContainer = document.createElement('div');
+        document.body.appendChild(filterContainer);
+        filterContainerCallbacks().forEach((cb) => cb(filterContainer));
+
+        const button = filterContainer.querySelector(`.${INVENTORY_BUTTON_CLASS}`);
+        expect(button.tagName).toBe('BUTTON');
+        expect(button.getAttribute('aria-label')).toBe('Openable Analytics');
+    });
+
+    test('clicking the button opens Lifetime with all rows collapsed', () => {
         const filterContainer = document.createElement('div');
         document.body.appendChild(filterContainer);
         filterContainerCallbacks().forEach((cb) => cb(filterContainer));
 
         filterContainer.querySelector(`.${INVENTORY_BUTTON_CLASS}`).onclick();
 
-        expect(document.querySelector('.toolasha-openable-analytics-popup')).not.toBeNull();
+        expect(popup()).not.toBeNull();
+        expect(popup().querySelectorAll('details[open]')).toHaveLength(0);
     });
 
     test('cleanup unregisters the observer so a later re-initialize does not double-register', () => {
@@ -216,5 +231,393 @@ describe('persistent Inventory panel entry point', () => {
         openableAnalyticsUI.initialize();
 
         expect(filterContainerCallbacks()).toHaveLength(1);
+    });
+});
+
+describe('View Analytics entry point (section 9)', () => {
+    test('opens Lifetime with the requested container expanded and brought into view', () => {
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        const row = accordionRow('/items/chest');
+        expect(row.open).toBe(true);
+    });
+
+    test('does not default to Session', () => {
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        const lifetimeButton = [...popup().querySelectorAll('button')].find((b) => b.textContent === 'Lifetime');
+        expect(lifetimeButton.style.background).not.toBe('#2a2a2a');
+    });
+});
+
+describe('Session vs Lifetime scope (section 9)', () => {
+    test('Session only lists containers that actually exist in the current in-memory Session', () => {
+        mocks.sessionContainers = [];
+        mocks.knownContainers = ['/items/chest'];
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.setScope('session');
+
+        expect(popup().textContent).toContain('No tracked chest, crate, or cache openings this session.');
+    });
+
+    test('switching scope clears the expanded selection if the container does not exist in the new scope', () => {
+        mocks.sessionContainers = [];
+        mocks.knownContainers = ['/items/chest'];
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        openableAnalyticsUI.setScope('session');
+
+        expect(popup().querySelectorAll('details[open]')).toHaveLength(0);
+    });
+
+    test('switching scope preserves the expanded selection if the container exists in both', () => {
+        mocks.sessionContainers = ['/items/chest'];
+        mocks.knownContainers = ['/items/chest'];
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        openableAnalyticsUI.setScope('session');
+
+        expect(accordionRow('/items/chest').open).toBe(true);
+    });
+});
+
+describe('one-open accordion behavior (section 9)', () => {
+    beforeEach(() => {
+        mocks.aggregates['/items/crate'] = emptyAggregate();
+        mocks.knownContainers = ['/items/chest', '/items/crate'];
+    });
+
+    test('expanding a second row collapses the first', () => {
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        openableAnalyticsUI.toggleContainer('/items/crate');
+
+        expect(accordionRow('/items/chest').open).toBe(false);
+        expect(accordionRow('/items/crate').open).toBe(true);
+    });
+
+    test('clicking an already-expanded row collapses it and clears selection', () => {
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        openableAnalyticsUI.toggleContainer('/items/chest');
+
+        expect(accordionRow('/items/chest').open).toBe(false);
+        expect(openableAnalyticsUI.expandedContainer).toBeNull();
+    });
+
+    test('rows are sorted alphabetically by display name, not by recent activity', () => {
+        openableAnalyticsUI.showPopup();
+        const names = [...popup().querySelectorAll('summary')].map((el) => el.textContent);
+        // "chest" < "crate" alphabetically
+        expect(names[0]).toContain('chest');
+    });
+});
+
+describe('unrelated live update safety (section 9)', () => {
+    test('a state-change notification refreshes content without stealing the current selection', () => {
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        mocks.stateChangeCallbacks.forEach((cb) => cb());
+
+        expect(accordionRow('/items/chest').open).toBe(true);
+    });
+
+    test('does not refresh (or throw) when the popup is not mounted', () => {
+        openableAnalyticsUI.closePopup();
+
+        expect(() => mocks.stateChangeCallbacks.forEach((cb) => cb())).not.toThrow();
+    });
+});
+
+describe('Actual/Expected/Luck detail contract (section 10)', () => {
+    test('does not repeat Tracked opening events / Containers opened / Partial-data rows from the old dashboard', () => {
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        expect(popup().textContent).not.toContain('Tracked opening events');
+        expect(popup().textContent).not.toContain('Partial-data events');
+    });
+
+    test('shows Actual [Partial] and Luck as an unavailable dash when Actual is incomplete', () => {
+        mocks.aggregates['/items/chest'] = {
+            ...mocks.aggregates['/items/chest'],
+            actualValuePartialEvents: 1,
+            luckEligibleRecordCount: 0,
+        };
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        expect(popup().textContent).toContain('[Partial]');
+    });
+
+    test('complete Expected of exactly zero still shows an absolute Luck value, omitting only the percent', () => {
+        mocks.aggregates['/items/chest'] = {
+            ...mocks.aggregates['/items/chest'],
+            actualValueTotal: 500,
+            expectedValueTotal: 0,
+            expectedValueAvailableEvents: 1,
+            valuationRecordCount: 1,
+            luckEligibleRecordCount: 1,
+        };
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        const row = accordionRow('/items/chest');
+        expect(row.textContent).toContain('+500');
+        expect(row.textContent).not.toContain('%');
+    });
+});
+
+describe('Loot table (section 11)', () => {
+    test('renamed from "Aggregated Item Outcomes" to "Loot"', () => {
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        expect(popup().textContent).toContain('Loot');
+        expect(popup().textContent).not.toContain('Aggregated Item Outcomes');
+    });
+
+    test('a resolved positive value sorts before a resolved zero, which sorts before an unavailable value', () => {
+        mocks.aggregates['/items/chest'] = {
+            ...emptyAggregate(),
+            itemTotals: { '/items/a': 1, '/items/b': 1, '/items/c': 1 },
+            itemValueTotals: { '/items/a': 0, '/items/b': 100 },
+        };
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        const rows = [...accordionRow('/items/chest').querySelectorAll('table tr')].slice(1); // skip header
+        expect(rows[0].textContent).toContain('b'); // positive value first
+        expect(rows[1].textContent).toContain('a'); // known zero second
+        expect(rows[2].textContent).toContain('c'); // unavailable last
+    });
+
+    test('unavailable value renders as a dash, not N/A', () => {
+        mocks.aggregates['/items/chest'] = {
+            ...emptyAggregate(),
+            itemTotals: { '/items/mystery': 1 },
+            itemValueTotals: {},
+        };
+        openableAnalyticsUI.showPopup({ containerHrid: '/items/chest' });
+
+        expect(accordionRow('/items/chest').textContent).toContain('—');
+        expect(accordionRow('/items/chest').textContent).not.toContain('N/A');
+    });
+});
+
+describe('Manage Data (section 14)', () => {
+    test('is collapsed by default', () => {
+        openableAnalyticsUI.showPopup();
+
+        expect(popup().querySelector('.toolasha-openable-analytics-manage-data').open).toBe(false);
+    });
+
+    test('lists each import source with a Remove Import action', () => {
+        mocks.importSourceKeys = ['import:edible'];
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.manageDataOpen = true;
+        openableAnalyticsUI.renderBody();
+
+        expect(popup().textContent).toContain('Edible Tools');
+        expect(popup().textContent).toContain('Remove Import');
+    });
+
+    test('Delete Container action only appears when a container is currently expanded', () => {
+        openableAnalyticsUI.showPopup(); // nothing expanded
+
+        expect(popup().textContent).not.toMatch(/Delete .* Data/);
+
+        openableAnalyticsUI.toggleContainer('/items/chest');
+        expect(popup().textContent).toMatch(/Delete .* Data/);
+    });
+
+    test('removeImport keeps the popup open and shows a status message', async () => {
+        mocks.importSourceKeys = ['import:edible'];
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.manageDataOpen = true;
+        openableAnalyticsUI.renderBody();
+
+        await openableAnalyticsUI.handleRemoveImport('import:edible');
+
+        expect(popup()).not.toBeNull();
+        expect(openableAnalyticsDataCollector.removeImport).toHaveBeenCalledWith('import:edible');
+    });
+
+    test('Delete All uses native confirm() and does not silently close the popup', async () => {
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+        openableAnalyticsUI.showPopup();
+
+        await openableAnalyticsUI.handleDeleteAll();
+
+        expect(confirmSpy).toHaveBeenCalled();
+        expect(popup()).not.toBeNull();
+        confirmSpy.mockRestore();
+    });
+
+    test('Delete All does nothing when confirm() is declined', async () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+        await openableAnalyticsUI.handleDeleteAll();
+
+        expect(openableAnalyticsDataCollector.resetAll).not.toHaveBeenCalled();
+    });
+});
+
+describe('async mutation safety (section 24)', () => {
+    test('a mutation handler cannot resurrect the popup if it was closed during the await', async () => {
+        let resolvePersist;
+        openableAnalyticsDataCollector.resetAll.mockReturnValueOnce(
+            new Promise((resolve) => {
+                resolvePersist = resolve;
+            })
+        );
+        openableAnalyticsUI.showPopup();
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+        const pending = openableAnalyticsUI.handleDeleteAll();
+        openableAnalyticsUI.closePopup();
+        resolvePersist(true);
+        await pending;
+
+        expect(popup()).toBeNull();
+    });
+
+    test('handleConfirmImport does not reopen a closed popup after its await', async () => {
+        let resolvePersist;
+        openableAnalyticsDataCollector.importContainers.mockReturnValueOnce(
+            new Promise((resolve) => {
+                resolvePersist = resolve;
+            })
+        );
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.pendingImport = {
+            source: 'edible',
+            prefixedSource: 'import:edible',
+            containers: [{ containerHrid: '/items/chest', containerCount: 1, itemTotals: {} }],
+            warnings: [],
+        };
+
+        const pending = openableAnalyticsUI.handleConfirmImport();
+        openableAnalyticsUI.closePopup();
+        resolvePersist({ persisted: true });
+        await pending;
+
+        expect(popup()).toBeNull();
+    });
+});
+
+describe('import auto-detect and preflight (sections 16, 21)', () => {
+    test('an unsupported/unparseable paste shows an inline error, not a thrown exception', () => {
+        detectImportSource.mockReturnValue({ source: null, error: 'Not a supported format.' });
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.manageDataOpen = true;
+        openableAnalyticsUI.renderBody();
+
+        expect(() => openableAnalyticsUI.beginImport('not json')).not.toThrow();
+        expect(popup().textContent).toContain('Not a supported format.');
+    });
+
+    test('a detected, ready-to-import source shows Import (not Replace) when the source is new', () => {
+        detectImportSource.mockReturnValue({ source: 'mwi-combat-suite' });
+        parseCombatSuiteExport.mockReturnValue({
+            status: 'ready',
+            containers: [{ containerHrid: '/items/chest', containerCount: 5, itemTotals: {} }],
+            warnings: [],
+        });
+        mocks.importSourceKeys = [];
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.manageDataOpen = true;
+        openableAnalyticsUI.renderBody();
+
+        openableAnalyticsUI.beginImport('{"chests":{}}');
+
+        expect(popup().textContent).toContain('Import');
+        expect(popup().textContent).not.toContain('Replace Import');
+    });
+
+    test('re-importing an existing source shows Replace Import wording', () => {
+        detectImportSource.mockReturnValue({ source: 'mwi-combat-suite' });
+        parseCombatSuiteExport.mockReturnValue({
+            status: 'ready',
+            containers: [{ containerHrid: '/items/chest', containerCount: 5, itemTotals: {} }],
+            warnings: [],
+        });
+        mocks.importSourceKeys = ['import:mwi-combat-suite'];
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.manageDataOpen = true;
+        openableAnalyticsUI.renderBody();
+
+        openableAnalyticsUI.beginImport('{"chests":{}}');
+
+        expect(popup().textContent).toContain('Replace Import');
+    });
+
+    test('an overlapping container against live history shows the overlap warning, not a silent auto-dedupe', () => {
+        detectImportSource.mockReturnValue({ source: 'mwi-combat-suite' });
+        parseCombatSuiteExport.mockReturnValue({
+            status: 'ready',
+            containers: [{ containerHrid: '/items/chest', containerCount: 5, itemTotals: {} }],
+            warnings: [],
+        });
+        mocks.aggregates['/items/chest'] = { ...emptyAggregate(), eventsCount: 3 };
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.manageDataOpen = true;
+        openableAnalyticsUI.renderBody();
+
+        openableAnalyticsUI.beginImport('{"chests":{}}');
+
+        expect(popup().textContent).toContain('cannot be reliably deduplicated');
+    });
+
+    test('a valid-empty export shows a no-op status message', () => {
+        detectImportSource.mockReturnValue({ source: 'edible' });
+        parseEdibleExport.mockReturnValue({
+            status: 'empty',
+            message: 'No opening history found in this export. Existing import was not changed.',
+            containers: [],
+            warnings: [],
+        });
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.manageDataOpen = true;
+        openableAnalyticsUI.renderBody();
+
+        openableAnalyticsUI.beginImport('{"Chest_Open_Data":{}}');
+
+        expect(popup().textContent).toContain('Existing import was not changed');
+    });
+
+    test('FileReader failure shows an inline error without destroying other pending state', () => {
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.manageDataOpen = true;
+        openableAnalyticsUI.renderBody();
+
+        openableAnalyticsUI.pendingImport = { errorMessage: 'Could not read the selected file.' };
+        openableAnalyticsUI.renderBody();
+
+        expect(popup().textContent).toContain('Could not read the selected file.');
+    });
+});
+
+describe('character lifecycle (section 8)', () => {
+    test('cleanup removes the popup and persistent entry point observer registration', () => {
+        openableAnalyticsUI.showPopup();
+        expect(popup()).not.toBeNull();
+
+        openableAnalyticsUI.cleanup();
+
+        expect(popup()).toBeNull();
+    });
+
+    test('a stale onStateChange callback from before cleanup cannot refresh/reopen after cleanup', () => {
+        openableAnalyticsUI.showPopup();
+        const staleCallbacks = [...mocks.stateChangeCallbacks];
+
+        openableAnalyticsUI.cleanup();
+
+        expect(() => staleCallbacks.forEach((cb) => cb())).not.toThrow();
+        expect(popup()).toBeNull();
+    });
+
+    test('character A ON -> B OFF -> A ON: a fresh initialize starts with a clean, non-mounted popup', () => {
+        openableAnalyticsUI.showPopup();
+        openableAnalyticsUI.cleanup(); // switch to B, feature off
+
+        openableAnalyticsUI.initialize(); // switch back to A
+        expect(popup()).toBeNull();
     });
 });

--- a/src/features/inventory/openable-analytics/openable-analytics.js
+++ b/src/features/inventory/openable-analytics/openable-analytics.js
@@ -1,0 +1,23 @@
+/**
+ * Openable Analytics Feature
+ * Main entry point for Actual vs Expected Value + Luck tracking on openable containers.
+ */
+
+import openableAnalyticsDataCollector from './openable-analytics-data-collector.js';
+import openableAnalyticsUI from './openable-analytics-ui.js';
+
+async function initialize() {
+    await openableAnalyticsDataCollector.initialize();
+    openableAnalyticsUI.initialize();
+}
+
+function cleanup() {
+    openableAnalyticsDataCollector.cleanup();
+    openableAnalyticsUI.cleanup();
+}
+
+export default {
+    name: 'Openable Analytics',
+    initialize,
+    cleanup,
+};

--- a/src/libraries/market.js
+++ b/src/libraries/market.js
@@ -45,6 +45,7 @@ import dungeonTokenTooltips from '../features/inventory/dungeon-token-tooltips.j
 import autoAllButton from '../features/inventory/auto-all-button.js';
 import inventoryCategoryTotals from '../features/inventory/inventory-category-totals.js';
 import customTabsFeature from '../features/inventory/custom-tabs/custom-tabs-feature.js';
+import openableAnalytics from '../features/inventory/openable-analytics/openable-analytics.js';
 
 // Export to global namespace
 const toolashaRoot = window.Toolasha || {};
@@ -86,6 +87,7 @@ toolashaRoot.Market = {
     autoAllButton,
     inventoryCategoryTotals,
     customTabsFeature,
+    openableAnalytics,
     marketplaceShortcuts,
     sellQueue,
 };


### PR DESCRIPTION
## Summary

- Adds **Openable Analytics** (chests/crates/caches): tracks Actual Value, Expected Value, and Luck (Actual - Expected) for each opening, using the native `loot_opened` WebSocket message.
- Reuses Toolasha's existing Expected Value calculator (`resolveSellSideValue`, `calculateExpectedValue`) and Pricing & Profit / tax stack rather than duplicating drop math or adding a parallel valuation system.
- Compact summary line injected into the native "Opened Loot" modal (idempotent - self-corrects whether the modal remounts or updates in place for a new opening), plus a character-scoped Analytics popup with a Session/Lifetime toggle and a single-open accordion of containers (Actual/Expected/Luck detail and a Loot table per container, plus per-container/Delete-All destructive resets under a collapsed Manage Data section).
- Non-monetary/buff-only openables (e.g. Seal of ... scrolls) are counted but show Expected as `—` - never a fabricated zero/Luck value.
- Character-scoped IndexedDB storage (new `openableAnalytics` store, `dbVersion` 19 → 20): lifetime aggregates persist independently of a bounded 500-event detailed history per character, so pruning history never changes lifetime totals.
- New settings toggle: `openableAnalytics` (default on), under "Inventory & Net Worth".

### Historical import (Edible Tools / MWI Combat Suite)

- Added a paste/upload import panel inside the Analytics popup for both **Edible Tools** and **MWI Combat Suite**.
- Both source tools only retain cumulative per-chest totals (no per-opening timestamps), so imports are merged into the **Lifetime aggregate only** - never the bounded per-event history, since there's no event-level data to give it.
- Actual/Expected/Luck are always **recomputed from the imported raw item counts** through Toolasha's own pricing/EV stack, never trusting either tool's own stored valuation numbers.
- Re-importing the same source **replaces** that source's previous per-container total instead of double-counting.
- Edible Tools data is keyed by localized display name, not HRID - import resolves names against current game data and reports anything it can't match instead of dropping it silently.
- Both Edible Tools and MWI Combat Suite imports carry ownership metadata (exact player-ID match, exact recorded-name match, or explicit unknown) into a shared preflight warning, so importing another character's export always surfaces a matched/mismatched/unknown warning before committing - not just for one of the two sources.
- Shared parser contract (`{containerHrid, containerCount, itemTotals}`) means a future third source only needs its own parser - no changes to storage or the data collector.

### Per-item value (in the modal and tracked historically)

- Each item in the native "Opened Loot" modal's "You found:" list now gets its own small value label (e.g. under the Coin icon, under the Pearl icon), not just the aggregate summary line. Shows `—` rather than a fabricated number for anything that couldn't be priced.
- The per-item breakdown is snapshotted into history and folded into a new per-item cumulative value total on the Lifetime aggregate, so the Analytics popup's Loot table now shows value alongside count for each item type.
- Two coordinated triggers (data-arrival + an observer on the item icons themselves) keep labels correct whether the native modal fully remounts for a new opening or updates its content in place. Labeling is skipped entirely - never guessed - if the rendered icon count doesn't match the value breakdown for that render.

### Standalone dev/test build IndexedDB isolation (TLA-022)

- The standalone dev/test build (`npm run build:dev`, `dist/Toolasha-dev.user.js`) previously shared the released product's `ToolashaDB` identity. Installing it on the normal production origin could upgrade the real `ToolashaDB` to this branch's unreleased schema, after which released Toolasha could never reopen it (`VersionError`) until a manual backup/delete/restore.
- The standalone dev build now injects a build-channel marker at build time and uses an isolated, schema-scoped `ToolashaDB-dev-v<version>` namespace; production is unaffected and still uses `ToolashaDB`.
- The standalone dev userscript is now visibly named `Toolasha DEV` and has production `@downloadURL`/`@updateURL` stripped.
- A `VersionError` on `indexedDB.open()` now reports a newer-schema diagnostic and never deletes/recreates the database.

### Pre-merge lifecycle hardening

Three deterministic gaps found in a final pre-merge review, all fixed with focused regressions (see commit `4087b952`):

- The persistent Inventory-panel entry point button now fails closed: injection is gated on the feature actually being initialized (a stale/captured DOM-observer callback can no longer inject a button after `cleanup()`), and `cleanup()` now removes every already-mounted Openable Analytics button instead of leaving it behind.
- Per-container delete and Delete All now consume the collector's persistence-success boolean instead of discarding it, and show a visible error next to the relevant control if the deletion could not be saved (data may reappear after reload) - previously this failure was silent past a `console.error`.
- `parseEdibleExport()` now returns the same `ownerName`/`ownerMismatch` metadata MWI Combat Suite imports already returned, so a single-player Edible export belonging to a different character now gets the same ownership-mismatch preflight warning.

## Test plan

- [x] 232 focused tests across calculator/storage/data-collector/modal-injector/import-parsers/UI, covering the original report's 16 acceptance criteria, import behavior, per-item value display/tracking, and the three pre-merge lifecycle fixes above.
- [x] Full suite: 1619/1619 passing (121 files)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run build:dev`, `npm run build`, `npm run build:enhancement` all pass
- [x] `npm run check:loadout-state` gate passes
- [x] CI bundle-size gate replicated locally - all bundles well under the 2MB limit
- [x] Standalone dev build artifact inspected: `Toolasha DEV` header, no production `@downloadURL`/`@updateURL`, isolated `ToolashaDB-dev-v20` namespace; production artifact confirmed unaffected (`Toolasha`, `ToolashaDB`)
- [ ] Live UI placement/spacing inside the actual native "Opened Loot" modal, the import panel's in-popup layout, and per-item label placement on the real item icons - can't be triggered/viewed on-demand in this sandbox. The Analytics popup itself has been visually confirmed working in-game (screenshot provided during review).
