### PR TITLE
fix: restore Character Activity acceptance correctness (TLA-025)

### DIFF
--- a/src/core/config-settings-loaded.test.js
+++ b/src/core/config-settings-loaded.test.js
@@ -78,6 +78,26 @@ describe('Config — onSettingsLoaded (character-switch settings resync)', () =>
         expect(changeSpy).not.toHaveBeenCalled();
     });
 
+    test('CA-50: fires within the synchronous tail of loadSettings(), strictly before anything the caller sequences after awaiting it (e.g. character-scoped feature init)', async () => {
+        settingsStorage.loadSettings.mockResolvedValueOnce({
+            profitCalc_pricingMode: { value: 'optimistic' },
+        });
+        const order = [];
+        // Mirrors character-activity-account-prefs-sync.js registering via onSettingsLoaded to
+        // keep the account preference mirror fresh before Character Activity's character-scoped
+        // feature initializes.
+        config.onSettingsLoaded(() => order.push('account-prefs-mirror-synced'));
+
+        const loadPromise = config.loadSettings({ notifyChanges: false });
+        order.push('load-in-flight');
+        await loadPromise;
+        // Caller code (main.js / feature-registry.js) always sequences feature initialization
+        // strictly after awaiting loadSettings() - simulated here as the next step.
+        order.push('character-scoped-feature-init');
+
+        expect(order).toEqual(['load-in-flight', 'account-prefs-mirror-synced', 'character-scoped-feature-init']);
+    });
+
     test('offSettingsLoaded unregisters the callback', async () => {
         settingsStorage.loadSettings.mockResolvedValueOnce({
             profitCalc_pricingMode: { value: 'optimistic' },

--- a/src/core/feature-registry-lifecycle.test.js
+++ b/src/core/feature-registry-lifecycle.test.js
@@ -251,4 +251,191 @@ describe('FeatureRegistry character-switch lifecycle ownership', () => {
             expect(content).not.toContain("dataManager.on('character_switching'");
         }
     });
+
+    test('TLA-025: a character switch beginning mid-initialize still finds and cleans up the in-flight feature', async () => {
+        const registry = (await import('./feature-registry.js')).default;
+        const initGate = createDeferred();
+        const featureModule = {
+            initialize: vi.fn(() => initGate.promise),
+            cleanup: vi.fn(),
+        };
+
+        registry.replaceFeatures([
+            {
+                key: 'slowFeature',
+                name: 'Slow Feature',
+                module: featureModule,
+                initialize: featureModule.initialize,
+            },
+        ]);
+        registry.setupCharacterSwitchHandler();
+
+        // initialize() is still pending - featureInstances must already know about this feature.
+        const initPromise = registry.initializeFeatures();
+
+        mocks.currentCharacterId = 'b';
+        mocks.handlers.get('character_switching')({ oldId: 'a', newId: 'b' });
+
+        // cleanupFeatures() runs its synchronous work before any await - this assertion
+        // intentionally happens before yielding to Promise jobs.
+        expect(featureModule.cleanup).toHaveBeenCalledTimes(1);
+
+        initGate.resolve();
+        await initPromise;
+    });
+
+    test('CA-54: a concurrent second init pass cannot start the same feature twice', async () => {
+        const registry = (await import('./feature-registry.js')).default;
+        const initGate = createDeferred();
+        const featureModule = {
+            initialize: vi.fn(() => initGate.promise),
+            cleanup: vi.fn(),
+        };
+
+        registry.replaceFeatures([
+            {
+                key: 'concurrentFeature',
+                name: 'Concurrent Feature',
+                module: featureModule,
+                initialize: featureModule.initialize,
+            },
+        ]);
+
+        // Ownership is claimed synchronously before the first await, so a second call made before
+        // the first one yields must see the key already owned and skip it entirely.
+        const first = registry.initializeFeatures();
+        const second = registry.initializeFeatures();
+
+        initGate.resolve();
+        await Promise.all([first, second]);
+
+        expect(featureModule.initialize).toHaveBeenCalledTimes(1);
+    });
+
+    test('CA-55: a stale resolve from a cleaned-up initialize cannot overwrite ownership reclaimed by a later init pass', async () => {
+        const registry = (await import('./feature-registry.js')).default;
+        const firstGate = createDeferred();
+        const secondGate = createDeferred();
+        const firstInstance = { tag: 'first' };
+        const secondInstance = { tag: 'second' };
+        let callCount = 0;
+        const featureModule = {
+            initialize: vi.fn(() => {
+                callCount += 1;
+                return callCount === 1 ? firstGate.promise : secondGate.promise;
+            }),
+            cleanup: vi.fn(),
+        };
+
+        registry.replaceFeatures([
+            {
+                key: 'raceFeature',
+                name: 'Race Feature',
+                module: featureModule,
+                initialize: featureModule.initialize,
+            },
+        ]);
+        registry.setupCharacterSwitchHandler();
+
+        const firstInit = registry.initializeFeatures();
+
+        mocks.currentCharacterId = 'b';
+        mocks.handlers.get('character_switching')({ oldId: 'a', newId: 'b' });
+        // cleanupFeatures() ran synchronously above: it saw the provisional ownership token (the
+        // real instance never arrived yet), called module cleanup with `null`, and removed ownership.
+        expect(featureModule.cleanup).toHaveBeenCalledTimes(1);
+        expect(featureModule.cleanup).toHaveBeenLastCalledWith(null);
+
+        // A later init pass reclaims the now-empty key with a brand-new ownership token while the
+        // FIRST initialize() call is still pending.
+        const secondInit = registry.initializeFeatures();
+        expect(featureModule.initialize).toHaveBeenCalledTimes(2);
+
+        // The stale first call resolves after the second pass has already reclaimed ownership -
+        // it must not resurrect/overwrite the newer owner.
+        firstGate.resolve(firstInstance);
+        await firstInit;
+
+        secondGate.resolve(secondInstance);
+        await secondInit;
+
+        // Prove which instance actually ended up owning the slot by cleaning up again: it must be
+        // the second (current) instance, never the stale first instance the cleaned-up call
+        // resolved with.
+        mocks.currentCharacterId = 'a';
+        const switching = mocks.handlers.get('character_switching')({ oldId: 'b', newId: 'a' });
+        expect(featureModule.cleanup).toHaveBeenLastCalledWith(secondInstance);
+        await switching;
+    });
+
+    test('CA-56: releasing provisional ownership on rejection only happens if this attempt still owns the key', async () => {
+        const registry = (await import('./feature-registry.js')).default;
+        const featureModule = {
+            initialize: vi.fn(() => Promise.reject(new Error('boom'))),
+            cleanup: vi.fn(),
+        };
+
+        registry.replaceFeatures([
+            {
+                key: 'rejectingFeature',
+                name: 'Rejecting Feature',
+                module: featureModule,
+                initialize: featureModule.initialize,
+            },
+        ]);
+
+        await registry.initializeFeatures();
+        expect(featureModule.initialize).toHaveBeenCalledTimes(1);
+
+        // Ownership must have been released on rejection (never left dangling forever) so a later
+        // init pass can retry the feature instead of silently treating it as already-initialized.
+        await registry.initializeFeatures();
+        expect(featureModule.initialize).toHaveBeenCalledTimes(2);
+    });
+
+    test('CA-57: retryFailedFeatures() claims ownership before awaiting and cannot resurrect after cleanup reclaims the key', async () => {
+        const registry = (await import('./feature-registry.js')).default;
+        const retryGate = createDeferred();
+        const reclaimInstance = { tag: 'reclaimed' };
+        let initCallCount = 0;
+        const featureModule = {
+            initialize: vi.fn(() => {
+                initCallCount += 1;
+                return initCallCount === 1 ? retryGate.promise : Promise.resolve(reclaimInstance);
+            }),
+            cleanup: vi.fn(),
+        };
+
+        registry.replaceFeatures([
+            {
+                key: 'retryFeature',
+                name: 'Retry Feature',
+                module: featureModule,
+                initialize: featureModule.initialize,
+                healthCheck: () => true,
+            },
+        ]);
+        registry.setupCharacterSwitchHandler();
+
+        const retryPromise = registry.retryFailedFeatures([{ key: 'retryFeature' }]);
+
+        // retryFailedFeatures() must have claimed ownership synchronously before awaiting - a
+        // character switch beginning mid-retry must still find and clean up the in-flight feature.
+        mocks.currentCharacterId = 'b';
+        mocks.handlers.get('character_switching')({ oldId: 'a', newId: 'b' });
+        expect(featureModule.cleanup).toHaveBeenCalledTimes(1);
+
+        // A fresh init pass reclaims the key with a new token while the stale retry call is still pending.
+        await registry.initializeFeatures();
+        expect(featureModule.initialize).toHaveBeenCalledTimes(2);
+
+        // The stale retry resolves after reclaim - it must not overwrite the freshly claimed ownership.
+        retryGate.resolve({ tag: 'stale' });
+        await retryPromise;
+
+        mocks.currentCharacterId = 'a';
+        const switching = mocks.handlers.get('character_switching')({ oldId: 'b', newId: 'a' });
+        expect(featureModule.cleanup).toHaveBeenLastCalledWith(reclaimInstance);
+        await switching;
+    });
 });

--- a/src/core/feature-registry.js
+++ b/src/core/feature-registry.js
@@ -39,6 +39,12 @@ async function initializeFeatures({ shouldContinue = () => true } = {}) {
             break;
         }
 
+        // Unique provisional ownership token for this initialize() attempt. A plain sentinel
+        // (e.g. `null`) cannot distinguish "still owned by this attempt" from "reclaimed by a
+        // later attempt after cleanup ran" - only an object identity comparison against this
+        // exact token can. Declared outside the try so the catch block can also identify it.
+        let ownershipToken;
+
         try {
             const isEnabled = feature.customCheck ? feature.customCheck() : config.isFeatureEnabled(feature.key);
 
@@ -46,10 +52,18 @@ async function initializeFeatures({ shouldContinue = () => true } = {}) {
                 continue;
             }
 
-            // Skip if already initialized (idempotency — same-character resync guard)
+            // Skip if already initialized (idempotency — same-character resync guard, and also
+            // what stops a concurrent second init pass from starting the same feature twice).
             if (featureInstances.has(feature.key)) {
                 continue;
             }
+
+            // Claim ownership synchronously, before awaiting, so cleanupFeatures() can find and
+            // tear down this feature even if a character switch begins while initialize() is
+            // still in flight - slow persistence inside a feature must never decide whether
+            // cleanup can see it.
+            ownershipToken = Symbol(feature.key);
+            featureInstances.set(feature.key, ownershipToken);
 
             // Initialize feature; always await the result so async flag is not required for correctness
             const start = performance.now();
@@ -57,9 +71,20 @@ async function initializeFeatures({ shouldContinue = () => true } = {}) {
             const elapsed = performance.now() - start;
             performanceMonitor.snapshot(`init:${feature.key}`, elapsed);
 
-            // Store the returned instance (may be undefined for module-singleton features)
-            featureInstances.set(feature.key, instance ?? null);
+            // A concurrent cleanupFeatures() may have already reclaimed and deleted this entry
+            // (and possibly torn the feature back down), or a later attempt may have re-claimed
+            // the key, while initialize() was in flight - only replace the entry if it's still
+            // the exact token this attempt claimed; otherwise a stale resolve must not resurrect
+            // or overwrite ownership that has since moved on.
+            if (featureInstances.get(feature.key) === ownershipToken) {
+                featureInstances.set(feature.key, instance ?? null);
+            }
         } catch (error) {
+            // Release ownership on rejection only if this attempt's token still owns the key -
+            // a concurrent cleanup/reclaim may have already replaced it, in which case leave it alone.
+            if (ownershipToken !== undefined && featureInstances.get(feature.key) === ownershipToken) {
+                featureInstances.delete(feature.key);
+            }
             errors.push({
                 feature: feature.name,
                 error: error.message,
@@ -85,9 +110,14 @@ async function cleanupFeatures() {
     for (const feature of featureRegistry) {
         if (!featureInstances.has(feature.key)) continue;
 
-        const instance = featureInstances.get(feature.key);
+        const rawEntry = featureInstances.get(feature.key);
         featureInstances.delete(feature.key);
         performanceMonitor.clearSnapshot(`init:${feature.key}`);
+
+        // While initialize() is still pending, the stored entry is a provisional ownership
+        // token (a Symbol), never a real feature instance - module cleanup must see "no instance
+        // yet" (null), not leak the internal token as if it were the feature's returned value.
+        const instance = typeof rawEntry === 'symbol' ? null : rawEntry;
 
         try {
             const featureModule = feature.module || feature;
@@ -298,12 +328,19 @@ async function retryFailedFeatures(failedFeatures) {
         const feature = getFeature(failed.key);
         if (!feature) continue;
 
-        // Clear stale instance state so initializeFeatures won't skip it
+        // Clear any stale entry so initializeFeatures won't skip it, then immediately reclaim
+        // ownership with a fresh unique token (see initializeFeatures) so cleanupFeatures() can
+        // still find this feature - and only this retry attempt can resolve its own claim - if a
+        // character switch begins while this retry's initialize() is in flight.
         featureInstances.delete(feature.key);
+        const ownershipToken = Symbol(feature.key);
+        featureInstances.set(feature.key, ownershipToken);
 
         try {
             const instance = await Promise.resolve(feature.initialize());
-            featureInstances.set(feature.key, instance ?? null);
+            if (featureInstances.get(feature.key) === ownershipToken) {
+                featureInstances.set(feature.key, instance ?? null);
+            }
 
             // Verify the retry actually worked by running health check
             if (feature.healthCheck) {
@@ -313,6 +350,9 @@ async function retryFailedFeatures(failedFeatures) {
                 }
             }
         } catch (error) {
+            if (featureInstances.get(feature.key) === ownershipToken) {
+                featureInstances.delete(feature.key);
+            }
             console.error(`[Toolasha] ${feature.name} retry failed:`, error);
         }
     }

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -255,10 +255,36 @@ class Storage {
         }
 
         if (immediate) {
-            return this._saveToIndexedDB(key, value, storeName);
+            return this._saveImmediate(key, value, storeName);
         } else {
             return this._debouncedSave(key, value, storeName);
         }
+    }
+
+    /**
+     * Internal: Save immediately, superseding any pending debounced write for the same key so it
+     * can never later overwrite this value with stale data.
+     * @private
+     */
+    async _saveImmediate(key, value, storeName) {
+        const timerKey = `${storeName}:${key}`;
+
+        if (this.saveDebounceTimers.has(timerKey)) {
+            clearTimeout(this.saveDebounceTimers.get(timerKey));
+            this.saveDebounceTimers.delete(timerKey);
+        }
+        // Claim the slot so a same-tick-scheduled old timer sees `!pending` and no-ops, and bump
+        // the generation as a second guard against any already-in-flight timer callback.
+        const pending = this.pendingWrites.get(timerKey);
+        this.pendingWrites.delete(timerKey);
+        this._writeGeneration.set(timerKey, (this._writeGeneration.get(timerKey) || 0) + 1);
+
+        const success = await this._saveToIndexedDB(key, value, storeName);
+
+        if (pending) {
+            for (const resolve of pending.resolvers) resolve(success);
+        }
+        return success;
     }
 
     /**

--- a/src/core/storage.test.js
+++ b/src/core/storage.test.js
@@ -172,6 +172,40 @@ describe('Storage write durability (TLA-007)', () => {
         expect(goodDb._store['z']).toBe('new');
     });
 
+    test('TLA-025: an immediate write supersedes an older still-pending debounced write to the same key', async () => {
+        const s = await makeStorage();
+        const goodDb = makeFakeDb(false);
+        s.db = goodDb;
+
+        const debouncedPromise = s.set('shared', 'A', 'settings'); // pending, timer not fired yet
+        const immediatePromise = s.set('shared', 'B', 'settings', true); // supersedes it right away
+
+        expect(await immediatePromise).toBe(true);
+        expect(goodDb._store['shared']).toBe('B');
+
+        // Let the old debounce timer's opportunity pass - it must be a no-op, not overwrite B with A.
+        await vi.runAllTimersAsync();
+        expect(goodDb._store['shared']).toBe('B');
+
+        // The superseded debounced caller must still resolve rather than hang forever.
+        expect(await debouncedPromise).toBe(true);
+        expect(s.pendingWrites.has('settings:shared')).toBe(false);
+    });
+
+    test('TLA-025: normal debounce coalescing is unaffected by the immediate-write path', async () => {
+        const s = await makeStorage();
+        const goodDb = makeFakeDb(false);
+        s.db = goodDb;
+
+        const p1 = s.set('k', 'v1', 'settings');
+        const p2 = s.set('k', 'v2', 'settings');
+        await vi.runAllTimersAsync();
+
+        expect(goodDb._store['k']).toBe('v2');
+        expect(await p1).toBe(true);
+        expect(await p2).toBe(true);
+    });
+
     test('cleanupPendingWrites resolves all pending promises with false', async () => {
         const s = await makeStorage();
         s.db = makeFakeDb(false);

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -862,6 +862,10 @@ if (isCombatSimulatorPage()) {
     // since Character Select can be the very first page shown in a session.
     UI.characterSelectRenderer.startWatching();
 
+    // Keeps the account-level preference mirror Character Select reads fresh independently of
+    // whether the character-scoped Character Activity collector is currently running.
+    UI.startAccountPreferencesSync();
+
     // Set up scroll listener to dismiss stuck tooltips
     setupScrollTooltipDismissal();
 

--- a/src/features/actions/action-time-display.js
+++ b/src/features/actions/action-time-display.js
@@ -512,33 +512,41 @@ export class ActionTimeDisplay {
                     limitType: null,
                     limitLabel: '',
                     isEnhancing,
+                    // Calculation failure, not a genuine zero-duration/zero-work result - callers
+                    // must fail closed to uncertain rather than treat this as an ended action.
+                    timingUnavailable: true,
                 };
             }
 
             const { actionTime, totalEfficiency } = timeData;
 
-            if (isInfinite) {
-                const equipment = context.equipment;
-                const itemDetailMap = dataManager.getInitClientData()?.itemDetailMap || {};
-                const drinkConcentration = getDrinkConcentration(equipment, itemDetailMap);
-                const artisanBonus = parseArtisanBonus(context.drinks, itemDetailMap, drinkConcentration);
+            // Native header logic always computes the resource/gold/upgrade limit and, when the
+            // action hasMaxCount, takes min(resourceLimit, maxCount-currentCount) - a finite action
+            // can still end on exhausted materials before reaching its requested count.
+            const equipment = context.equipment;
+            const itemDetailMap = dataManager.getInitClientData()?.itemDetailMap || {};
+            const drinkConcentration = getDrinkConcentration(equipment, itemDetailMap);
+            const artisanBonus = parseArtisanBonus(context.drinks, itemDetailMap, drinkConcentration);
 
-                const limitResult = this.calculateMaterialLimit(
-                    actionDetails,
-                    inventoryLookup,
-                    artisanBonus,
-                    actionObj
-                );
-                if (limitResult) {
-                    materialLimit = limitResult.maxActions;
-                    limitType = limitResult.limitType;
-                }
+            const limitResult = this.calculateMaterialLimit(actionDetails, inventoryLookup, artisanBonus, actionObj);
+            if (limitResult) {
+                materialLimit = limitResult.maxActions;
+                limitType = limitResult.limitType;
             }
 
             isTrulyInfinite = isInfinite && materialLimit === null;
 
             if (!isInfinite) {
-                count = actionObj.maxCount - actionObj.currentCount;
+                const requestedCount = actionObj.maxCount - actionObj.currentCount;
+                if (materialLimit !== null && materialLimit < requestedCount) {
+                    count = materialLimit;
+                } else {
+                    count = requestedCount;
+                    // The requested count itself is the binding constraint here, not the resource
+                    // limit (if any) - clear limitType so callers don't misreport this as a
+                    // materials/gold/upgrade-item cause when the queue count is what actually ends it.
+                    limitType = null;
+                }
             } else if (materialLimit !== null) {
                 count = materialLimit;
             }

--- a/src/features/actions/action-time-display.test.js
+++ b/src/features/actions/action-time-display.test.js
@@ -684,3 +684,100 @@ describe('ActionTimeDisplay Current Action Bar DOM ownership (TLA-035)', () => {
         expect(oldProfitElement.innerHTML).toBe('');
     });
 });
+
+describe('ActionTimeDisplay finite-count actions also respect the material/resource limit (TLA-025)', () => {
+    let instance;
+
+    const actionDetails = {
+        type: '/action_types/cheesesmithing',
+        inputItems: [{ itemHrid: '/items/iron', count: 1 }],
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        instance = new ActionTimeDisplay();
+        calculateActionStats.mockReturnValue({ actionTime: 10, totalEfficiency: 0 });
+        calculateEfficiencyMultiplier.mockReturnValue(1);
+        dataManager.getElapsedSecondsInCurrentUnit.mockReturnValue(0);
+    });
+
+    function makeAction(overrides = {}) {
+        return {
+            id: 1,
+            hasMaxCount: true,
+            maxCount: 100,
+            currentCount: 0,
+            actionHrid: '/actions/cheesesmithing/iron_bar',
+            ...overrides,
+        };
+    }
+
+    test('materials run out before the requested count: count/time reflect the material limit, not maxCount', () => {
+        const inventoryLookup = { byHrid: { '/items/iron': 40 }, byEnhancedKey: {} };
+        const result = instance.calculateSingleQueueActionTime(makeAction(), actionDetails, inventoryLookup);
+        expect(result.count).toBe(40);
+        expect(result.totalTime).toBe(400); // 40 actions * 10s
+        expect(result.limitType).toBe('material:/items/iron');
+    });
+
+    test('materials are plentiful: count/time reflect maxCount, and limitType is cleared (not misreported as materials)', () => {
+        const inventoryLookup = { byHrid: { '/items/iron': 1000 }, byEnhancedKey: {} };
+        const result = instance.calculateSingleQueueActionTime(makeAction(), actionDetails, inventoryLookup);
+        expect(result.count).toBe(100);
+        expect(result.totalTime).toBe(1000);
+        expect(result.limitType).toBeNull();
+    });
+
+    test('no input items at all: unaffected by the material-limit check (still just maxCount-currentCount)', () => {
+        const inventoryLookup = { byHrid: {}, byEnhancedKey: {} };
+        const result = instance.calculateSingleQueueActionTime(
+            makeAction(),
+            { type: '/action_types/cheesesmithing' },
+            inventoryLookup
+        );
+        expect(result.count).toBe(100);
+        expect(result.totalTime).toBe(1000);
+        expect(result.limitType).toBeNull();
+    });
+});
+
+describe('ActionTimeDisplay calculation failure fails closed instead of a fake zero-duration result (TLA-025)', () => {
+    let instance;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        instance = new ActionTimeDisplay();
+    });
+
+    test('calculateActionTime returning null (e.g. unresolvable action stats) sets timingUnavailable, not a real 0s result', () => {
+        calculateActionStats.mockReturnValue(null);
+        const inventoryLookup = { byHrid: {}, byEnhancedKey: {} };
+        const action = { id: 1, hasMaxCount: true, maxCount: 5, currentCount: 0, actionHrid: '/actions/woodcutting/x' };
+
+        const result = instance.calculateSingleQueueActionTime(
+            action,
+            { type: '/action_types/woodcutting' },
+            inventoryLookup
+        );
+
+        expect(result.timingUnavailable).toBe(true);
+        expect(result.totalTime).toBe(0);
+    });
+
+    test('a genuinely successful calculation never sets timingUnavailable', () => {
+        calculateActionStats.mockReturnValue({ actionTime: 10, totalEfficiency: 0 });
+        calculateEfficiencyMultiplier.mockReturnValue(1);
+        dataManager.getElapsedSecondsInCurrentUnit.mockReturnValue(0);
+        const inventoryLookup = { byHrid: {}, byEnhancedKey: {} };
+        const action = { id: 1, hasMaxCount: true, maxCount: 5, currentCount: 0, actionHrid: '/actions/woodcutting/x' };
+
+        const result = instance.calculateSingleQueueActionTime(
+            action,
+            { type: '/action_types/woodcutting' },
+            inventoryLookup
+        );
+
+        expect(result.timingUnavailable).toBeUndefined();
+        expect(result.totalTime).toBe(50);
+    });
+});

--- a/src/features/character-activity/character-activity-account-prefs-sync.js
+++ b/src/features/character-activity/character-activity-account-prefs-sync.js
@@ -1,0 +1,54 @@
+/**
+ * Character Activity Account Preferences Sync
+ * Keeps the account-level preference mirror (enabled flag + date/time format) fresh independently
+ * of whether the character-scoped Character Activity collector is currently running. The
+ * always-on Character Select renderer reads that mirror before any character has ever connected,
+ * or after the feature has been toggled off - the collector itself only writes it while active,
+ * so this listens directly to settings infrastructure that stays live regardless.
+ */
+
+import config from '../../core/config.js';
+import { saveAccountPreferences } from './character-activity-storage.js';
+import characterSelectRenderer from './character-select-renderer.js';
+
+function readCurrentAccountPreferences() {
+    return {
+        enabled: config.getSetting('characterActivityStatus'),
+        dateFormat: config.getSettingValue('market_listingDateFormat', 'MM-DD'),
+        timeFormat: config.getSettingValue('market_listingTimeFormat', '24hour'),
+    };
+}
+
+// These writes are rare (a settings change, not a hot path) and should preserve callback order
+// even if IndexedDB/rendering is momentarily slow - a serialized queue keeps two rapid changes
+// from committing (or refreshing the renderer) out of order.
+let accountPreferencesSyncQueue = Promise.resolve();
+
+function syncAccountPreferencesMirror() {
+    // Capture one coherent settings snapshot at callback time, before this task's turn in the queue.
+    const prefs = readCurrentAccountPreferences();
+
+    accountPreferencesSyncQueue = accountPreferencesSyncQueue
+        .catch((error) => {
+            console.warn('[Character Activity] Previous account preference sync failed:', error);
+        })
+        .then(async () => {
+            const saved = await saveAccountPreferences(prefs, true);
+            if (!saved) return;
+            await characterSelectRenderer.refreshNow();
+        });
+
+    return accountPreferencesSyncQueue;
+}
+
+/**
+ * Register the always-on listeners. Safe to call once at module/page-load time, before
+ * config.initialize() has even run - onSettingChange/onSettingsLoaded only register callbacks
+ * for later, and reads before initialization complete safely fall back to schema defaults.
+ */
+export function startAccountPreferencesSync() {
+    config.onSettingsLoaded(syncAccountPreferencesMirror);
+    config.onSettingChange('characterActivityStatus', syncAccountPreferencesMirror);
+    config.onSettingChange('market_listingDateFormat', syncAccountPreferencesMirror);
+    config.onSettingChange('market_listingTimeFormat', syncAccountPreferencesMirror);
+}

--- a/src/features/character-activity/character-activity-account-prefs-sync.test.js
+++ b/src/features/character-activity/character-activity-account-prefs-sync.test.js
@@ -1,0 +1,157 @@
+/**
+ * Tests for the account-preference mirror sync (TLA-025 item 17): the mirror must stay fresh via
+ * config's own settings-loaded/change infrastructure, independent of whether the character-scoped
+ * Character Activity collector is currently running.
+ */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    settingsLoadedCallbacks: [],
+    settingChangeCallbacks: {},
+    settingValue: true,
+    savedPrefs: null,
+}));
+
+vi.mock('../../core/config.js', () => ({
+    default: {
+        getSetting: vi.fn(() => mocks.settingValue),
+        getSettingValue: vi.fn((key, defaultValue) => defaultValue),
+        onSettingsLoaded: vi.fn((cb) => mocks.settingsLoadedCallbacks.push(cb)),
+        onSettingChange: vi.fn((key, cb) => {
+            (mocks.settingChangeCallbacks[key] ||= []).push(cb);
+        }),
+    },
+}));
+
+vi.mock('./character-activity-storage.js', () => ({
+    saveAccountPreferences: vi.fn(async (prefs) => {
+        mocks.savedPrefs = prefs;
+        return true;
+    }),
+}));
+
+vi.mock('./character-select-renderer.js', () => ({
+    default: { refreshNow: vi.fn(async () => {}) },
+}));
+
+const { startAccountPreferencesSync } = await import('./character-activity-account-prefs-sync.js');
+const { saveAccountPreferences } = await import('./character-activity-storage.js');
+const { default: config } = await import('../../core/config.js');
+const { default: characterSelectRenderer } = await import('./character-select-renderer.js');
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.settingsLoadedCallbacks = [];
+    mocks.settingChangeCallbacks = {};
+    mocks.settingValue = true;
+    mocks.savedPrefs = null;
+});
+
+describe('startAccountPreferencesSync', () => {
+    test('registers an onSettingsLoaded listener and one onSettingChange listener per relevant setting', () => {
+        startAccountPreferencesSync();
+
+        expect(config.onSettingsLoaded).toHaveBeenCalledTimes(1);
+        expect(config.onSettingChange).toHaveBeenCalledWith('characterActivityStatus', expect.any(Function));
+        expect(config.onSettingChange).toHaveBeenCalledWith('market_listingDateFormat', expect.any(Function));
+        expect(config.onSettingChange).toHaveBeenCalledWith('market_listingTimeFormat', expect.any(Function));
+    });
+
+    test('onSettingsLoaded firing writes the mirror immediately and then refreshes the renderer', async () => {
+        startAccountPreferencesSync();
+
+        await mocks.settingsLoadedCallbacks[0]();
+
+        expect(saveAccountPreferences).toHaveBeenCalledWith(
+            { enabled: true, dateFormat: 'MM-DD', timeFormat: '24hour' },
+            true
+        );
+        expect(characterSelectRenderer.refreshNow).toHaveBeenCalledTimes(1);
+    });
+
+    test('toggling characterActivityStatus off refreshes the mirror with the new value, with no active collector involved', async () => {
+        startAccountPreferencesSync();
+        mocks.settingValue = false;
+
+        await mocks.settingChangeCallbacks.characterActivityStatus[0]();
+
+        expect(mocks.savedPrefs.enabled).toBe(false);
+        expect(characterSelectRenderer.refreshNow).toHaveBeenCalledTimes(1);
+    });
+
+    test('changing the date/time format settings also refreshes the mirror', async () => {
+        startAccountPreferencesSync();
+
+        await mocks.settingChangeCallbacks.market_listingDateFormat[0]();
+        expect(saveAccountPreferences).toHaveBeenCalled();
+
+        await mocks.settingChangeCallbacks.market_listingTimeFormat[0]();
+        expect(saveAccountPreferences).toHaveBeenCalledTimes(2);
+    });
+
+    test('TLA-025 DEV4 fix: a slow immediate write does not skip the renderer refresh', async () => {
+        startAccountPreferencesSync();
+        let releaseSave;
+        saveAccountPreferences.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    releaseSave = () => resolve(true);
+                })
+        );
+
+        const syncPromise = mocks.settingsLoadedCallbacks[0]();
+        // Let the queued `.then()` actually invoke saveAccountPreferences before asserting.
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(characterSelectRenderer.refreshNow).not.toHaveBeenCalled();
+
+        releaseSave();
+        await syncPromise;
+
+        expect(characterSelectRenderer.refreshNow).toHaveBeenCalledTimes(1);
+    });
+
+    test('TLA-025 DEV4 fix: a failed immediate write does not trigger a renderer refresh', async () => {
+        startAccountPreferencesSync();
+        saveAccountPreferences.mockResolvedValueOnce(false);
+
+        await mocks.settingsLoadedCallbacks[0]();
+
+        expect(characterSelectRenderer.refreshNow).not.toHaveBeenCalled();
+    });
+
+    test('TLA-025 DEV4 fix: two rapid setting changes complete in callback order even if the first persist resolves slowly', async () => {
+        startAccountPreferencesSync();
+        const order = [];
+        let releaseFirst;
+        saveAccountPreferences.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    releaseFirst = () => {
+                        order.push('first-saved');
+                        resolve(true);
+                    };
+                })
+        );
+        saveAccountPreferences.mockImplementationOnce(async () => {
+            order.push('second-saved');
+            return true;
+        });
+        characterSelectRenderer.refreshNow.mockImplementation(async () => {
+            order.push('refresh');
+        });
+
+        mocks.settingValue = false;
+        const first = mocks.settingChangeCallbacks.characterActivityStatus[0]();
+        mocks.settingValue = true;
+        const second = mocks.settingChangeCallbacks.characterActivityStatus[0]();
+
+        // Let the first task's saveAccountPreferences() call actually start before releasing it.
+        await Promise.resolve();
+        await Promise.resolve();
+        releaseFirst();
+        await Promise.all([first, second]);
+
+        expect(order).toEqual(['first-saved', 'refresh', 'second-saved', 'refresh']);
+    });
+});

--- a/src/features/character-activity/character-activity-collector.js
+++ b/src/features/character-activity/character-activity-collector.js
@@ -39,7 +39,9 @@ class CharacterActivityCollector {
         this.beforeUnloadHandler = () => this.recomputeAndPersist(generation, true);
         window.addEventListener('beforeunload', this.beforeUnloadHandler);
 
-        await this.recomputeAndPersist(generation);
+        // Immediate so a previously-unseen character's first observation is visible right away on
+        // Character Select, without waiting for the normal 3s debounce or a later action update.
+        await this.recomputeAndPersist(generation, true);
     }
 
     /**

--- a/src/features/character-activity/character-activity-collector.test.js
+++ b/src/features/character-activity/character-activity-collector.test.js
@@ -76,6 +76,12 @@ describe('lifecycle registration', () => {
         expect(mocks.savedRecords.get('char-a').record.projection).toBe(mocks.liveProjection);
     });
 
+    test('TLA-025 item 16: the initial persist is immediate, not the normal 3s-debounced write', async () => {
+        await characterActivityCollector.initialize();
+
+        expect(mocks.savedRecords.get('char-a').immediate).toBe(true);
+    });
+
     test('persisted record captures the current offline cap and MooPass expiry', async () => {
         mocks.offlineHourCap = 14;
         mocks.mooPassExpireTime = 99999;

--- a/src/features/character-activity/character-activity-projection.js
+++ b/src/features/character-activity/character-activity-projection.js
@@ -1,55 +1,249 @@
 /**
  * Character Activity Projection Engine
- * Pure functions that project a character's current action + queue forward in time to find
- * the earliest trustworthy point at which useful progress stops (action ends, queue ends,
- * materials run out, or - resolved separately, at display time - the character's offline cap).
- *
- * Deliberately reuses Action Time Display's existing per-action duration/material-limit math
- * (already corrected for partial-progress-in-the-current-unit, TLA-015) rather than building a
- * second duration engine. This module's only job is to walk the queue sequentially and decide
- * where the trustworthy chain has to stop.
+ * Pure functions that project a character's current action + queue forward in time to find the
+ * earliest trustworthy point at which useful progress stops. Reuses Action Time Display's
+ * existing per-action duration/material-limit math rather than a second duration engine.
  */
 
 import dataManager from '../../core/data-manager.js';
 import actionTimeDisplay from '../actions/action-time-display.js';
+import loadoutState from '../../core/loadout-state.js';
+import { resolveCurrentActionContext } from '../../utils/action-context.js';
+import { calculateDrinkRemainingSeconds } from '../../utils/drink-calculator.js';
 
-const UNCERTAIN_ACTION_TYPES = new Set(['/action_types/labyrinth', '/action_types/enhancing']);
+const UNCERTAIN_REASON_BY_TYPE = {
+    '/action_types/labyrinth': 'labyrinth',
+    '/action_types/enhancing': 'enhancing',
+    '/action_types/special': 'special',
+};
 
-/**
- * An action type/hrid this feature will never assert a trustworthy deadline for - Combat and
- * Labyrinth have non-deterministic duration, and Enhancing has a stochastic outcome. Action Time
- * Display shows an expected-value estimate for Enhancing; this feature is intentionally stricter
- * (a false early warning is preferable to telling the player an alt is safe when it might not be).
- * @param {Object} actionObj - Entry from `dataManager.getCurrentActions()`
- * @param {Object} actionDetails - `dataManager.getActionDetails(actionObj.actionHrid)`
- * @returns {boolean}
- */
-function isUncertainAction(actionObj, actionDetails) {
-    if (actionObj.actionHrid?.includes('/combat/')) return true;
-    return UNCERTAIN_ACTION_TYPES.has(actionDetails?.type);
+const RESOURCE_STOP_CAUSES = new Set(['materials', 'coins', 'upgrade-materials']);
+
+// Combat has no dedicated action type of its own - identified by hrid, checked before the map.
+function classifyUncertainty(actionObj, actionDetails) {
+    if (actionObj.actionHrid?.includes('/combat/')) return 'combat';
+    return UNCERTAIN_REASON_BY_TYPE[actionDetails?.type] || null;
 }
 
-function buildSegment({ actionObj, actionDetails, queuedIndex, startAt, endAt, certainty, stopCause }) {
+// Gold/upgrade-item costs are distinct real reasons, not a generic "count" bucket.
+function classifyStopCause(limitType) {
+    if (!limitType) return 'count';
+    if (limitType === 'gold') return 'coins';
+    if (limitType.startsWith('material:')) return 'materials';
+    if (limitType.startsWith('upgrade:')) return 'upgrade-materials';
+    return 'count';
+}
+
+/** Enriched name matching native getActionDisplayName() - item name, enhancement level, combat tier/party. */
+function buildDisplayName(actionObj, actionDetails) {
+    const baseName = actionDetails?.name || actionObj.actionHrid;
+    if (!actionDetails) return baseName;
+
+    if (actionDetails.type === '/action_types/alchemy' && actionObj.primaryItemHash) {
+        const { itemHrid } = actionTimeDisplay.parseItemHash(actionObj.primaryItemHash);
+        const itemDetails = itemHrid ? dataManager.getItemDetails(itemHrid) : null;
+        if (itemDetails?.name) return `${baseName}: ${itemDetails.name}`;
+    }
+
+    if (actionDetails.type === '/action_types/enhancing' && actionObj.primaryItemHash) {
+        const { itemHrid, level } = actionTimeDisplay.parseItemHash(actionObj.primaryItemHash);
+        const itemDetails = itemHrid ? dataManager.getItemDetails(itemHrid) : null;
+        if (itemDetails?.name) return `${itemDetails.name} +${level}`;
+    }
+
+    if (actionObj.actionHrid?.includes('/combat/')) {
+        let name = baseName;
+        if (actionObj.difficultyTier >= 1) name += ` (T${actionObj.difficultyTier})`;
+        if (actionObj.partyID) name += ' (Party)';
+        return name;
+    }
+
+    return baseName;
+}
+
+/**
+ * Consumed/produced item hrids for one segment - identity overlap only (no quantity simulation),
+ * used to detect a LATER resource-limited segment silently depending on stale starting inventory.
+ */
+function getSegmentItemFootprint(actionDetails, actionObj) {
+    const consumed = new Set();
+    const produced = new Set();
+    if (!actionDetails) return { consumed, produced };
+
+    for (const input of actionDetails.inputItems || []) {
+        if (input.itemHrid) consumed.add(input.itemHrid);
+    }
+    if (actionDetails.upgradeItemHrid) consumed.add(actionDetails.upgradeItemHrid);
+    if (actionDetails.coinCost > 0) consumed.add('/items/coin');
+    if (actionObj.primaryItemHash) {
+        const { itemHrid } = actionTimeDisplay.parseItemHash(actionObj.primaryItemHash);
+        if (itemHrid) consumed.add(itemHrid);
+    }
+    if (actionObj.secondaryItemHash) {
+        const { itemHrid } = actionTimeDisplay.parseItemHash(actionObj.secondaryItemHash);
+        if (itemHrid) consumed.add(itemHrid);
+    }
+    for (const output of actionDetails.outputItems || []) {
+        if (output.itemHrid) produced.add(output.itemHrid);
+    }
+    for (const drop of actionDetails.dropTable || []) {
+        if (drop.itemHrid) produced.add(drop.itemHrid);
+    }
+    return { consumed, produced };
+}
+
+function footprintOverlapsSeen(footprint, seenFootprint) {
+    for (const hrid of footprint.consumed) {
+        if (seenFootprint.has(hrid)) return true;
+    }
+    return false;
+}
+
+/**
+ * Native queued actions use `characterLoadoutID` (capital ID) - Toolasha's DataManager preserves
+ * the raw server object rather than renaming it. `0`/null/missing means no explicit native
+ * loadout (the native queue/header UI itself only renders a loadout marker when truthy). A
+ * malformed non-zero value fails closed rather than silently falling through to a predictive
+ * default.
+ * @param {Object} actionObj
+ * @returns {{hasExplicitLoadout: boolean, loadoutId: number|null, malformed: boolean}}
+ */
+function getNativeQueuedLoadoutIdentity(actionObj) {
+    const raw = actionObj?.characterLoadoutID;
+
+    if (raw === undefined || raw === null || raw === 0 || raw === '0') {
+        return { hasExplicitLoadout: false, loadoutId: null, malformed: false };
+    }
+
+    const loadoutId = Number(raw);
+    if (!Number.isSafeInteger(loadoutId) || loadoutId <= 0) {
+        return { hasExplicitLoadout: true, loadoutId: null, malformed: true };
+    }
+
+    return { hasExplicitLoadout: true, loadoutId, malformed: false };
+}
+
+/**
+ * Resolve the equipment/drinks context for a queued (i>0) segment tagged with an explicit native
+ * `characterLoadoutID`: use exactly that loadout, or fail closed (return `unresolvable: true`) if
+ * it's missing/deleted/has unavailable equipment - never substitute an unrelated Toolasha
+ * predictive default for a loadout the player explicitly configured for this queued action.
+ * Drinks follow the same atomic-context rule as the predictive resolver
+ * (resolveActionContext in action-context.js): an action-specific loadout's own resolved saved
+ * drinks apply (`drinksApplicable === true`), but an All Skills loadout structurally never carries
+ * real drink slots, so its always-blank drinks array is a void, not a player choice - use the
+ * action's current drinks instead, preserving current-main semantics.
+ * @param {number} loadoutId
+ * @param {string} actionTypeHrid
+ * @returns {{context: Object, unresolvable: false}|{context: null, unresolvable: true}}
+ */
+function resolveExplicitQueuedLoadoutContext(loadoutId, actionTypeHrid) {
+    const snapshot = loadoutState.getUsableSnapshotById(loadoutId);
+    if (!snapshot) return { context: null, unresolvable: true };
+
+    const drinks = snapshot.drinksApplicable
+        ? (snapshot.drinks || []).filter((entry) => entry.itemHrid)
+        : resolveCurrentActionContext(actionTypeHrid).drinks;
+
+    return {
+        context: {
+            equipment: new Map((snapshot.equipment || []).map((entry) => [entry.itemLocationHrid, entry])),
+            drinks,
+        },
+        unresolvable: false,
+    };
+}
+
+/**
+ * Character Activity may publish an ETA only from a structurally valid timing result. Genuine
+ * zero-work/zero-resource boundaries are valid; `Infinity` is valid only when the helper
+ * explicitly proved a truly-unbounded action. Everything else non-finite, negative, or
+ * contradictory (e.g. a finite queued row with real work remaining but no limiter explaining a
+ * zero count) fails closed rather than reaching the persisted timeline.
+ * @param {Object|null|undefined} timing
+ * @param {Object} actionObj
+ * @returns {boolean}
+ */
+function isTrustworthyTimingResult(timing, actionObj) {
+    if (!timing || timing.timingUnavailable) return false;
+
+    const { count, baseActionsNeeded, materialLimit } = timing;
+    if (typeof count !== 'number' || !Number.isFinite(count) || count < 0) return false;
+    if (typeof baseActionsNeeded !== 'number' || !Number.isFinite(baseActionsNeeded) || baseActionsNeeded < 0) {
+        return false;
+    }
+    if (materialLimit !== null && materialLimit !== undefined) {
+        if (typeof materialLimit !== 'number' || !Number.isFinite(materialLimit) || materialLimit < 0) return false;
+    }
+
+    if (timing.isTrulyInfinite) return timing.totalTime === Infinity;
+
+    const { totalTime, actionTimeSeconds } = timing;
+    if (typeof totalTime !== 'number' || !Number.isFinite(totalTime) || totalTime < 0) return false;
+    if (typeof actionTimeSeconds !== 'number' || !Number.isFinite(actionTimeSeconds) || actionTimeSeconds < 0) {
+        return false;
+    }
+
+    if (actionObj?.hasMaxCount) {
+        const { maxCount, currentCount } = actionObj;
+        if (typeof maxCount !== 'number' || !Number.isFinite(maxCount)) return false;
+        if (typeof currentCount !== 'number' || !Number.isFinite(currentCount)) return false;
+        const remaining = maxCount - currentCount;
+        if (remaining < 0 || count > remaining) return false;
+        if (remaining > 0 && count === 0 && !timing.limitType) return false;
+    } else if (count === 0 && !timing.limitType) {
+        // A non-finite native action that isn't truly infinite must have a concrete limiter.
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Epoch ms when the drink(s) slotted for an action type run out, or null. Memoized per type per
+ * projection call; a revisited type still checks the same fixed instant, which can only truncate
+ * a segment earlier than the true cutoff (the drink isn't consumed while a different type runs).
+ */
+function getDrinkCutoffAt(actionTypeHrid, now, cache) {
+    if (cache.has(actionTypeHrid)) return cache.get(actionTypeHrid);
+
+    const drinks = calculateDrinkRemainingSeconds(actionTypeHrid) || [];
+    const minRemainingSeconds = drinks.length ? Math.min(...drinks.map((d) => d.totalSeconds)) : null;
+    const cutoffAt = minRemainingSeconds != null ? now + minRemainingSeconds * 1000 : null;
+
+    cache.set(actionTypeHrid, cutoffAt);
+    return cutoffAt;
+}
+
+function buildSegment({
+    actionObj,
+    actionDetails,
+    queuedIndex,
+    remainingQueuedCount,
+    startAt,
+    endAt,
+    certainty,
+    stopCause,
+}) {
     return {
         actionHrid: actionObj.actionHrid,
         actionName: actionDetails?.name || actionObj.actionHrid,
+        displayName: buildDisplayName(actionObj, actionDetails),
         actionTypeHrid: actionDetails?.type || null,
         startAt,
         endAt,
         queuedIndex,
+        remainingQueuedCount,
         certainty,
         stopCause,
     };
 }
 
 /**
- * Project the character's current action + queue forward from `now`, using only the current
- * live action-queue data. Does not consider the offline-progress cap - that is deliberately
- * resolved later against a live `lastOfflineTime` (see `resolveDisplayProjection`), since while
- * this function runs the character is still connected and hasn't gone offline yet.
- * @param {number} [now] - Epoch ms to project from (defaults to `Date.now()`)
+ * Project the queue forward from `now`. Does not consider the offline-progress cap - see
+ * `resolveDisplayProjection`, resolved separately against a live `lastOfflineTime`.
+ * @param {number} [now]
  * @returns {{segments: Array, terminalCause: string, terminalAt: number|null, certainty: string}}
- *      terminalCause is one of: 'idle' | 'action' | 'queue' | 'materials' | 'infinite' | 'unknown'
  */
 export function computeLiveProjection(now = Date.now()) {
     const actions = dataManager.getCurrentActions();
@@ -59,6 +253,8 @@ export function computeLiveProjection(now = Date.now()) {
     }
 
     const inventoryLookup = actionTimeDisplay.buildInventoryLookup(dataManager.getInventory());
+    const drinkCutoffCache = new Map();
+    const seenFootprint = new Set();
 
     const segments = [];
     let currentTime = now;
@@ -66,36 +262,107 @@ export function computeLiveProjection(now = Date.now()) {
     let terminalAt = null;
     let certainty = 'trustworthy';
 
+    function pushUncertain(actionObj, actionDetails, i, remainingQueuedCount, startAt, stopCause) {
+        segments.push(
+            buildSegment({
+                actionObj,
+                actionDetails,
+                queuedIndex: i,
+                remainingQueuedCount,
+                startAt,
+                endAt: null,
+                certainty: 'uncertain',
+                stopCause,
+            })
+        );
+        terminalCause = 'unknown';
+        terminalAt = null;
+        certainty = 'uncertain';
+    }
+
+    function pushDrinkBoundary(actionObj, actionDetails, i, remainingQueuedCount, startAt, cutoffAt) {
+        segments.push(
+            buildSegment({
+                actionObj,
+                actionDetails,
+                queuedIndex: i,
+                remainingQueuedCount,
+                startAt,
+                endAt: cutoffAt,
+                certainty: 'trustworthy',
+                stopCause: 'drink',
+            })
+        );
+        terminalCause = 'drink';
+        terminalAt = cutoffAt;
+    }
+
     for (let i = 0; i < actions.length; i++) {
         const actionObj = actions[i];
         const actionDetails = dataManager.getActionDetails(actionObj.actionHrid);
+        const remainingQueuedCount = actions.length - i - 1;
 
-        if (!actionDetails || isUncertainAction(actionObj, actionDetails)) {
-            segments.push(
-                buildSegment({
-                    actionObj,
-                    actionDetails,
-                    queuedIndex: i,
-                    startAt: currentTime,
-                    endAt: null,
-                    certainty: 'uncertain',
-                    stopCause: 'unknown',
-                })
-            );
-            terminalCause = 'unknown';
-            terminalAt = null;
-            certainty = 'uncertain';
+        const uncertainReason = actionDetails ? classifyUncertainty(actionObj, actionDetails) : 'timing-unavailable';
+        if (uncertainReason) {
+            pushUncertain(actionObj, actionDetails, i, remainingQueuedCount, currentTime, uncertainReason);
             break;
         }
 
-        const timing = actionTimeDisplay.calculateSingleQueueActionTime(actionObj, actionDetails, inventoryLookup);
+        // The front action already runs on live equipment/drinks (matches Action Time Display's
+        // own current-action surfaces). A queued action explicitly tagged with a native
+        // characterLoadoutID must use exactly that loadout or fail closed if it's unresolvable -
+        // never an unrelated Toolasha predictive default. With no explicit loadout, the
+        // predictive default is the only justifiable context for that eventual action.
+        let actionContext;
+        if (i === 0) {
+            actionContext = resolveCurrentActionContext(actionDetails.type);
+        } else {
+            const nativeLoadout = getNativeQueuedLoadoutIdentity(actionObj);
+            if (nativeLoadout.malformed) {
+                pushUncertain(actionObj, actionDetails, i, remainingQueuedCount, currentTime, 'loadout-unavailable');
+                break;
+            }
+            if (nativeLoadout.hasExplicitLoadout) {
+                const resolved = resolveExplicitQueuedLoadoutContext(nativeLoadout.loadoutId, actionDetails.type);
+                if (resolved.unresolvable) {
+                    pushUncertain(
+                        actionObj,
+                        actionDetails,
+                        i,
+                        remainingQueuedCount,
+                        currentTime,
+                        'loadout-unavailable'
+                    );
+                    break;
+                }
+                actionContext = resolved.context;
+            }
+        }
+        const timing = actionTimeDisplay.calculateSingleQueueActionTime(
+            actionObj,
+            actionDetails,
+            inventoryLookup,
+            actionContext
+        );
+
+        if (!isTrustworthyTimingResult(timing, actionObj)) {
+            pushUncertain(actionObj, actionDetails, i, remainingQueuedCount, currentTime, 'timing-unavailable');
+            break;
+        }
 
         if (timing.isTrulyInfinite) {
+            const drinkCutoffAt = getDrinkCutoffAt(actionDetails.type, now, drinkCutoffCache);
+            if (drinkCutoffAt != null && drinkCutoffAt > currentTime) {
+                pushDrinkBoundary(actionObj, actionDetails, i, remainingQueuedCount, currentTime, drinkCutoffAt);
+                break;
+            }
+
             segments.push(
                 buildSegment({
                     actionObj,
                     actionDetails,
                     queuedIndex: i,
+                    remainingQueuedCount,
                     startAt: currentTime,
                     endAt: null,
                     certainty: 'trustworthy',
@@ -107,26 +374,57 @@ export function computeLiveProjection(now = Date.now()) {
             break;
         }
 
-        const segmentEndAt = currentTime + timing.totalTime * 1000;
-        const stopCause = timing.limitType?.startsWith('material') ? 'materials' : 'count';
+        const stopCause = classifyStopCause(timing.limitType);
+
+        // Check against the ACTUAL item dependency, not merely which limiter won against the
+        // stale starting inventory - a segment whose own calculated stopCause happens to resolve
+        // as 'count' (against that stale snapshot) can still genuinely depend on an earlier
+        // segment's consumption/production of the same item.
+        const footprint = getSegmentItemFootprint(actionDetails, actionObj);
+        if (footprintOverlapsSeen(footprint, seenFootprint)) {
+            pushUncertain(actionObj, actionDetails, i, remainingQueuedCount, currentTime, 'inventory-dependency');
+            break;
+        }
+
+        const naturalEndAt = currentTime + timing.totalTime * 1000;
+        if (!Number.isFinite(naturalEndAt) || naturalEndAt < currentTime) {
+            pushUncertain(actionObj, actionDetails, i, remainingQueuedCount, currentTime, 'timing-unavailable');
+            break;
+        }
+        const drinkCutoffAt = getDrinkCutoffAt(actionDetails.type, now, drinkCutoffCache);
+
+        if (drinkCutoffAt != null && drinkCutoffAt > currentTime && drinkCutoffAt < naturalEndAt) {
+            pushDrinkBoundary(actionObj, actionDetails, i, remainingQueuedCount, currentTime, drinkCutoffAt);
+            break;
+        }
 
         segments.push(
             buildSegment({
                 actionObj,
                 actionDetails,
                 queuedIndex: i,
+                remainingQueuedCount,
                 startAt: currentTime,
-                endAt: segmentEndAt,
+                endAt: naturalEndAt,
                 certainty: 'trustworthy',
                 stopCause,
             })
         );
 
-        currentTime = segmentEndAt;
+        // Track consumed/produced items so a LATER segment depending on them is recognized as no
+        // longer trustworthy - never applied retroactively to this segment's own accepted time.
+        for (const hrid of footprint.consumed) seenFootprint.add(hrid);
+        for (const hrid of footprint.produced) seenFootprint.add(hrid);
+
+        currentTime = naturalEndAt;
 
         if (i === actions.length - 1) {
-            terminalAt = segmentEndAt;
-            terminalCause = stopCause === 'materials' ? 'materials' : segments.length === 1 ? 'action' : 'queue';
+            terminalAt = naturalEndAt;
+            terminalCause = RESOURCE_STOP_CAUSES.has(stopCause)
+                ? stopCause
+                : segments.length === 1
+                  ? 'action'
+                  : 'queue';
         }
     }
 
@@ -134,47 +432,50 @@ export function computeLiveProjection(now = Date.now()) {
 }
 
 /**
- * Resolve a persisted projection into what should actually be displayed right now, applying the
- * offline-progress-cap overlay against a freshly-read native `lastOfflineTime` (from Character
- * Select) - never a value baked in at observation time, since while the character was still
- * connected it hadn't gone offline yet and the true offline boundary wasn't knowable.
- *
- * Never asserts a green/yellow offline deadline across a MooPass expiry boundary this evidence
- * can't prove the server's semantics for - falls back to 'unknown' (neutral, not a false
- * reassurance) in that case, per the fail-closed requirement.
- * @param {Object} stored - A persisted character-activity record (see character-activity-storage.js)
- * @param {number|null} freshLastOfflineTime - Native `lastOfflineTime` from Character Select, ms epoch
- * @returns {{terminalCause: string, terminalAt: number|null, segments: Array}}
+ * Resolve a persisted projection for display now, overlaying the offline-progress cap against a
+ * freshly-read `lastOfflineTime` (never a value baked in at observation time). Fails closed to
+ * 'unknown' rather than asserting a deadline across an unresolved MooPass-expiry boundary, and
+ * still finds a trustworthy deterministic prefix (segments before the first uncertain one) even
+ * when the whole chain is 'unknown' - an early uncertain segment must not hide an earlier,
+ * perfectly knowable offline-cap deadline.
  */
 export function resolveDisplayProjection(stored, freshLastOfflineTime) {
     const { segments, terminalCause, terminalAt } = stored.projection;
 
-    // Already uncertain/idle at observation time - the offline cap can never turn that into a
-    // safe assertion, so there's nothing to overlay.
-    if (terminalCause === 'unknown' || terminalCause === 'idle') {
+    if (terminalCause === 'idle') {
         return { segments, terminalCause, terminalAt };
     }
 
     const offlineHourCap = stored.offline?.hourCap;
-    if (!(offlineHourCap > 0) || freshLastOfflineTime == null) {
-        // No trustworthy cap, or the character hasn't actually gone offline yet by any evidence
-        // we have - an 'infinite' chain has no other possible deadline, so it's unknown; a
-        // finite chain's own terminalAt still stands on its own.
+    const mooPassExpireTime = stored.offline?.mooPassExpireTime;
+    const hasTrustworthyCap = offlineHourCap > 0 && freshLastOfflineTime != null;
+    const offlineLimitAt = hasTrustworthyCap ? freshLastOfflineTime + offlineHourCap * 3600 * 1000 : null;
+    const mooPassAmbiguous = hasTrustworthyCap && mooPassExpireTime != null && mooPassExpireTime < offlineLimitAt;
+
+    if (terminalCause === 'unknown') {
+        const trustworthySegments = segments.filter((s) => s.certainty === 'trustworthy');
+        if (trustworthySegments.length === 0 || !hasTrustworthyCap || mooPassAmbiguous) {
+            return { segments, terminalCause, terminalAt };
+        }
+        const prefixEndAt = trustworthySegments[trustworthySegments.length - 1].endAt;
+        if (prefixEndAt != null && offlineLimitAt < prefixEndAt) {
+            return { segments, terminalCause: 'offline', terminalAt: offlineLimitAt };
+        }
+        return { segments, terminalCause, terminalAt };
+    }
+
+    if (!hasTrustworthyCap) {
         return terminalCause === 'infinite'
             ? { segments, terminalCause: 'unknown', terminalAt: null }
             : { segments, terminalCause, terminalAt };
     }
 
-    const mooPassExpireTime = stored.offline?.mooPassExpireTime;
-    const offlineLimitAt = freshLastOfflineTime + offlineHourCap * 3600 * 1000;
-
-    if (mooPassExpireTime != null && mooPassExpireTime < offlineLimitAt) {
-        // The saved cap may have included MooPass hours that won't all be honored - the server's
-        // mid-offline MooPass-expiry behavior isn't provable from client evidence, so fail closed
-        // rather than assert a deadline that assumes the full cap held.
-        return terminalCause === 'infinite'
-            ? { segments, terminalCause: 'unknown', terminalAt: null }
-            : { segments, terminalCause, terminalAt };
+    if (mooPassAmbiguous) {
+        if (terminalCause === 'infinite') return { segments, terminalCause: 'unknown', terminalAt: null };
+        if (terminalAt != null && terminalAt > mooPassExpireTime) {
+            return { segments, terminalCause: 'unknown', terminalAt: null };
+        }
+        return { segments, terminalCause, terminalAt };
     }
 
     if (terminalCause === 'infinite' || terminalAt === null || offlineLimitAt < terminalAt) {

--- a/src/features/character-activity/character-activity-projection.test.js
+++ b/src/features/character-activity/character-activity-projection.test.js
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({
     actionDetailsByHrid: {},
     inventory: [],
     timingByActionId: {},
+    drinkRemainingSecondsByType: {},
+    usableSnapshotsById: {},
 }));
 
 vi.mock('../../core/data-manager.js', () => ({
@@ -12,6 +14,7 @@ vi.mock('../../core/data-manager.js', () => ({
         getCurrentActions: vi.fn(() => mocks.currentActions),
         getActionDetails: vi.fn((hrid) => mocks.actionDetailsByHrid[hrid] || null),
         getInventory: vi.fn(() => mocks.inventory),
+        getItemDetails: vi.fn(() => null),
     },
 }));
 
@@ -19,10 +22,35 @@ vi.mock('../actions/action-time-display.js', () => ({
     default: {
         buildInventoryLookup: vi.fn((inventory) => ({ inventory })),
         calculateSingleQueueActionTime: vi.fn((actionObj) => mocks.timingByActionId[actionObj.id]),
+        parseItemHash: vi.fn((hash) => {
+            const parts = String(hash).split('::');
+            const itemHrid = parts.find((part) => part.startsWith('/items/')) || null;
+            const last = parts[parts.length - 1];
+            const level = last && !last.startsWith('/') ? parseInt(last, 10) || 0 : 0;
+            return { itemHrid, level };
+        }),
+    },
+}));
+
+vi.mock('../../utils/action-context.js', () => ({
+    resolveActionContext: vi.fn(() => ({ equipment: new Map(), drinks: [] })),
+    resolveCurrentActionContext: vi.fn(() => ({ equipment: new Map(), drinks: [] })),
+}));
+
+vi.mock('../../utils/drink-calculator.js', () => ({
+    calculateDrinkRemainingSeconds: vi.fn((actionTypeHrid) => mocks.drinkRemainingSecondsByType[actionTypeHrid] || []),
+}));
+
+vi.mock('../../core/loadout-state.js', () => ({
+    default: {
+        getUsableSnapshotById: vi.fn((id) => mocks.usableSnapshotsById[String(id)] || null),
     },
 }));
 
 const { computeLiveProjection, resolveDisplayProjection } = await import('./character-activity-projection.js');
+const { default: actionTimeDisplay } = await import('../actions/action-time-display.js');
+const { resolveCurrentActionContext } = await import('../../utils/action-context.js');
+const { default: dataManager } = await import('../../core/data-manager.js');
 
 function action(overrides = {}) {
     return {
@@ -40,19 +68,27 @@ function actionDetails(overrides = {}) {
 }
 
 function timing(overrides = {}) {
+    const totalTime = overrides.totalTime ?? 100;
     return {
-        totalTime: 100,
+        totalTime,
+        actionTimeSeconds: totalTime,
         isTrulyInfinite: false,
         limitType: null,
+        count: 1,
+        baseActionsNeeded: 1,
+        materialLimit: null,
         ...overrides,
     };
 }
 
 beforeEach(() => {
+    vi.clearAllMocks();
     mocks.currentActions = [];
     mocks.actionDetailsByHrid = {};
     mocks.inventory = [];
     mocks.timingByActionId = {};
+    mocks.drinkRemainingSecondsByType = {};
+    mocks.usableSnapshotsById = {};
 });
 
 describe('computeLiveProjection - limiter selection', () => {
@@ -142,6 +178,31 @@ describe('computeLiveProjection - limiter selection', () => {
         expect(result.terminalAt).toBeNull();
         expect(result.certainty).toBe('uncertain');
         expect(result.segments).toHaveLength(1);
+        expect(result.segments[0].stopCause).toBe('combat');
+        // The real native queue has 2 entries; projection stops at index 0, but the true remaining
+        // count (1) must still be recoverable from this segment, not derived from segments.length.
+        expect(result.segments[0].remainingQueuedCount).toBe(1);
+    });
+
+    test('CA-25: a later queued segment with invalid timing stops the chain as unknown while the earlier trustworthy running segment is retained', () => {
+        mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        mocks.timingByActionId.a2 = timing({ totalTime: NaN });
+
+        const now = 1000;
+        const result = computeLiveProjection(now);
+
+        expect(result.terminalCause).toBe('unknown');
+        expect(result.terminalAt).toBeNull();
+        expect(result.segments).toHaveLength(2);
+        // The already-running first segment is untouched - still trustworthy, with its own real
+        // start/end - so a display layer showing "what's running right now" can still use it.
+        expect(result.segments[0].certainty).toBe('trustworthy');
+        expect(result.segments[0].startAt).toBe(now);
+        expect(result.segments[0].endAt).toBe(now + 100_000);
+        expect(result.segments[1].certainty).toBe('uncertain');
+        expect(result.segments[1].stopCause).toBe('timing-unavailable');
     });
 
     test('uncertain Labyrinth action type stops the trustworthy chain', () => {
@@ -155,6 +216,7 @@ describe('computeLiveProjection - limiter selection', () => {
 
         expect(result.terminalCause).toBe('unknown');
         expect(result.certainty).toBe('uncertain');
+        expect(result.segments[0].stopCause).toBe('labyrinth');
     });
 
     test('stochastic Enhancing action type stops the trustworthy chain', () => {
@@ -168,6 +230,22 @@ describe('computeLiveProjection - limiter selection', () => {
 
         expect(result.terminalCause).toBe('unknown');
         expect(result.certainty).toBe('uncertain');
+        expect(result.segments[0].stopCause).toBe('enhancing');
+    });
+
+    test('Special (Party Ready) is treated as uncertain, never fed into deterministic timing math', () => {
+        mocks.currentActions = [action({ id: 'a1', actionHrid: '/actions/special/party_ready' })];
+        mocks.actionDetailsByHrid['/actions/special/party_ready'] = actionDetails({
+            name: 'Party Ready',
+            type: '/action_types/special',
+        });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.terminalCause).toBe('unknown');
+        expect(result.certainty).toBe('uncertain');
+        expect(result.segments[0].stopCause).toBe('special');
+        expect(actionTimeDisplay.calculateSingleQueueActionTime).not.toHaveBeenCalled();
     });
 
     test('idle - no current actions', () => {
@@ -187,6 +265,570 @@ describe('computeLiveProjection - limiter selection', () => {
 
         expect(result.terminalCause).toBe('unknown');
         expect(result.certainty).toBe('uncertain');
+    });
+});
+
+describe('computeLiveProjection - live context for the front action, predictive default for later ones', () => {
+    test('the front (currently running) segment uses resolveCurrentActionContext, not the predictive default', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        const liveContext = { equipment: new Map([['tool', {}]]), drinks: [] };
+        resolveCurrentActionContext.mockReturnValue(liveContext);
+
+        computeLiveProjection(1000);
+
+        expect(resolveCurrentActionContext).toHaveBeenCalledWith('/action_types/woodcutting');
+        expect(actionTimeDisplay.calculateSingleQueueActionTime).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'a1' }),
+            expect.anything(),
+            expect.anything(),
+            liveContext
+        );
+    });
+
+    test('queued (i>0) segments with no explicit characterLoadoutID keep the predictive default', () => {
+        mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        mocks.timingByActionId.a2 = timing({ totalTime: 100 });
+
+        computeLiveProjection(1000);
+
+        expect(actionTimeDisplay.calculateSingleQueueActionTime).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({ id: 'a2' }),
+            expect.anything(),
+            expect.anything(),
+            undefined
+        );
+    });
+
+    test('TLA-025 DEV4 fix: native characterLoadoutID (capital ID) is the field actually consumed, not a lowercase alias', () => {
+        // Deliberately no `characterLoadoutId` anywhere in this fixture - only the real native
+        // spelling - so the earlier casing bug (checking `.characterLoadoutId`) cannot pass again.
+        mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2', characterLoadoutID: 7 })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        mocks.timingByActionId.a2 = timing({ totalTime: 100 });
+        const equipmentEntry = { itemLocationHrid: '/item_locations/tool', itemHrid: '/items/rainbow_hatchet' };
+        mocks.usableSnapshotsById['7'] = {
+            equipment: [equipmentEntry],
+            drinks: [{ itemHrid: '/items/tea' }],
+            drinksApplicable: true,
+        };
+
+        computeLiveProjection(1000);
+
+        const call = actionTimeDisplay.calculateSingleQueueActionTime.mock.calls[1];
+        expect(call[3].equipment.get('/item_locations/tool')).toBe(equipmentEntry);
+        expect(call[3].drinks).toEqual([{ itemHrid: '/items/tea' }]);
+    });
+
+    test('CA-02: characterLoadoutID === null means no explicit native loadout - no lookup is attempted', () => {
+        mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2', characterLoadoutID: null })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        mocks.timingByActionId.a2 = timing({ totalTime: 100 });
+
+        computeLiveProjection(1000);
+
+        expect(actionTimeDisplay.calculateSingleQueueActionTime).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({ id: 'a2' }),
+            expect.anything(),
+            expect.anything(),
+            undefined
+        );
+    });
+
+    test("CA-04: characterLoadoutID === '0' (string) means no explicit native loadout - no lookup is attempted", () => {
+        mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2', characterLoadoutID: '0' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        mocks.timingByActionId.a2 = timing({ totalTime: 100 });
+
+        computeLiveProjection(1000);
+
+        expect(actionTimeDisplay.calculateSingleQueueActionTime).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({ id: 'a2' }),
+            expect.anything(),
+            expect.anything(),
+            undefined
+        );
+    });
+
+    test('CA-06: an equivalent string-numeric characterLoadoutID resolves to the same exact snapshot as the numeric form', () => {
+        mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2', characterLoadoutID: '7' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        mocks.timingByActionId.a2 = timing({ totalTime: 100 });
+        const equipmentEntry = { itemLocationHrid: '/item_locations/tool', itemHrid: '/items/rainbow_hatchet' };
+        mocks.usableSnapshotsById['7'] = { equipment: [equipmentEntry], drinks: [], drinksApplicable: true };
+
+        computeLiveProjection(1000);
+
+        const call = actionTimeDisplay.calculateSingleQueueActionTime.mock.calls[1];
+        expect(call[3].equipment.get('/item_locations/tool')).toBe(equipmentEntry);
+    });
+
+    test('CA-09: a valid explicit queued loadout with intentionally empty equipment stays empty, never falls through to current equipment', () => {
+        mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2', characterLoadoutID: 7 })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        mocks.timingByActionId.a2 = timing({ totalTime: 100 });
+        mocks.usableSnapshotsById['7'] = { equipment: [], drinks: [], drinksApplicable: true };
+
+        computeLiveProjection(1000);
+
+        const call = actionTimeDisplay.calculateSingleQueueActionTime.mock.calls[1];
+        expect(call[3].equipment.size).toBe(0);
+        // resolveCurrentActionContext is called once for the front (i===0) action's live context;
+        // the explicit-loadout queued segment (drinksApplicable === true) must not call it again
+        // and must not fall through to current equipment.
+        expect(resolveCurrentActionContext).toHaveBeenCalledTimes(1);
+    });
+
+    test('CA-10: an action-specific explicit queued loadout (drinksApplicable === true) uses its own resolved saved drinks', () => {
+        mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2', characterLoadoutID: 7 })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        mocks.timingByActionId.a2 = timing({ totalTime: 100 });
+        mocks.usableSnapshotsById['7'] = {
+            equipment: [],
+            drinks: [{ itemHrid: '/items/tea' }],
+            drinksApplicable: true,
+        };
+        resolveCurrentActionContext.mockReturnValue({ equipment: new Map(), drinks: [{ itemHrid: '/items/wrong' }] });
+
+        computeLiveProjection(1000);
+
+        const call = actionTimeDisplay.calculateSingleQueueActionTime.mock.calls[1];
+        expect(call[3].drinks).toEqual([{ itemHrid: '/items/tea' }]);
+    });
+
+    test('CA-11: an All Skills explicit queued loadout (drinksApplicable === false) uses current action drinks, not its always-blank saved drinks', () => {
+        mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2', characterLoadoutID: 7 })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        mocks.timingByActionId.a2 = timing({ totalTime: 100 });
+        const equipmentEntry = { itemLocationHrid: '/item_locations/tool', itemHrid: '/items/rainbow_hatchet' };
+        // All Skills loadouts structurally never carry real drinks - drinks is always blank.
+        mocks.usableSnapshotsById['7'] = { equipment: [equipmentEntry], drinks: [], drinksApplicable: false };
+        const currentDrinks = [{ itemHrid: '/items/current_tea' }];
+        resolveCurrentActionContext.mockReturnValue({ equipment: new Map(), drinks: currentDrinks });
+
+        computeLiveProjection(1000);
+
+        expect(resolveCurrentActionContext).toHaveBeenCalledWith('/action_types/woodcutting');
+        const call = actionTimeDisplay.calculateSingleQueueActionTime.mock.calls[1];
+        expect(call[3].equipment.get('/item_locations/tool')).toBe(equipmentEntry);
+        expect(call[3].drinks).toBe(currentDrinks);
+    });
+
+    test('TLA-025 DEV4 fix: an explicit characterLoadoutID that cannot be resolved fails closed rather than falling back to a Toolasha default', () => {
+        mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2', characterLoadoutID: 99 })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        // No entry in usableSnapshotsById for id 99 - deleted/unusable/missing equipment.
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments).toHaveLength(2);
+        expect(result.segments[1].certainty).toBe('uncertain');
+        expect(result.segments[1].stopCause).toBe('loadout-unavailable');
+        expect(result.terminalCause).toBe('unknown');
+        // The unresolvable loadout must stop the chain before ever computing a duration for it.
+        expect(actionTimeDisplay.calculateSingleQueueActionTime).toHaveBeenCalledTimes(1);
+    });
+
+    test('TLA-025 DEV4 fix: characterLoadoutID === 0 means no explicit native loadout - no lookup is attempted', () => {
+        mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2', characterLoadoutID: 0 })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        mocks.timingByActionId.a2 = timing({ totalTime: 100 });
+
+        computeLiveProjection(1000);
+
+        // Falls through to the predictive-default path (no explicit context passed), never a
+        // loadout lookup or a fail-closed segment.
+        expect(actionTimeDisplay.calculateSingleQueueActionTime).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({ id: 'a2' }),
+            expect.anything(),
+            expect.anything(),
+            undefined
+        );
+    });
+
+    test.each([[-1], [1.5], ['not-a-number']])(
+        'TLA-025 DEV4 fix: a malformed non-zero characterLoadoutID (%p) fails closed, never falls back to a predictive default',
+        (malformedId) => {
+            mocks.currentActions = [action({ id: 'a1' }), action({ id: 'a2', characterLoadoutID: malformedId })];
+            mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+            mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+
+            const result = computeLiveProjection(1000);
+
+            expect(result.segments).toHaveLength(2);
+            expect(result.segments[1].stopCause).toBe('loadout-unavailable');
+            expect(actionTimeDisplay.calculateSingleQueueActionTime).toHaveBeenCalledTimes(1);
+        }
+    );
+});
+
+describe('computeLiveProjection - fail-closed on calculation failure (does not become a fake zero-duration terminal)', () => {
+    test('timingUnavailable is treated as uncertain, never a zero-time deterministic terminal', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = { timingUnavailable: true, totalTime: 0, isTrulyInfinite: false, limitType: null };
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.terminalCause).toBe('unknown');
+        expect(result.terminalAt).toBeNull();
+        expect(result.certainty).toBe('uncertain');
+        expect(result.segments[0].stopCause).toBe('timing-unavailable');
+        expect(result.segments[0].endAt).toBeNull();
+    });
+
+    test('TLA-025 DEV4 fix: NaN totalTime fails closed, never becomes a NaN terminalAt', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: NaN });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.terminalCause).toBe('unknown');
+        expect(result.terminalAt).toBeNull();
+        expect(result.segments[0].stopCause).toBe('timing-unavailable');
+        expect(Number.isNaN(result.terminalAt)).toBe(false);
+    });
+
+    test('TLA-025 DEV4 fix: NaN actionTimeSeconds fails closed', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ actionTimeSeconds: NaN });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.terminalCause).toBe('unknown');
+        expect(result.segments[0].stopCause).toBe('timing-unavailable');
+    });
+
+    test('TLA-025 DEV4 fix: a negative totalTime fails closed', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: -50, actionTimeSeconds: -50 });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.terminalCause).toBe('unknown');
+        expect(result.segments[0].stopCause).toBe('timing-unavailable');
+    });
+
+    test('TLA-025 DEV4 fix: totalTime: Infinity without isTrulyInfinite fails closed rather than being accepted', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({
+            totalTime: Infinity,
+            actionTimeSeconds: Infinity,
+            isTrulyInfinite: false,
+        });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.terminalCause).toBe('unknown');
+        expect(result.segments[0].stopCause).toBe('timing-unavailable');
+    });
+
+    test('TLA-025 DEV4 fix: isTrulyInfinite + totalTime Infinity is accepted as a genuine unbounded action', () => {
+        mocks.currentActions = [action({ id: 'a1', hasMaxCount: false })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({
+            isTrulyInfinite: true,
+            totalTime: Infinity,
+            count: 0,
+            baseActionsNeeded: 0,
+        });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.terminalCause).toBe('infinite');
+        expect(result.segments[0].stopCause).toBe('infinite');
+    });
+
+    test('TLA-025 DEV4 fix: a finite queued row with remaining work but count:0/no limiter fails closed (contradictory helper output)', () => {
+        mocks.currentActions = [action({ id: 'a1', maxCount: 10, currentCount: 0 })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ count: 0, limitType: null });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.terminalCause).toBe('unknown');
+        expect(result.segments[0].stopCause).toBe('timing-unavailable');
+    });
+
+    test('TLA-025 DEV4 fix: a zero-resource boundary (count:0, totalTime:0, an explicit limitType) remains a valid immediate deterministic terminal', () => {
+        mocks.currentActions = [action({ id: 'a1', maxCount: 10, currentCount: 0 })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({
+            count: 0,
+            baseActionsNeeded: 0,
+            totalTime: 0,
+            actionTimeSeconds: 0,
+            limitType: 'material:/items/log',
+        });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.terminalCause).toBe('materials');
+        expect(result.segments[0].endAt).toBe(1000);
+    });
+
+    test('TLA-025 DEV4 fix: an already-complete finite row (maxCount === currentCount) with zero work is distinguishable from calculation failure', () => {
+        mocks.currentActions = [action({ id: 'a1', maxCount: 10, currentCount: 10 })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({
+            count: 0,
+            baseActionsNeeded: 0,
+            totalTime: 0,
+            actionTimeSeconds: 0,
+            limitType: null,
+        });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.terminalCause).toBe('action');
+        expect(result.segments[0].stopCause).toBe('count');
+        expect(result.segments[0].endAt).toBe(1000);
+    });
+});
+
+describe('computeLiveProjection - resource limiter identity (TLA-025 item 9)', () => {
+    test('gold-limited action reports coins, not a generic count terminal', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 50, limitType: 'gold' });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments[0].stopCause).toBe('coins');
+        expect(result.terminalCause).toBe('coins');
+    });
+
+    test('upgrade-item-limited action reports upgrade-materials, not a generic count terminal', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 50, limitType: 'upgrade:/items/gizmo' });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments[0].stopCause).toBe('upgrade-materials');
+        expect(result.terminalCause).toBe('upgrade-materials');
+    });
+
+    test('no limiter at all still reports the plain count cause', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 50, limitType: null });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments[0].stopCause).toBe('count');
+        expect(result.terminalCause).toBe('action');
+    });
+});
+
+describe('computeLiveProjection - sequential inventory dependency across segments (TLA-025 item 11)', () => {
+    test('a later materials-limited segment depending on an earlier segment’s output is no longer trustworthy', () => {
+        mocks.currentActions = [
+            action({ id: 'a1', actionHrid: '/actions/woodcutting/log' }),
+            action({ id: 'a2', actionHrid: '/actions/cheesesmithing/bar' }),
+        ];
+        mocks.actionDetailsByHrid['/actions/woodcutting/log'] = actionDetails({
+            outputItems: [{ itemHrid: '/items/log' }],
+        });
+        mocks.actionDetailsByHrid['/actions/cheesesmithing/bar'] = actionDetails({
+            inputItems: [{ itemHrid: '/items/log' }],
+        });
+        mocks.timingByActionId.a1 = timing({ totalTime: 100, limitType: null });
+        mocks.timingByActionId.a2 = timing({ totalTime: 50, limitType: 'material:/items/log' });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments).toHaveLength(2);
+        expect(result.segments[1].certainty).toBe('uncertain');
+        expect(result.segments[1].stopCause).toBe('inventory-dependency');
+        expect(result.terminalCause).toBe('unknown');
+    });
+
+    test('a later materials-limited segment on a non-overlapping item stays trustworthy', () => {
+        mocks.currentActions = [
+            action({ id: 'a1', actionHrid: '/actions/woodcutting/log' }),
+            action({ id: 'a2', actionHrid: '/actions/cheesesmithing/bar' }),
+        ];
+        mocks.actionDetailsByHrid['/actions/woodcutting/log'] = actionDetails({
+            outputItems: [{ itemHrid: '/items/log' }],
+        });
+        mocks.actionDetailsByHrid['/actions/cheesesmithing/bar'] = actionDetails({
+            inputItems: [{ itemHrid: '/items/iron' }],
+        });
+        mocks.timingByActionId.a1 = timing({ totalTime: 100, limitType: null });
+        mocks.timingByActionId.a2 = timing({ totalTime: 50, limitType: 'material:/items/iron' });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments).toHaveLength(2);
+        expect(result.segments[1].certainty).toBe('trustworthy');
+        expect(result.terminalCause).toBe('materials');
+    });
+
+    test('TLA-025 rejection fix: a later segment depending on a shared item is flagged even when its OWN calculated stopCause is count (not resource-based)', () => {
+        // Against the stale starting inventory, B's own material check may resolve to a plain
+        // count limit (e.g. plentiful stock at snapshot time) even though B genuinely consumes
+        // the same item A produces - the dependency must not be gated behind B's own stopCause.
+        mocks.currentActions = [
+            action({ id: 'a1', actionHrid: '/actions/woodcutting/log' }),
+            action({ id: 'a2', actionHrid: '/actions/cheesesmithing/bar' }),
+        ];
+        mocks.actionDetailsByHrid['/actions/woodcutting/log'] = actionDetails({
+            outputItems: [{ itemHrid: '/items/log' }],
+        });
+        mocks.actionDetailsByHrid['/actions/cheesesmithing/bar'] = actionDetails({
+            inputItems: [{ itemHrid: '/items/log' }],
+        });
+        mocks.timingByActionId.a1 = timing({ totalTime: 100, limitType: null });
+        mocks.timingByActionId.a2 = timing({ totalTime: 50, limitType: null }); // stale-snapshot count-limited
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments).toHaveLength(2);
+        expect(result.segments[1].certainty).toBe('uncertain');
+        expect(result.segments[1].stopCause).toBe('inventory-dependency');
+        expect(result.terminalCause).toBe('unknown');
+    });
+
+    test('a later segment with no item overlap at all stays trustworthy regardless of its own stopCause', () => {
+        mocks.currentActions = [
+            action({ id: 'a1', actionHrid: '/actions/woodcutting/log' }),
+            action({ id: 'a2', actionHrid: '/actions/foraging/berry' }),
+        ];
+        mocks.actionDetailsByHrid['/actions/woodcutting/log'] = actionDetails({
+            outputItems: [{ itemHrid: '/items/log' }],
+        });
+        mocks.actionDetailsByHrid['/actions/foraging/berry'] = actionDetails(); // no inputItems/upgradeItem/coinCost at all
+        mocks.timingByActionId.a1 = timing({ totalTime: 100, limitType: null });
+        mocks.timingByActionId.a2 = timing({ totalTime: 50, limitType: null });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments).toHaveLength(2);
+        expect(result.segments[1].certainty).toBe('trustworthy');
+        expect(result.terminalCause).toBe('queue');
+    });
+});
+
+describe('computeLiveProjection - timed-context (drink/tea) trust boundary (TLA-025 item 12)', () => {
+    test('a drink running out mid-segment truncates the trustworthy window instead of assuming it holds constant', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 7200 }); // 2h segment
+        mocks.drinkRemainingSecondsByType['/action_types/woodcutting'] = [
+            { itemHrid: '/items/gathering_tea', totalSeconds: 1800 }, // 30 min remaining
+        ];
+
+        const now = 1000;
+        const result = computeLiveProjection(now);
+
+        expect(result.terminalCause).toBe('drink');
+        expect(result.terminalAt).toBe(now + 1_800_000);
+        expect(result.segments[0].stopCause).toBe('drink');
+        expect(result.segments[0].endAt).toBe(now + 1_800_000);
+    });
+
+    test('a drink outlasting the segment does not truncate anything', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+        mocks.drinkRemainingSecondsByType['/action_types/woodcutting'] = [
+            { itemHrid: '/items/gathering_tea', totalSeconds: 999_999 },
+        ];
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.terminalCause).toBe('action');
+        expect(result.segments[0].stopCause).toBe('count');
+    });
+
+    test('an infinite action under a finite drink is bounded by the drink cutoff, not left unknowable forever', () => {
+        mocks.currentActions = [action({ id: 'a1', hasMaxCount: false })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ isTrulyInfinite: true, totalTime: Infinity });
+        mocks.drinkRemainingSecondsByType['/action_types/woodcutting'] = [
+            { itemHrid: '/items/gathering_tea', totalSeconds: 3600 },
+        ];
+
+        const now = 1000;
+        const result = computeLiveProjection(now);
+
+        expect(result.terminalCause).toBe('drink');
+        expect(result.terminalAt).toBe(now + 3_600_000);
+        expect(result.segments[0].endAt).toBe(now + 3_600_000);
+    });
+});
+
+describe('computeLiveProjection - display name enrichment (TLA-025 item 4)', () => {
+    test('ordinary actions are unchanged - displayName equals the raw action name', () => {
+        mocks.currentActions = [action({ id: 'a1' })];
+        mocks.actionDetailsByHrid['/actions/woodcutting/redwood'] = actionDetails();
+        mocks.timingByActionId.a1 = timing({ totalTime: 100 });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments[0].displayName).toBe('Redwood Tree');
+    });
+
+    test('Alchemy actions include the item name: "<action>: <item>"', () => {
+        mocks.currentActions = [
+            action({ id: 'a1', actionHrid: '/actions/alchemy/coinify', primaryItemHash: '/items/dragon_fruit::0' }),
+        ];
+        mocks.actionDetailsByHrid['/actions/alchemy/coinify'] = actionDetails({
+            name: 'Coinify',
+            type: '/action_types/alchemy',
+        });
+        mocks.timingByActionId.a1 = timing({ totalTime: 50 });
+        dataManager.getItemDetails.mockReturnValue({ name: 'Dragon Fruit' });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments[0].displayName).toBe('Coinify: Dragon Fruit');
+    });
+
+    test('Combat actions with a difficulty tier append " (Tn)"', () => {
+        mocks.currentActions = [action({ id: 'a1', actionHrid: '/actions/combat/aqua_planet', difficultyTier: 2 })];
+        mocks.actionDetailsByHrid['/actions/combat/aqua_planet'] = actionDetails({
+            name: 'Aqua Planet',
+            type: '/action_types/combat',
+        });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments[0].displayName).toBe('Aqua Planet (T2)');
+    });
+
+    test('Combat actions with a partyID append a party marker', () => {
+        mocks.currentActions = [action({ id: 'a1', actionHrid: '/actions/combat/aqua_planet', partyID: 'p1' })];
+        mocks.actionDetailsByHrid['/actions/combat/aqua_planet'] = actionDetails({
+            name: 'Aqua Planet',
+            type: '/action_types/combat',
+        });
+
+        const result = computeLiveProjection(1000);
+
+        expect(result.segments[0].displayName).toContain('Aqua Planet');
+        expect(result.segments[0].displayName).toContain('Party');
     });
 });
 
@@ -313,5 +955,91 @@ describe('resolveDisplayProjection - offline cap overlay', () => {
 
         expect(result.terminalCause).toBe('offline');
         expect(result.terminalAt).toBe(offlineLimitAt);
+    });
+
+    test('TLA-025 item 13: offline cap landing inside a trustworthy prefix wins even though the queue later goes uncertain', () => {
+        const stored = storedRecord({
+            offline: { hourCap: 0.01, mooPassExpireTime: null }, // ~36s cap
+            projection: {
+                segments: [
+                    { startAt: 0, endAt: 100_000, certainty: 'trustworthy', stopCause: 'count' },
+                    { startAt: 100_000, endAt: null, certainty: 'uncertain', stopCause: 'labyrinth' },
+                ],
+                terminalCause: 'unknown',
+                terminalAt: null,
+            },
+        });
+
+        const result = resolveDisplayProjection(stored, 0);
+
+        expect(result.terminalCause).toBe('offline');
+        expect(result.terminalAt).toBe(36_000);
+    });
+
+    test('TLA-025 item 13: offline cap landing after the trustworthy prefix ends stays unknown', () => {
+        const stored = storedRecord({
+            offline: { hourCap: 10, mooPassExpireTime: null }, // far later than the 100s prefix
+            projection: {
+                segments: [
+                    { startAt: 0, endAt: 100_000, certainty: 'trustworthy', stopCause: 'count' },
+                    { startAt: 100_000, endAt: null, certainty: 'uncertain', stopCause: 'labyrinth' },
+                ],
+                terminalCause: 'unknown',
+                terminalAt: null,
+            },
+        });
+
+        const result = resolveDisplayProjection(stored, 0);
+
+        expect(result.terminalCause).toBe('unknown');
+        expect(result.terminalAt).toBeNull();
+    });
+
+    test('TLA-025 item 13: no trustworthy prefix at all (already uncertain from the start) stays unknown unchanged', () => {
+        const stored = storedRecord({
+            offline: { hourCap: 0.01, mooPassExpireTime: null },
+            projection: {
+                segments: [{ startAt: 0, endAt: null, certainty: 'uncertain', stopCause: 'combat' }],
+                terminalCause: 'unknown',
+                terminalAt: null,
+            },
+        });
+
+        const result = resolveDisplayProjection(stored, 0);
+
+        expect(result.terminalCause).toBe('unknown');
+        expect(result.terminalAt).toBeNull();
+    });
+
+    test('TLA-025 item 14: a finite terminal that crosses an unresolved MooPass boundary fails closed to unknown', () => {
+        const stored = storedRecord({
+            offline: { hourCap: 10, mooPassExpireTime: 6000 },
+            projection: {
+                segments: [{ endAt: 100_000_000 }],
+                terminalCause: 'queue',
+                terminalAt: 100_000_000, // far past the MooPass boundary
+            },
+        });
+
+        const result = resolveDisplayProjection(stored, 5000); // offlineLimitAt = 5000 + 36,000,000
+
+        expect(result.terminalCause).toBe('unknown');
+        expect(result.terminalAt).toBeNull();
+    });
+
+    test('TLA-025 item 14: a finite terminal provably before the MooPass boundary is unaffected', () => {
+        const stored = storedRecord({
+            offline: { hourCap: 10, mooPassExpireTime: 6000 },
+            projection: {
+                segments: [{ endAt: 3000 }],
+                terminalCause: 'action',
+                terminalAt: 3000, // before mooPassExpireTime (6000)
+            },
+        });
+
+        const result = resolveDisplayProjection(stored, 5000);
+
+        expect(result.terminalCause).toBe('action');
+        expect(result.terminalAt).toBe(3000);
     });
 });

--- a/src/features/character-activity/character-activity-storage.js
+++ b/src/features/character-activity/character-activity-storage.js
@@ -61,11 +61,13 @@ export async function loadAccountPreferences() {
  * scoped values currently in effect for the active character, so Character Select later shows
  * whatever was last actually used rather than a schema default.
  * @param {Partial<{enabled: boolean, dateFormat: string, timeFormat: string}>} prefs
+ * @param {boolean} [immediate=false] - Skip the normal debounce (e.g. a rare presentation-setting
+ *      change made just before navigating to Character Select, where a delayed write could miss it)
  * @returns {Promise<boolean>}
  */
-export async function saveAccountPreferences(prefs) {
+export async function saveAccountPreferences(prefs, immediate = false) {
     const current = await loadAccountPreferences();
-    return storage.setJSON(ACCOUNT_PREFS_KEY, { ...current, ...prefs }, STORE_NAME);
+    return storage.setJSON(ACCOUNT_PREFS_KEY, { ...current, ...prefs }, STORE_NAME, immediate);
 }
 
 export const CHARACTER_ACTIVITY_STORE = STORE_NAME;

--- a/src/features/character-activity/character-activity-storage.test.js
+++ b/src/features/character-activity/character-activity-storage.test.js
@@ -1,14 +1,15 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({ values: new Map() }));
+const mocks = vi.hoisted(() => ({ values: new Map(), setJSONCalls: [] }));
 
 vi.mock('../../core/storage.js', () => ({
     default: {
         getJSON: vi.fn(async (key, _store, defaultValue = null) =>
             mocks.values.has(key) ? mocks.values.get(key) : defaultValue
         ),
-        setJSON: vi.fn(async (key, value) => {
+        setJSON: vi.fn(async (key, value, storeName, immediate = false) => {
             mocks.values.set(key, value);
+            mocks.setJSONCalls.push({ key, value, storeName, immediate });
             return true;
         }),
     },
@@ -24,6 +25,7 @@ const {
 
 beforeEach(() => {
     mocks.values.clear();
+    mocks.setJSONCalls = [];
 });
 
 describe('character activity persistence', () => {
@@ -82,5 +84,19 @@ describe('account-level preferences', () => {
         await saveAccountPreferences({ enabled: false });
 
         expect(await loadAccountPreferences()).toEqual({ enabled: false, dateFormat: 'DD-MM', timeFormat: '12hour' });
+    });
+
+    test('TLA-025 DEV4 fix: the immediate flag forwards to Storage while partial-merge semantics are preserved', async () => {
+        await saveAccountPreferences({ dateFormat: 'DD-MM', timeFormat: '12hour' }, true);
+        await saveAccountPreferences({ enabled: false }, true);
+
+        expect(mocks.setJSONCalls.every((call) => call.immediate === true)).toBe(true);
+        expect(await loadAccountPreferences()).toEqual({ enabled: false, dateFormat: 'DD-MM', timeFormat: '12hour' });
+    });
+
+    test('TLA-025 DEV4 fix: immediate defaults to false when omitted, matching prior debounced behavior', async () => {
+        await saveAccountPreferences({ enabled: false });
+
+        expect(mocks.setJSONCalls[0].immediate).toBe(false);
     });
 });

--- a/src/features/character-activity/character-select-renderer.js
+++ b/src/features/character-activity/character-select-renderer.js
@@ -25,6 +25,9 @@ const FUTURE_LABELS = {
     action: 'Action ends',
     queue: 'Queue ends',
     materials: 'Materials run out',
+    coins: 'Coins run out',
+    'upgrade-materials': 'Upgrade materials run out',
+    drink: 'Buff expiring',
     offline: 'Offline limit',
 };
 
@@ -32,8 +35,25 @@ const PAST_LABELS = {
     action: 'Action ended',
     queue: 'Queue ended',
     materials: 'Materials ran out',
+    coins: 'Coins ran out',
+    'upgrade-materials': 'Upgrade materials ran out',
+    drink: 'Buff expired',
     offline: 'Offline progress stopped',
 };
+
+// Per-cause text for the neutral "unknown" branch, keyed by the active uncertain segment's own
+// `stopCause`. Locked copy per the approved UX contract - do not abbreviate the suffix.
+const UNCERTAIN_REASON_TEXT = {
+    combat: 'Variable duration · ETA unavailable',
+    labyrinth: 'Variable duration · ETA unavailable',
+    enhancing: 'Stochastic outcome · ETA unavailable',
+    special: 'Waiting for party · ETA unavailable',
+    'loadout-unavailable': 'Configured loadout unavailable · ETA unavailable',
+};
+// Current segment is still a trustworthy earlier one, but a later segment in the same queue is
+// uncertain - the deadline itself (not the current action) is what's unknowable.
+const QUEUE_UNCERTAIN_TEXT = 'Queue duration uncertain · ETA unavailable';
+const DEFAULT_UNCERTAIN_TEXT = 'End time unavailable';
 
 const COLOR_HEX = {
     green: '#51cf66',
@@ -41,6 +61,17 @@ const COLOR_HEX = {
     red: '#ff6b6b',
     neutral: '#888888',
 };
+
+// Native ActionTypeIcons: the 10 skilling types live in skills_sprite, Combat/Labyrinth live in
+// misc_sprite, and Special (Party Ready) has no native type icon at all.
+const MISC_SPRITE_TYPES = new Set(['/action_types/combat', '/action_types/labyrinth']);
+const NO_ICON_TYPES = new Set(['/action_types/special']);
+
+/** Sprite sheet for a segment's icon, or null for action types with no native icon (Special). */
+function spriteFamilyForType(actionTypeHrid) {
+    if (!actionTypeHrid || NO_ICON_TYPES.has(actionTypeHrid)) return null;
+    return MISC_SPRITE_TYPES.has(actionTypeHrid) ? 'misc' : 'skills';
+}
 
 /**
  * Find whichever segment covers a given instant (its own `startAt`-`endAt` range covers `time`,
@@ -61,7 +92,7 @@ function findSegmentAtTime(segments, time) {
 }
 
 function formatActivityLine(segment, isPaused, queuedCount) {
-    let text = segment.actionName;
+    let text = segment.displayName || segment.actionName;
     if (isPaused) text += ' ⏸';
     if (queuedCount > 0) text += ` +${queuedCount} queued`;
     return text;
@@ -74,7 +105,7 @@ function formatActivityLine(segment, isPaused, queuedCount) {
  * @param {Object} character - Native character object (id, name, lastOfflineTime, isOnline)
  * @param {Object} prefs - Account-level date/time preferences
  * @param {number} [now]
- * @returns {{firstLineText: string, limiterColor: string, limiterText: string}}
+ * @returns {{firstLineText: string, limiterColor: string, limiterText: string, activeSegment: Object|null}}
  */
 export function computeSlotDisplayState(record, character, prefs, now = Date.now()) {
     if (!record) {
@@ -82,6 +113,7 @@ export function computeSlotDisplayState(record, character, prefs, now = Date.now
             firstLineText: 'No activity data yet',
             limiterColor: 'neutral',
             limiterText: 'Open character once to enable status',
+            activeSegment: null,
         };
     }
 
@@ -90,21 +122,49 @@ export function computeSlotDisplayState(record, character, prefs, now = Date.now
             firstLineText: 'Activity status outdated',
             limiterColor: 'neutral',
             limiterText: 'Open character to refresh',
+            activeSegment: null,
         };
     }
 
-    const { segments, terminalCause, terminalAt } = resolveDisplayProjection(record, character.lastOfflineTime);
+    // A currently-online character must never get an offline deadline from a stale lastOfflineTime.
+    const effectiveLastOfflineTime = character.isOnline ? null : character.lastOfflineTime;
+    const { segments, terminalCause, terminalAt } = resolveDisplayProjection(record, effectiveLastOfflineTime);
 
     if (terminalCause === 'idle') {
-        return { firstLineText: 'No active action', limiterColor: 'red', limiterText: 'Character is idle' };
+        return {
+            firstLineText: 'No active action',
+            limiterColor: 'red',
+            limiterText: 'Character is idle',
+            activeSegment: null,
+        };
     }
 
     if (terminalCause === 'unknown' || segments.length === 0) {
-        const last = segments[segments.length - 1];
+        const found = findSegmentAtTime(segments, now);
+        const activeSegment = found ? found.segment : null;
+
+        if (!activeSegment) {
+            return {
+                firstLineText: 'No active action expected',
+                limiterColor: 'neutral',
+                limiterText: DEFAULT_UNCERTAIN_TEXT,
+                activeSegment: null,
+            };
+        }
+
+        // The currently active segment may still be an earlier trustworthy one - the queue only
+        // becomes uncertain at a LATER segment. Line 1 must keep showing what's actually running
+        // now, not the future segment that made the total deadline unknowable.
+        const limiterText =
+            activeSegment.certainty === 'uncertain'
+                ? UNCERTAIN_REASON_TEXT[activeSegment.stopCause] || DEFAULT_UNCERTAIN_TEXT
+                : QUEUE_UNCERTAIN_TEXT;
+
         return {
-            firstLineText: last ? formatActivityLine(last, false, 0) : 'No active action expected',
+            firstLineText: formatActivityLine(activeSegment, false, activeSegment.remainingQueuedCount ?? 0),
             limiterColor: 'neutral',
-            limiterText: 'End time unavailable',
+            limiterText,
+            activeSegment,
         };
     }
 
@@ -117,28 +177,31 @@ export function computeSlotDisplayState(record, character, prefs, now = Date.now
                 segment: segments[segments.length - 1],
                 index: segments.length - 1,
             };
-            const queuedCount = segments.length - found.index - 1;
             return {
-                firstLineText: formatActivityLine(found.segment, true, queuedCount),
+                firstLineText: formatActivityLine(found.segment, true, found.segment.remainingQueuedCount ?? 0),
                 limiterColor: 'red',
                 limiterText: `${PAST_LABELS.offline} · ${time}`,
+                activeSegment: found.segment,
             };
         }
         return {
             firstLineText: 'No active action expected',
             limiterColor: 'red',
             limiterText: `${PAST_LABELS[terminalCause]} · ${time}`,
+            activeSegment: null,
         };
     }
 
     const found = findSegmentAtTime(segments, now);
-    const queuedCount = found ? segments.length - found.index - 1 : 0;
     const color = terminalAt - now > ONE_HOUR_MS ? 'green' : 'yellow';
 
     return {
-        firstLineText: found ? formatActivityLine(found.segment, false, queuedCount) : 'No active action expected',
+        firstLineText: found
+            ? formatActivityLine(found.segment, false, found.segment.remainingQueuedCount ?? 0)
+            : 'No active action expected',
         limiterColor: color,
         limiterText: `${FUTURE_LABELS[terminalCause]} · ${time}`,
+        activeSegment: found ? found.segment : null,
     };
 }
 
@@ -149,6 +212,7 @@ class CharacterSelectRenderer {
         this.unregisterReady = null;
         this.refreshTimer = null;
         this.trackedSlots = new Map(); // characterId -> {slotElement, character}
+        this.renderGeneration = 0;
     }
 
     /**
@@ -204,36 +268,59 @@ class CharacterSelectRenderer {
     }
 
     async onCharacterSelectMounted(rootElement) {
+        // Bumped before any await - every in-flight continuation below checks it before touching
+        // the DOM, so a stale render from this mount can never overwrite a newer one.
+        const generation = ++this.renderGeneration;
+
         const resolved = resolveCharacterSelectSlots(rootElement);
         if (!resolved) return;
+        if (generation !== this.renderGeneration) return;
 
         this.trackedSlots.clear();
         for (const { slotElement, character } of resolved) {
             this.trackedSlots.set(character.id, { slotElement, character });
         }
 
-        await this.renderAllTrackedSlots();
+        await this.renderAllTrackedSlots(generation);
         this.startRefreshTimer();
     }
 
-    async renderAllTrackedSlots() {
+    async renderAllTrackedSlots(generation = this.renderGeneration) {
         const prefs = await loadAccountPreferences();
+        if (generation !== this.renderGeneration) return;
+
         if (!prefs.enabled) {
             this.clearAllInjectedBlocks();
             return;
         }
 
-        const spriteUrl = await assetManifest.getSpriteUrl('skills');
+        // Sprite resolution can hit the network (asset-manifest.json) - kick it off without
+        // blocking the text render below. Text must never wait on, or be suppressed by, icons.
+        const spriteUrlsPromise = Promise.all([
+            assetManifest.getSpriteUrl('skills'),
+            assetManifest.getSpriteUrl('misc'),
+        ]).then(([skills, misc]) => ({ skills, misc }));
 
+        const rendered = [];
         for (const { slotElement, character } of this.trackedSlots.values()) {
+            if (generation !== this.renderGeneration) return;
             if (!slotElement.isConnected) continue;
             const record = await loadCharacterActivity(character.id);
+            if (generation !== this.renderGeneration) return;
             const state = computeSlotDisplayState(record, character, prefs);
-            this.renderSlotBlock(slotElement, state, record, spriteUrl);
+            this.renderSlotBlock(slotElement, state, null);
+            rendered.push({ slotElement, state });
+        }
+
+        const spriteUrls = await spriteUrlsPromise;
+        if (generation !== this.renderGeneration) return;
+        for (const { slotElement, state } of rendered) {
+            if (!slotElement.isConnected) continue;
+            this.renderSlotBlock(slotElement, state, spriteUrls);
         }
     }
 
-    renderSlotBlock(slotElement, state, record, spriteUrl) {
+    renderSlotBlock(slotElement, state, spriteUrls) {
         let block = slotElement.querySelector(`.${BLOCK_CLASS}`);
         if (!block) {
             block = document.createElement('div');
@@ -242,10 +329,11 @@ class CharacterSelectRenderer {
             slotElement.appendChild(block);
         }
 
-        const iconHtml =
-            spriteUrl && record?.projection?.segments?.length
-                ? `<svg width="16" height="16" style="vertical-align:middle;margin-right:3px;"><use href="${spriteUrl}#${skillSlugFromSegment(record.projection.segments[0])}"></use></svg>`
-                : '';
+        const family = spriteFamilyForType(state.activeSegment?.actionTypeHrid);
+        const spriteUrl = family && spriteUrls ? spriteUrls[family] : null;
+        const iconHtml = spriteUrl
+            ? `<svg width="16" height="16" style="vertical-align:middle;margin-right:3px;"><use href="${spriteUrl}#${skillSlugFromSegment(state.activeSegment)}"></use></svg>`
+            : '';
 
         block.innerHTML = `
             <div style="display:flex;align-items:center;overflow:hidden;">
@@ -265,8 +353,26 @@ class CharacterSelectRenderer {
                 this.stopRefreshTimer();
                 return;
             }
-            this.renderAllTrackedSlots();
+            this.renderAllTrackedSlots(this.renderGeneration);
         }, REFRESH_INTERVAL_MS);
+    }
+
+    /**
+     * Explicitly invalidate any in-flight render and immediately re-read the account preference
+     * mirror. Used only for rare presentation-setting changes, so their effect (enabled toggle,
+     * date/time format) is visible on an already-mounted Character Select without waiting for the
+     * periodic refresh timer or an unrelated action event.
+     */
+    async refreshNow() {
+        if (!this.isWatching) return;
+
+        const generation = ++this.renderGeneration;
+
+        if (this.trackedSlots.size === 0 || !this.anySlotStillConnected()) {
+            return;
+        }
+
+        await this.renderAllTrackedSlots(generation);
     }
 
     anySlotStillConnected() {
@@ -304,6 +410,7 @@ class CharacterSelectRenderer {
         this.stopRefreshTimer();
         this.clearAllInjectedBlocks();
         this.trackedSlots.clear();
+        this.renderGeneration += 1;
         this.isWatching = false;
     }
 }

--- a/src/features/character-activity/character-select-renderer.test.js
+++ b/src/features/character-activity/character-select-renderer.test.js
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
     accountPrefs: { enabled: true, dateFormat: 'MM-DD', timeFormat: '24hour' },
     activityRecords: new Map(),
     spriteUrl: 'https://example.com/skills_sprite.svg',
+    miscSpriteUrl: 'https://example.com/misc_sprite.svg',
 }));
 
 vi.mock('../../core/dom-observer.js', () => ({
@@ -44,7 +45,7 @@ vi.mock('../../core/dom-observer.js', () => ({
 }));
 
 vi.mock('../../utils/asset-manifest.js', () => ({
-    default: { getSpriteUrl: vi.fn(async () => mocks.spriteUrl) },
+    default: { getSpriteUrl: vi.fn(async (key) => (key === 'misc' ? mocks.miscSpriteUrl : mocks.spriteUrl)) },
 }));
 
 vi.mock('./character-select-resolver.js', () => ({
@@ -130,6 +131,78 @@ describe('computeSlotDisplayState', () => {
         expect(state.firstLineText).toBe('Aqua Planet');
         expect(state.limiterColor).toBe('neutral');
         expect(state.limiterText).toBe('End time unavailable');
+    });
+
+    test.each([
+        ['combat', 'Variable duration · ETA unavailable'],
+        ['labyrinth', 'Variable duration · ETA unavailable'],
+        ['enhancing', 'Stochastic outcome · ETA unavailable'],
+        ['special', 'Waiting for party · ETA unavailable'],
+    ])('TLA-025: approved locked copy for stopCause=%s includes the ETA-unavailable suffix', (stopCause, expected) => {
+        const rec = record({
+            projection: {
+                segments: [
+                    {
+                        actionName: 'X',
+                        startAt: 1000,
+                        endAt: null,
+                        queuedIndex: 0,
+                        certainty: 'uncertain',
+                        stopCause,
+                    },
+                ],
+                terminalCause: 'unknown',
+                terminalAt: null,
+            },
+        });
+
+        const state = computeSlotDisplayState(rec, character(), PREFS, 2000);
+
+        expect(state.limiterText).toBe(expected);
+    });
+
+    test('TLA-025 item 4/5: a currently-running trustworthy segment stays on line 1 even though the queue later becomes uncertain', () => {
+        const rec = record({
+            projection: {
+                segments: [
+                    {
+                        actionName: 'Crafting',
+                        actionTypeHrid: '/action_types/crafting',
+                        startAt: 0,
+                        endAt: 10_000,
+                        queuedIndex: 0,
+                        certainty: 'trustworthy',
+                        stopCause: 'count',
+                        remainingQueuedCount: 1,
+                    },
+                    {
+                        actionName: 'Explore Labyrinth',
+                        actionTypeHrid: '/action_types/labyrinth',
+                        startAt: 10_000,
+                        endAt: null,
+                        queuedIndex: 1,
+                        certainty: 'uncertain',
+                        stopCause: 'labyrinth',
+                        remainingQueuedCount: 0,
+                    },
+                ],
+                terminalCause: 'unknown',
+                terminalAt: null,
+            },
+        });
+
+        // now = 5000, still inside the Crafting segment - Labyrinth hasn't started yet.
+        const state = computeSlotDisplayState(rec, character(), PREFS, 5000);
+
+        expect(state.firstLineText).toBe('Crafting +1 queued');
+        expect(state.limiterText).toBe('Queue duration uncertain · ETA unavailable');
+        expect(state.activeSegment.actionName).toBe('Crafting');
+
+        // Once time actually reaches the Labyrinth segment, line 1 switches to it.
+        const laterState = computeSlotDisplayState(rec, character(), PREFS, 15_000);
+        expect(laterState.firstLineText).toBe('Explore Labyrinth');
+        expect(laterState.limiterText).toBe('Variable duration · ETA unavailable');
+        expect(laterState.activeSegment.actionName).toBe('Explore Labyrinth');
     });
 
     test('one finite action not yet ended, more than 1h away -> green Action ends', () => {
@@ -272,9 +345,9 @@ describe('computeSlotDisplayState', () => {
             offline: { hourCap: null, mooPassExpireTime: null },
             projection: {
                 segments: [
-                    { actionName: 'First', startAt: 0, endAt: 1000, queuedIndex: 0 },
-                    { actionName: 'Second', startAt: 1000, endAt: 2000, queuedIndex: 1 },
-                    { actionName: 'Third', startAt: 2000, endAt: 3000, queuedIndex: 2 },
+                    { actionName: 'First', startAt: 0, endAt: 1000, queuedIndex: 0, remainingQueuedCount: 2 },
+                    { actionName: 'Second', startAt: 1000, endAt: 2000, queuedIndex: 1, remainingQueuedCount: 1 },
+                    { actionName: 'Third', startAt: 2000, endAt: 3000, queuedIndex: 2, remainingQueuedCount: 0 },
                 ],
                 terminalCause: 'queue',
                 terminalAt: 3000,
@@ -284,6 +357,88 @@ describe('computeSlotDisplayState', () => {
         const state = computeSlotDisplayState(rec, character(), PREFS, 1500); // mid-way through segment 2
 
         expect(state.firstLineText).toBe('Second +1 queued');
+    });
+
+    test('the active segment (not always segment 0) is returned for icon resolution', () => {
+        const rec = record({
+            offline: { hourCap: null, mooPassExpireTime: null },
+            projection: {
+                segments: [
+                    {
+                        actionName: 'First',
+                        actionTypeHrid: '/action_types/woodcutting',
+                        startAt: 0,
+                        endAt: 1000,
+                        queuedIndex: 0,
+                    },
+                    {
+                        actionName: 'Second',
+                        actionTypeHrid: '/action_types/combat',
+                        startAt: 1000,
+                        endAt: 2000,
+                        queuedIndex: 1,
+                    },
+                ],
+                terminalCause: 'queue',
+                terminalAt: 2000,
+            },
+        });
+
+        const state = computeSlotDisplayState(rec, character(), PREFS, 1500);
+
+        expect(state.activeSegment.actionTypeHrid).toBe('/action_types/combat');
+    });
+
+    test('an online character never receives an offline-cap deadline derived from a stale lastOfflineTime', () => {
+        const rec = record({
+            offline: { hourCap: 1, mooPassExpireTime: null },
+            projection: {
+                segments: [
+                    {
+                        actionName: 'Cheese',
+                        startAt: 1000,
+                        endAt: null,
+                        queuedIndex: 0,
+                        certainty: 'trustworthy',
+                        stopCause: 'infinite',
+                    },
+                ],
+                terminalCause: 'infinite',
+                terminalAt: null,
+            },
+        });
+        const char = character({ isOnline: true, lastOfflineTime: 1000 }); // stale offline stretch, but online now
+        const offlineLimitAt = 1000 + 1 * 3600 * 1000;
+
+        const state = computeSlotDisplayState(rec, char, PREFS, offlineLimitAt + 10000);
+
+        expect(state.limiterText).not.toContain('Offline progress stopped');
+    });
+
+    test('an offline character with the same lastOfflineTime does get the offline-cap deadline', () => {
+        const rec = record({
+            offline: { hourCap: 1, mooPassExpireTime: null },
+            projection: {
+                segments: [
+                    {
+                        actionName: 'Cheese',
+                        startAt: 1000,
+                        endAt: null,
+                        queuedIndex: 0,
+                        certainty: 'trustworthy',
+                        stopCause: 'infinite',
+                    },
+                ],
+                terminalCause: 'infinite',
+                terminalAt: null,
+            },
+        });
+        const char = character({ isOnline: false, lastOfflineTime: 1000 });
+        const offlineLimitAt = 1000 + 1 * 3600 * 1000;
+
+        const state = computeSlotDisplayState(rec, char, PREFS, offlineLimitAt + 10000);
+
+        expect(state.limiterText).toContain('Offline progress stopped');
     });
 });
 
@@ -350,6 +505,73 @@ describe('idempotent Character Select injection and lifecycle', () => {
         await mocks.onClassRegistrations[0].callback(root);
 
         expect(slot.querySelector('.toolasha-character-activity-status')).toBeNull();
+    });
+
+    test('TLA-025 DEV4 fix: refreshNow() removes blocks immediately when the mirror flips to disabled, without waiting for the timer/an action event', async () => {
+        const root = buildRoot();
+        const slot = buildSlot(root);
+        mocks.resolvedSlots = [{ slotElement: slot, character: character() }];
+        mocks.activityRecords.set('char-a', record());
+
+        characterSelectRenderer.startWatching();
+        await mocks.onClassRegistrations[0].callback(root);
+        expect(slot.querySelector('.toolasha-character-activity-status')).not.toBeNull();
+
+        mocks.accountPrefs = { enabled: false, dateFormat: 'MM-DD', timeFormat: '24hour' };
+        await characterSelectRenderer.refreshNow();
+
+        expect(slot.querySelector('.toolasha-character-activity-status')).toBeNull();
+    });
+
+    test('TLA-025 DEV4 fix: refreshNow() restores blocks immediately when the mirror flips back to enabled', async () => {
+        const root = buildRoot();
+        const slot = buildSlot(root);
+        mocks.resolvedSlots = [{ slotElement: slot, character: character() }];
+        mocks.activityRecords.set('char-a', record());
+        mocks.accountPrefs = { enabled: false, dateFormat: 'MM-DD', timeFormat: '24hour' };
+
+        characterSelectRenderer.startWatching();
+        await mocks.onClassRegistrations[0].callback(root);
+        expect(slot.querySelector('.toolasha-character-activity-status')).toBeNull();
+
+        mocks.accountPrefs = { enabled: true, dateFormat: 'MM-DD', timeFormat: '24hour' };
+        await characterSelectRenderer.refreshNow();
+
+        expect(slot.querySelector('.toolasha-character-activity-status')).not.toBeNull();
+        expect(slot.textContent).toContain('Character is idle');
+    });
+
+    test('TLA-025 DEV4 fix: refreshNow() re-renders with a newly changed date/time format, and never duplicates the block', async () => {
+        const root = buildRoot();
+        const slot = buildSlot(root);
+        mocks.resolvedSlots = [{ slotElement: slot, character: character() }];
+        mocks.activityRecords.set(
+            'char-a',
+            record({
+                offline: { hourCap: null, mooPassExpireTime: null },
+                projection: {
+                    segments: [{ actionName: 'Redwood Tree', startAt: 1000, endAt: 1000 + 7200_000, queuedIndex: 0 }],
+                    terminalCause: 'action',
+                    terminalAt: 1000 + 7200_000,
+                },
+            })
+        );
+
+        characterSelectRenderer.startWatching();
+        await mocks.onClassRegistrations[0].callback(root);
+        const firstText = slot.querySelector('.toolasha-character-activity-status').textContent;
+
+        mocks.accountPrefs = { enabled: true, dateFormat: 'DD-MM', timeFormat: '12hour' };
+        await characterSelectRenderer.refreshNow();
+
+        expect(slot.querySelectorAll('.toolasha-character-activity-status')).toHaveLength(1);
+        // The limiter line embeds the formatted deadline, which depends on the prefs just changed.
+        expect(slot.querySelector('.toolasha-character-activity-status').textContent).not.toBe(firstText);
+    });
+
+    test('TLA-025 DEV4 fix: refreshNow() is a no-op before startWatching() / after stopWatching()', async () => {
+        characterSelectRenderer.stopWatching();
+        await expect(characterSelectRenderer.refreshNow()).resolves.toBeUndefined();
     });
 
     test('stopWatching removes injected blocks and unregisters the observer', async () => {
@@ -452,5 +674,200 @@ describe('idempotent Character Select injection and lifecycle', () => {
         // Re-notification/remount catch-up remains idempotent.
         await mocks.onReadyRegistrations[0].callback();
         expect(slot.querySelectorAll('.toolasha-character-activity-status')).toHaveLength(1);
+    });
+
+    test('TLA-025 item 6: text renders immediately even when sprite resolution hangs - icons are non-blocking', async () => {
+        const root = buildRoot();
+        const slot = buildSlot(root);
+        mocks.resolvedSlots = [{ slotElement: slot, character: character() }];
+        mocks.activityRecords.set(
+            'char-a',
+            record({ projection: { segments: [], terminalCause: 'idle', terminalAt: 1000 } })
+        );
+
+        const { default: assetManifest } = await import('../../utils/asset-manifest.js');
+        let releaseSprites;
+        const spriteGate = new Promise((resolve) => {
+            releaseSprites = resolve;
+        });
+        assetManifest.getSpriteUrl.mockImplementation(() => spriteGate.then(() => mocks.spriteUrl));
+
+        characterSelectRenderer.startWatching();
+        const mountPromise = mocks.onClassRegistrations[0].callback(root);
+        // Flush the per-slot record load (not sprite-gated) without resolving the sprite gate.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(slot.textContent).toContain('Character is idle');
+        expect(slot.querySelector('svg')).toBeNull();
+
+        releaseSprites();
+        await mountPromise;
+        expect(slot.textContent).toContain('Character is idle');
+
+        // Restore the default implementation so later tests in this file aren't affected.
+        assetManifest.getSpriteUrl.mockImplementation(async (key) =>
+            key === 'misc' ? mocks.miscSpriteUrl : mocks.spriteUrl
+        );
+    });
+
+    test('CA-46: sprite lookup failure/empty sprite leaves already-rendered status text correct and visible', async () => {
+        const root = buildRoot();
+        const slot = buildSlot(root);
+        mocks.resolvedSlots = [{ slotElement: slot, character: character() }];
+        mocks.activityRecords.set(
+            'char-a',
+            record({ projection: { segments: [], terminalCause: 'idle', terminalAt: 1000 } })
+        );
+
+        const { default: assetManifest } = await import('../../utils/asset-manifest.js');
+        // getSpriteUrl never actually rejects in production (asset-manifest.js swallows fetch
+        // errors internally) - the observable failure mode is an empty/null resolved URL.
+        assetManifest.getSpriteUrl.mockImplementation(async () => null);
+
+        characterSelectRenderer.startWatching();
+        await mocks.onClassRegistrations[0].callback(root);
+
+        expect(slot.textContent).toContain('Character is idle');
+        expect(slot.querySelector('svg')).toBeNull();
+
+        // Restore the default implementation so later tests in this file aren't affected.
+        assetManifest.getSpriteUrl.mockImplementation(async (key) =>
+            key === 'misc' ? mocks.miscSpriteUrl : mocks.spriteUrl
+        );
+    });
+
+    test('TLA-025 item 1: Combat/Labyrinth icons resolve from the misc sprite sheet, not skills', async () => {
+        const root = buildRoot();
+        const slot = buildSlot(root);
+        mocks.resolvedSlots = [{ slotElement: slot, character: character() }];
+        mocks.activityRecords.set(
+            'char-a',
+            record({
+                projection: {
+                    segments: [
+                        {
+                            actionName: 'Aqua Planet',
+                            actionTypeHrid: '/action_types/combat',
+                            startAt: 1000,
+                            endAt: null,
+                            queuedIndex: 0,
+                            certainty: 'uncertain',
+                            stopCause: 'combat',
+                        },
+                    ],
+                    terminalCause: 'unknown',
+                    terminalAt: null,
+                },
+            })
+        );
+
+        characterSelectRenderer.startWatching();
+        await mocks.onClassRegistrations[0].callback(root);
+
+        expect(slot.innerHTML).toContain(`${mocks.miscSpriteUrl}#combat`);
+        expect(slot.innerHTML).not.toContain(`${mocks.spriteUrl}#combat`);
+    });
+
+    test('TLA-025 item 1: an ordinary skilling type still resolves from the skills sprite sheet', async () => {
+        const root = buildRoot();
+        const slot = buildSlot(root);
+        mocks.resolvedSlots = [{ slotElement: slot, character: character() }];
+        mocks.activityRecords.set(
+            'char-a',
+            record({
+                projection: {
+                    segments: [
+                        {
+                            actionName: 'Redwood Tree',
+                            actionTypeHrid: '/action_types/woodcutting',
+                            startAt: 1000,
+                            endAt: null,
+                            queuedIndex: 0,
+                            certainty: 'trustworthy',
+                            stopCause: 'infinite',
+                        },
+                    ],
+                    terminalCause: 'infinite',
+                    terminalAt: null,
+                },
+            })
+        );
+
+        characterSelectRenderer.startWatching();
+        await mocks.onClassRegistrations[0].callback(root);
+
+        expect(slot.innerHTML).toContain(`${mocks.spriteUrl}#woodcutting`);
+    });
+
+    test('TLA-025 item 1: Special (Party Ready) never renders an icon, matching native behavior', async () => {
+        const root = buildRoot();
+        const slot = buildSlot(root);
+        mocks.resolvedSlots = [{ slotElement: slot, character: character() }];
+        mocks.activityRecords.set(
+            'char-a',
+            record({
+                projection: {
+                    segments: [
+                        {
+                            actionName: 'Party Ready',
+                            actionTypeHrid: '/action_types/special',
+                            startAt: 1000,
+                            endAt: null,
+                            queuedIndex: 0,
+                            certainty: 'uncertain',
+                            stopCause: 'special',
+                        },
+                    ],
+                    terminalCause: 'unknown',
+                    terminalAt: null,
+                },
+            })
+        );
+
+        characterSelectRenderer.startWatching();
+        await mocks.onClassRegistrations[0].callback(root);
+
+        expect(slot.innerHTML).not.toContain('<svg');
+        expect(slot.textContent).toContain('Waiting for party');
+    });
+
+    test('TLA-025 item 18: a stale async render from an earlier mount cannot overwrite a newer mount', async () => {
+        const rootA = buildRoot();
+        const slotA = buildSlot(rootA);
+        const rootB = buildRoot();
+        const slotB = buildSlot(rootB);
+
+        let releaseFirstLoad;
+        const firstLoadGate = new Promise((resolve) => {
+            releaseFirstLoad = resolve;
+        });
+
+        mocks.resolvedSlots = [{ slotElement: slotA, character: character({ id: 'char-a', name: 'Alice' }) }];
+        mocks.activityRecords.set('char-a', record());
+
+        const { loadAccountPreferences } = await import('./character-activity-storage.js');
+        // The FIRST mount's preferences load hangs until explicitly released, simulating a slow
+        // async continuation that resolves only after a second, newer mount has already rendered.
+        loadAccountPreferences.mockImplementationOnce(() => firstLoadGate.then(() => mocks.accountPrefs));
+
+        characterSelectRenderer.startWatching();
+        const firstMountPromise = mocks.onClassRegistrations[0].callback(rootA);
+
+        // A second, newer mount arrives and completes fully before the first one's gate opens.
+        mocks.resolvedSlots = [{ slotElement: slotB, character: character({ id: 'char-b', name: 'Bob' }) }];
+        mocks.activityRecords.set('char-b', record());
+        await mocks.onClassRegistrations[0].callback(rootB);
+
+        expect(slotB.querySelector('.toolasha-character-activity-status')).not.toBeNull();
+        expect(slotA.querySelector('.toolasha-character-activity-status')).toBeNull();
+
+        // Now let the first mount's stale continuation resolve - it must be a no-op.
+        releaseFirstLoad();
+        await firstMountPromise;
+        await Promise.resolve();
+
+        expect(slotA.querySelector('.toolasha-character-activity-status')).toBeNull();
+        expect(slotB.querySelector('.toolasha-character-activity-status')).not.toBeNull();
     });
 });

--- a/src/features/character-activity/character-select-resolver.js
+++ b/src/features/character-activity/character-select-resolver.js
@@ -90,7 +90,9 @@ export function findPopulatedCharacterSlots(rootElement) {
     const slotsById = new Map();
 
     for (const slot of slots) {
-        const link = slot.querySelector('a[href*="characterId="]');
+        // The populated native slot may be the `<a href="...characterId=...">` itself, not just a
+        // wrapper containing one - querySelector alone never matches the calling element.
+        const link = slot.matches?.('a[href*="characterId="]') ? slot : slot.querySelector('a[href*="characterId="]');
         if (!link) continue;
 
         const characterId = getCharacterIdFromSlotLink(link);

--- a/src/features/character-activity/character-select-resolver.test.js
+++ b/src/features/character-activity/character-select-resolver.test.js
@@ -140,6 +140,37 @@ describe('findPopulatedCharacterSlots', () => {
 
         expect(findPopulatedCharacterSlots(root)).toEqual([]);
     });
+
+    test('resolves when the populated slot IS the native <a> anchor itself, not just a wrapper containing one', () => {
+        const root = document.createElement('div');
+        const slot = document.createElement('a');
+        slot.className = 'CharacterSelectPage_slot__abc';
+        slot.setAttribute('href', '/game?characterId=char-a');
+        root.appendChild(slot);
+
+        const result = findPopulatedCharacterSlots(root);
+
+        expect(result).toEqual([{ slotElement: slot, characterId: 'char-a' }]);
+    });
+
+    test('still resolves the wrapper-with-descendant-anchor shape alongside a self-anchor slot', () => {
+        const root = document.createElement('div');
+        const wrapperSlot = buildSlot('char-a');
+        const selfAnchorSlot = document.createElement('a');
+        selfAnchorSlot.className = 'CharacterSelectPage_slot__abc';
+        selfAnchorSlot.setAttribute('href', '/game?characterId=char-b');
+        root.append(wrapperSlot, selfAnchorSlot);
+
+        const result = findPopulatedCharacterSlots(root);
+
+        expect(result).toEqual(
+            expect.arrayContaining([
+                { slotElement: wrapperSlot, characterId: 'char-a' },
+                { slotElement: selfAnchorSlot, characterId: 'char-b' },
+            ])
+        );
+        expect(result).toHaveLength(2);
+    });
 });
 
 describe('resolveCharacterSelectSlots', () => {

--- a/src/libraries/ui.js
+++ b/src/libraries/ui.js
@@ -49,6 +49,9 @@ import pformancePanel from '../features/dev/pformance-panel.js';
 // feature/character logic in entrypoint.js), kept in the primary bundle rather than the
 // secondary one so it never lands on the tail @require.
 import characterSelectRenderer from '../features/character-activity/character-select-renderer.js';
+// Same reasoning as characterSelectRenderer above - started unconditionally right after it in
+// entrypoint.js/main.js, so it must live in the primary bundle too.
+import { startAccountPreferencesSync } from '../features/character-activity/character-activity-account-prefs-sync.js';
 
 // Export to global namespace
 const toolashaRoot = window.Toolasha || {};
@@ -85,6 +88,7 @@ toolashaRoot.UI = {
     settingsUI,
     pformancePanel,
     characterSelectRenderer,
+    startAccountPreferencesSync,
 };
 
 console.log('[Toolasha] UI library loaded');

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ import settingsUI from './features/settings/settings-ui.js';
 import { setupScrollTooltipDismissal } from './utils/dom.js';
 import guildXPTrackerFeature from './features/guild/guild-xp-tracker.js';
 import characterSelectRenderer from './features/character-activity/character-select-renderer.js';
+import { startAccountPreferencesSync } from './features/character-activity/character-activity-account-prefs-sync.js';
 
 /**
  * Detect if running on a supported Combat Simulator page
@@ -43,6 +44,10 @@ if (isCombatSimulatorPage()) {
     // Always-on Character Select renderer: must run before any character ever initializes,
     // since Character Select can be the very first page shown in a session.
     characterSelectRenderer.startWatching();
+
+    // Keeps the account-level preference mirror Character Select reads fresh independently of
+    // whether the character-scoped Character Activity collector is currently running.
+    startAccountPreferencesSync();
 
     // Set up scroll listener to dismiss stuck tooltips
     setupScrollTooltipDismissal();


### PR DESCRIPTION
## Summary

Corrects four regressions in Character Activity Status (the alt-character offline/ETA status shown on native Character Select), while preserving all current-main behavior (Log tab ordering + @mentions, Guild Shrine Szerra import/export, `drinksApplicable`, TLA-036 sub-cycle guard, isolated DEV IndexedDB).

## Root-cause fixes

1. **Native queued-loadout identity ignored** (`character-activity-projection.js`, `action-time-display.js`): queued native actions with an explicit `characterLoadoutID` fell back to Toolasha's predictive default loadout instead of resolving the exact loadout the player configured. Now resolves by ID via Core's `loadoutState`, treats `0`/`'0'`/`null`/`undefined` as "no explicit loadout" (preserving predictive behavior), and fails closed (never substitutes a default) if the ID is malformed, missing, or unusable. An explicit All-Skills queued loadout now correctly falls back to the current action's live drinks instead of its own always-blank drinks field, matching the existing predictive resolver's semantics.
2. **Timing trust boundary**: malformed/non-finite/negative/contradictory timing results are rejected before they can produce a fabricated deterministic ETA; represented as explicit uncertainty instead. A trustworthy current-now segment stays visible even when a later queued segment is uncertain.
3. **Preference mirror + renderer lifecycle** (`character-activity-account-prefs-sync.js` new, `character-select-renderer.js`, `storage.js`): account-level preference writes (`characterActivityStatus`, date/time format) now have an immediate path that supersedes stale pending debounced writes, and the renderer shows status text before awaiting sprite lookups, with render-generation/slot-ownership checks so stale async work can never overwrite a newer character's slot.
4. **Feature Registry ownership race** (`feature-registry.js`): ownership of a feature key was previously claimed with a plain `null` sentinel only after `initialize()` resolved, so a character switch mid-init could miss cleanup, and a rejected `initialize()` never released ownership (permanently blocking retries). Now claims a unique `Symbol()` token synchronously before awaiting, compares by identity before replacing/deleting, and releases only if the same token still owns the key. `retryFailedFeatures()` uses the same semantics.

## Acceptance

- **57/57** CA acceptance cases (native queued-loadout identity, timing trust boundary, projection/display semantics, Character Select resolver/renderer lifecycle, account preference sync, Feature Registry ownership) have exact automated test coverage.
- Full suite: **168 test files, 2227 tests, all passing**.
- `npm run lint`: clean.
- `npm run format:check`: clean.
- `npm run build:dev` / `npm run build`: pass.
- `npm run check:loadout-state`: pass — one Core-owned state service, no legacy stateful copies.
- All library bundles comfortably under the existing 2MB CI size cap (largest is `toolasha-combat.js` at ~1.65MB); no CI workflow changes needed.

## Test plan

- [x] Full automated suite green (168/168 files, 2227/2227 tests)
- [x] Lint, format, both builds, loadout-state integrity gate all green
- [ ] Manual in-game smoke on native Character Select (multi-character offline/queue status display)