### PR TITLE
fix: correct viewer-relative persistent build score (TLA-041)

### DIFF
--- a/src/features/enhancement/tooltip-enhancement.js
+++ b/src/features/enhancement/tooltip-enhancement.js
@@ -743,6 +743,71 @@ export function calculatePerAttemptMaterialCost(itemDetails) {
 }
 
 /**
+ * Calculate the cheapest viewer-relative expected coin cost to enhance an item directly from
+ * `startLevel` to `targetLevel` (K->N), sweeping protection strategies itself and calling
+ * `calculateEnhancement()` with `startLevel` set on every call. Never approximates K->N via two
+ * independently-optimized 0-based totals (TLA-041 / F-04). Composed entirely from already-exported
+ * primitives (`calculatePerAttemptMaterialCost`, `getCheapestProtectionPrice`, `calculateEnhancement`)
+ * — it does not call `calculateEnhancementPath`/`calculateCostForStrategy`/`calculateTotalCost`, so
+ * no existing consumer of this file is affected by this addition.
+ * @param {string} itemHrid
+ * @param {number} startLevel - Current enhancement level to start from (0 <= startLevel < targetLevel)
+ * @param {number} targetLevel - Desired enhancement level
+ * @param {Object} enhancingParams - Viewer's own params from getEnhancingParams()
+ * @returns {{cost: number|null, complete: boolean, protectFrom: number|null}}
+ */
+export function calculateDirectEnhancementCost(itemHrid, startLevel, targetLevel, enhancingParams) {
+    const gameData = dataManager.getInitClientData();
+    const itemDetails = gameData?.itemDetailMap?.[itemHrid];
+    if (!itemDetails?.enhancementCosts?.length) {
+        return { cost: null, complete: false, protectFrom: null };
+    }
+
+    const { cost: perAttemptCost, hasCost, costPartial } = calculatePerAttemptMaterialCost(itemDetails);
+    if (!hasCost || costPartial) {
+        return { cost: null, complete: false, protectFrom: null };
+    }
+
+    const itemLevel = itemDetails.itemLevel || 1;
+    const protectFromCandidates = [0];
+    for (let pf = 2; pf <= targetLevel; pf++) protectFromCandidates.push(pf);
+
+    let best = null;
+    for (const protectFrom of protectFromCandidates) {
+        let stats;
+        try {
+            stats = calculateEnhancement({
+                enhancingLevel: enhancingParams.enhancingLevel,
+                toolBonus: enhancingParams.toolBonus || 0,
+                speedBonus: enhancingParams.speedBonus || 0,
+                itemLevel,
+                targetLevel,
+                startLevel,
+                protectFrom,
+                blessedTea: enhancingParams.teas?.blessed,
+                guzzlingBonus: enhancingParams.guzzlingBonus,
+            });
+        } catch {
+            continue;
+        }
+
+        let protectionCost = 0;
+        if (protectFrom > 0 && stats.protectionCount > 0) {
+            const { price } = getCheapestProtectionPrice(itemHrid);
+            if (!(price > 0)) continue; // protection needed but unpriceable - strategy unusable
+            protectionCost = price * stats.protectionCount;
+        }
+
+        const totalCost = perAttemptCost * stats.attempts + protectionCost;
+        if (best === null || totalCost < best.cost) {
+            best = { cost: totalCost, protectFrom };
+        }
+    }
+
+    return best ? { ...best, complete: true } : { cost: null, complete: false, protectFrom: null };
+}
+
+/**
  * Fibonacci calculation for item quantities (from Enhancelator)
  * @private
  */

--- a/src/features/enhancement/tooltip-enhancement.test.js
+++ b/src/features/enhancement/tooltip-enhancement.test.js
@@ -2,8 +2,14 @@
  * Tests for the enhancement tooltip's minimum-sell-price calculation
  */
 
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest';
+import * as mathJs from 'mathjs';
 import { MARKET_TAX } from '../../utils/profit-constants.js';
+import { calculateEnhancement } from '../../utils/enhancement-calculator.js';
+
+beforeAll(() => {
+    globalThis.math = mathJs;
+});
 
 const settingsMap = {};
 
@@ -22,13 +28,14 @@ vi.mock('../../core/config.js', () => ({
     },
 }));
 
+const itemDetailMap = {};
 vi.mock('../../core/data-manager.js', () => ({
-    default: { getInitClientData: () => ({ itemDetailMap: {} }) },
+    default: { getInitClientData: () => ({ itemDetailMap }) },
 }));
 
 vi.mock('../../utils/market-data.js', () => ({
-    getItemPrice: () => 0,
-    getItemPrices: () => ({ ask: 400_000_000, bid: 390_000_000 }),
+    getItemPrice: vi.fn(() => 0),
+    getItemPrices: vi.fn(() => ({ ask: 400_000_000, bid: 390_000_000 })),
 }));
 
 const marketPrices = {};
@@ -36,8 +43,14 @@ vi.mock('../../api/marketplace.js', () => ({
     default: { getPrice: (itemHrid) => marketPrices[itemHrid], on: () => {} },
 }));
 
-const { buildEnhancementTooltipHTML, calculateMinimumSellPrice, calculatePerAttemptMaterialCost } =
-    await import('./tooltip-enhancement.js');
+import { getItemPrices } from '../../utils/market-data.js';
+
+const {
+    buildEnhancementTooltipHTML,
+    calculateMinimumSellPrice,
+    calculatePerAttemptMaterialCost,
+    calculateDirectEnhancementCost,
+} = await import('./tooltip-enhancement.js');
 
 function makeEnhancementData(overrides = {}) {
     return {
@@ -190,5 +203,129 @@ describe('calculatePerAttemptMaterialCost', () => {
         const result = calculatePerAttemptMaterialCost({ enhancementCosts: [] });
 
         expect(result).toEqual({ cost: 0, hasCost: false, costPartial: false });
+    });
+});
+
+describe('calculateDirectEnhancementCost - K->N direct Markov cost (TLA-041 / F-04)', () => {
+    const enhancingParams = {
+        enhancingLevel: 50,
+        toolBonus: 0,
+        speedBonus: 0,
+        teas: { blessed: false },
+        guzzlingBonus: 1,
+    };
+
+    beforeEach(() => {
+        for (const key of Object.keys(marketPrices)) delete marketPrices[key];
+        for (const key of Object.keys(itemDetailMap)) delete itemDetailMap[key];
+        getItemPrices.mockReturnValue({ ask: 400_000_000, bid: 390_000_000 });
+    });
+
+    test('returns incomplete for an item with no enhancementCosts, never a fake zero', () => {
+        itemDetailMap['/items/no_enh'] = { itemLevel: 1, enhancementCosts: [] };
+        const result = calculateDirectEnhancementCost('/items/no_enh', 1, 4, enhancingParams);
+        expect(result).toEqual({ cost: null, complete: false, protectFrom: null });
+    });
+
+    test('returns incomplete when a required material has no ask price, instead of a partial number', () => {
+        itemDetailMap['/items/partial'] = {
+            itemLevel: 1,
+            enhancementCosts: [{ itemHrid: '/items/unpriced', count: 1 }],
+        };
+        const result = calculateDirectEnhancementCost('/items/partial', 1, 4, enhancingParams);
+        expect(result).toEqual({ cost: null, complete: false, protectFrom: null });
+    });
+
+    test('F-04: uses calculateEnhancement with startLevel set directly, never defaulting to a 0-based computation', () => {
+        marketPrices['/items/mat'] = { ask: 1000, bid: 900 };
+        itemDetailMap['/items/testitem'] = {
+            itemLevel: 1,
+            enhancementCosts: [{ itemHrid: '/items/mat', count: 1 }],
+        };
+
+        const direct = calculateDirectEnhancementCost('/items/testitem', 1, 4, enhancingParams);
+        expect(direct.complete).toBe(true);
+
+        const baseParams = {
+            enhancingLevel: enhancingParams.enhancingLevel,
+            toolBonus: 0,
+            speedBonus: 0,
+            itemLevel: 1,
+            targetLevel: 4,
+            protectFrom: direct.protectFrom,
+            blessedTea: false,
+            guzzlingBonus: 1,
+        };
+        const attemptsFromK = calculateEnhancement({ ...baseParams, startLevel: 1 }).attempts;
+        const attemptsFrom0 = calculateEnhancement({ ...baseParams, startLevel: 0 }).attempts;
+
+        // startLevel actually changes the answer - ruling out a bug where it's silently ignored.
+        expect(attemptsFromK).not.toBeCloseTo(attemptsFrom0, 2);
+
+        // The function's result matches the real startLevel=K computation, never the startLevel=0 one.
+        expect(direct.cost).toBeCloseTo(1000 * attemptsFromK, 5);
+        expect(direct.cost).not.toBeCloseTo(1000 * attemptsFrom0, 0);
+    });
+
+    test('sweeps protectFrom and reports the winning strategy alongside the cost', () => {
+        marketPrices['/items/mat'] = { ask: 1000, bid: 900 };
+        itemDetailMap['/items/testitem'] = {
+            itemLevel: 1,
+            enhancementCosts: [{ itemHrid: '/items/mat', count: 1 }],
+        };
+
+        const result = calculateDirectEnhancementCost('/items/testitem', 1, 4, enhancingParams);
+        expect(result.complete).toBe(true);
+        expect([0, 2, 3, 4]).toContain(result.protectFrom);
+        expect(result.cost).toBeGreaterThan(0);
+    });
+
+    test('a protection-requiring strategy with no priceable protection item is excluded, not zero-substituted', () => {
+        marketPrices['/items/mat'] = { ask: 1000, bid: 900 };
+        itemDetailMap['/items/testitem'] = {
+            itemLevel: 1,
+            enhancementCosts: [{ itemHrid: '/items/mat', count: 1 }],
+            protectionItemHrids: [],
+        };
+        // No positive price anywhere -> getCheapestProtectionPrice resolves to 0 for every
+        // candidate, so every protectFrom>0 strategy must be excluded, leaving only protectFrom=0.
+        getItemPrices.mockReturnValue({ ask: 0, bid: 0 });
+
+        const result = calculateDirectEnhancementCost('/items/testitem', 1, 4, enhancingParams);
+        expect(result.complete).toBe(true);
+        expect(result.protectFrom).toBe(0);
+    });
+
+    test('F-08 (Option B): a temporary Blessed Tea setup changes the expected cost, but its own purchase price is never added', () => {
+        marketPrices['/items/mat'] = { ask: 1000, bid: 900 };
+        itemDetailMap['/items/testitem'] = {
+            itemLevel: 1,
+            enhancementCosts: [{ itemHrid: '/items/mat', count: 1 }],
+        };
+
+        const withoutBlessed = calculateDirectEnhancementCost('/items/testitem', 1, 4, {
+            ...enhancingParams,
+            teas: { blessed: false },
+        });
+        const withBlessed = calculateDirectEnhancementCost('/items/testitem', 1, 4, {
+            ...enhancingParams,
+            teas: { blessed: true },
+            guzzlingBonus: 2, // scales the blessed-tea skip chance, making the effect measurable
+        });
+
+        expect(withoutBlessed.complete).toBe(true);
+        expect(withBlessed.complete).toBe(true);
+        // The setup measurably changes the expected math...
+        expect(withBlessed.cost).not.toBeCloseTo(withoutBlessed.cost, 5);
+        // ...but the cost is still built purely from enhancementCosts materials (1000/attempt) -
+        // no separate line item for the Blessed Tea's own purchase price was ever added, since
+        // this function never reads/prices any tea item at all.
+        marketPrices['/items/blessed_tea'] = { ask: 999_999_999, bid: 999_999_999 };
+        const withBlessedAgain = calculateDirectEnhancementCost('/items/testitem', 1, 4, {
+            ...enhancingParams,
+            teas: { blessed: true },
+            guzzlingBonus: 2,
+        });
+        expect(withBlessedAgain.cost).toBeCloseTo(withBlessed.cost, 5);
     });
 });

--- a/src/features/profile/combat-score.js
+++ b/src/features/profile/combat-score.js
@@ -165,6 +165,8 @@ class CombatScore {
         const playerName = profileData.profile?.sharableCharacter?.name || 'Player';
         const equipmentHiddenText =
             scoreData.equipmentHidden && !scoreData.hasEquipmentData ? ' (Equipment hidden)' : '';
+        const scoreTooltip =
+            'Estimated cost for you to reproduce this persistent build now, using current acquisition prices and your current Enhancing setup. Market values use current best Ask/unit estimates and are not order-book-depth adjusted.';
 
         // Create panel element
         const panel = document.createElement('div');
@@ -208,6 +210,30 @@ class CombatScore {
 
         // Build skiller equipment breakdown HTML
         const skillerEquipmentBreakdownHTML = scoreData.skillerBreakdown.equipment
+            .map(
+                (item) =>
+                    `<div style="margin-left: 10px; font-size: 0.8rem; color: ${config.COLOR_TEXT_SECONDARY};">${item.name}: ${item.value}</div>`
+            )
+            .join('');
+
+        // Build shrine breakdown HTML (Combat)
+        const shrineBreakdownHTML = (scoreData.breakdown.shrines || [])
+            .map(
+                (item) =>
+                    `<div style="margin-left: 10px; font-size: 0.8rem; color: ${config.COLOR_TEXT_SECONDARY};">${item.name}: ${item.value}</div>`
+            )
+            .join('');
+
+        // Build skiller house breakdown HTML
+        const skillerHouseBreakdownHTML = (scoreData.skillerBreakdown.houses || [])
+            .map(
+                (item) =>
+                    `<div style="margin-left: 10px; font-size: 0.8rem; color: ${config.COLOR_TEXT_SECONDARY};">${item.name}: ${item.value}</div>`
+            )
+            .join('');
+
+        // Build skiller shrine breakdown HTML
+        const skillerShrineBreakdownHTML = (scoreData.skillerBreakdown.shrines || [])
             .map(
                 (item) =>
                     `<div style="margin-left: 10px; font-size: 0.8rem; color: ${config.COLOR_TEXT_SECONDARY};">${item.name}: ${item.value}</div>`
@@ -268,8 +294,8 @@ class CombatScore {
                     line-height: 1;
                 " title="Close">×</span>
             </div>
-            <div style="cursor: pointer; font-weight: bold; margin-bottom: 8px; color: ${config.COLOR_PROFIT}; ${!config.getSetting('combatScore') ? 'display: none;' : ''}" id="mwi-score-toggle">
-                + Combat Score: ${numberFormatter(scoreData.total.toFixed(1))}${equipmentHiddenText}
+            <div style="cursor: pointer; font-weight: bold; margin-bottom: 8px; color: ${config.COLOR_PROFIT}; ${!config.getSetting('combatScore') ? 'display: none;' : ''}" id="mwi-score-toggle" title="${scoreTooltip}">
+                + Combat Score: ${numberFormatter(scoreData.total.toFixed(1))}${scoreData.complete === false ? '+' : ''}${equipmentHiddenText}
             </div>
             <div id="mwi-score-details" style="display: none; margin-left: 10px; color: ${config.COLOR_TEXT_PRIMARY};">
                 <div style="cursor: pointer; margin-bottom: 4px;" id="mwi-house-toggle">
@@ -289,20 +315,41 @@ class CombatScore {
                 <div style="cursor: pointer; margin-bottom: 4px;" id="mwi-equipment-toggle">
                     + Equipment: ${numberFormatter(scoreData.equipment.toFixed(1))}
                 </div>
-                <div id="mwi-equipment-breakdown" style="display: none;">
+                <div id="mwi-equipment-breakdown" style="display: none; margin-bottom: 6px;">
                     ${equipmentBreakdownHTML}
+                </div>
+
+                <div style="cursor: pointer; margin-bottom: 4px;" id="mwi-shrine-toggle">
+                    + Shrines: ${numberFormatter((scoreData.shrine || 0).toFixed(1))}
+                </div>
+                <div id="mwi-shrine-breakdown" style="display: none;">
+                    ${shrineBreakdownHTML}
                 </div>
             </div>
 
-            <div style="cursor: pointer; font-weight: bold; margin-top: 12px; margin-bottom: 8px; color: ${config.COLOR_PROFIT}; ${!config.getSetting('combatScore') ? 'display: none;' : ''}" id="mwi-skiller-score-toggle">
-                + Skiller Score: ${numberFormatter(scoreData.skillerTotal.toFixed(1))}
+            <div style="cursor: pointer; font-weight: bold; margin-top: 12px; margin-bottom: 8px; color: ${config.COLOR_PROFIT}; ${!config.getSetting('combatScore') ? 'display: none;' : ''}" id="mwi-skiller-score-toggle" title="${scoreTooltip}">
+                + Skiller Score: ${numberFormatter(scoreData.skillerTotal.toFixed(1))}${scoreData.skillerComplete === false ? '+' : ''}
             </div>
             <div id="mwi-skiller-score-details" style="display: none; margin-left: 10px; color: ${config.COLOR_TEXT_PRIMARY};">
+                <div style="cursor: pointer; margin-bottom: 4px;" id="mwi-skiller-house-toggle">
+                    + House: ${numberFormatter((scoreData.skillerHouse || 0).toFixed(1))}
+                </div>
+                <div id="mwi-skiller-house-breakdown" style="display: none; margin-bottom: 6px;">
+                    ${skillerHouseBreakdownHTML}
+                </div>
+
                 <div style="cursor: pointer; margin-bottom: 4px;" id="mwi-skiller-equipment-toggle">
                     + Equipment: ${numberFormatter(scoreData.skillerEquipment.toFixed(1))}
                 </div>
-                <div id="mwi-skiller-equipment-breakdown" style="display: none;">
+                <div id="mwi-skiller-equipment-breakdown" style="display: none; margin-bottom: 6px;">
                     ${skillerEquipmentBreakdownHTML}
+                </div>
+
+                <div style="cursor: pointer; margin-bottom: 4px;" id="mwi-skiller-shrine-toggle">
+                    + Shrines: ${numberFormatter((scoreData.skillerShrine || 0).toFixed(1))}
+                </div>
+                <div id="mwi-skiller-shrine-breakdown" style="display: none;">
+                    ${skillerShrineBreakdownHTML}
                 </div>
             </div>
 
@@ -438,7 +485,7 @@ class CombatScore {
                 details.style.display = isCollapsed ? 'block' : 'none';
                 toggleBtn.textContent =
                     (isCollapsed ? '- ' : '+ ') +
-                    `Combat Score: ${numberFormatter(scoreData.total.toFixed(1))}${equipmentHiddenText}`;
+                    `Combat Score: ${numberFormatter(scoreData.total.toFixed(1))}${scoreData.complete === false ? '+' : ''}${equipmentHiddenText}`;
             });
         }
 
@@ -478,6 +525,18 @@ class CombatScore {
             });
         }
 
+        // Toggle shrine breakdown (Combat)
+        const shrineToggle = panel.querySelector('#mwi-shrine-toggle');
+        const shrineBreakdown = panel.querySelector('#mwi-shrine-breakdown');
+        if (shrineToggle && shrineBreakdown) {
+            shrineToggle.addEventListener('click', () => {
+                const isCollapsed = shrineBreakdown.style.display === 'none';
+                shrineBreakdown.style.display = isCollapsed ? 'block' : 'none';
+                shrineToggle.textContent =
+                    (isCollapsed ? '- ' : '+ ') + `Shrines: ${numberFormatter((scoreData.shrine || 0).toFixed(1))}`;
+            });
+        }
+
         // Toggle skiller score details
         const skillerScoreToggle = panel.querySelector('#mwi-skiller-score-toggle');
         const skillerScoreDetails = panel.querySelector('#mwi-skiller-score-details');
@@ -487,7 +546,19 @@ class CombatScore {
                 skillerScoreDetails.style.display = isCollapsed ? 'block' : 'none';
                 skillerScoreToggle.textContent =
                     (isCollapsed ? '- ' : '+ ') +
-                    `Skiller Score: ${numberFormatter(scoreData.skillerTotal.toFixed(1))}`;
+                    `Skiller Score: ${numberFormatter(scoreData.skillerTotal.toFixed(1))}${scoreData.skillerComplete === false ? '+' : ''}`;
+            });
+        }
+
+        // Toggle skiller house breakdown
+        const skillerHouseToggle = panel.querySelector('#mwi-skiller-house-toggle');
+        const skillerHouseBreakdown = panel.querySelector('#mwi-skiller-house-breakdown');
+        if (skillerHouseToggle && skillerHouseBreakdown) {
+            skillerHouseToggle.addEventListener('click', () => {
+                const isCollapsed = skillerHouseBreakdown.style.display === 'none';
+                skillerHouseBreakdown.style.display = isCollapsed ? 'block' : 'none';
+                skillerHouseToggle.textContent =
+                    (isCollapsed ? '- ' : '+ ') + `House: ${numberFormatter((scoreData.skillerHouse || 0).toFixed(1))}`;
             });
         }
 
@@ -501,6 +572,19 @@ class CombatScore {
                 skillerEquipmentToggle.textContent =
                     (isCollapsed ? '- ' : '+ ') +
                     `Equipment: ${numberFormatter(scoreData.skillerEquipment.toFixed(1))}`;
+            });
+        }
+
+        // Toggle skiller shrine breakdown
+        const skillerShrineToggle = panel.querySelector('#mwi-skiller-shrine-toggle');
+        const skillerShrineBreakdown = panel.querySelector('#mwi-skiller-shrine-breakdown');
+        if (skillerShrineToggle && skillerShrineBreakdown) {
+            skillerShrineToggle.addEventListener('click', () => {
+                const isCollapsed = skillerShrineBreakdown.style.display === 'none';
+                skillerShrineBreakdown.style.display = isCollapsed ? 'block' : 'none';
+                skillerShrineToggle.textContent =
+                    (isCollapsed ? '- ' : '+ ') +
+                    `Shrines: ${numberFormatter((scoreData.skillerShrine || 0).toFixed(1))}`;
             });
         }
 

--- a/src/features/profile/combat-score.test.js
+++ b/src/features/profile/combat-score.test.js
@@ -191,3 +191,125 @@ describe('showScorePanel lifecycle (PROF-LAYOUT-09/10/11)', () => {
         expect(panel.innerHTML).toContain('Combat Score: 100');
     });
 });
+
+describe('showScorePanel TLA-041 additions (Shrines / Skiller Houses / partial suffix)', () => {
+    function makeFullScoreData(overrides = {}) {
+        return {
+            equipmentHidden: false,
+            hasEquipmentData: true,
+            total: 930,
+            complete: true,
+            house: 100,
+            ability: 50,
+            equipment: 700,
+            shrine: 80,
+            breakdown: {
+                houses: [{ name: 'Dojo 3', value: '100.0' }],
+                abilities: [{ name: 'Fireball 5', value: '50.0' }],
+                equipment: [{ name: 'Sword +10', value: '700.0' }],
+                shrines: [{ name: 'Shrine of Force 1', value: '80.0' }],
+            },
+            skillerTotal: 40,
+            skillerComplete: true,
+            skillerHouse: 20,
+            skillerEquipment: 15,
+            skillerShrine: 5,
+            skillerBreakdown: {
+                houses: [{ name: 'Garden 1', value: '20.0' }],
+                equipment: [{ name: 'Hoe', value: '15.0' }],
+                shrines: [{ name: 'Shrine of Wisdom 1', value: '5.0' }],
+            },
+            ...overrides,
+        };
+    }
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        Element.prototype.getBoundingClientRect = function () {
+            if (this.id === 'mwi-combat-score-panel') return mockRect({ width: 235 });
+            return mockRect({ left: 500, right: 700, top: 30 });
+        };
+    });
+
+    test('renders Combat Shrines, Skiller Houses, and Skiller Shrines rows', () => {
+        const modal = document.createElement('div');
+        document.body.appendChild(modal);
+        combatScore.showScorePanel({ profile: {} }, makeFullScoreData(), modal);
+
+        const panel = document.getElementById('mwi-combat-score-panel');
+        expect(panel.querySelector('#mwi-shrine-toggle')).not.toBeNull();
+        expect(panel.querySelector('#mwi-skiller-house-toggle')).not.toBeNull();
+        expect(panel.querySelector('#mwi-skiller-shrine-toggle')).not.toBeNull();
+        expect(panel.innerHTML).toContain('Shrine of Force 1: 80.0');
+        expect(panel.innerHTML).toContain('Garden 1: 20.0');
+        expect(panel.innerHTML).toContain('Shrine of Wisdom 1: 5.0');
+    });
+
+    test('all new detail sections start collapsed, matching the existing sections', () => {
+        const modal = document.createElement('div');
+        document.body.appendChild(modal);
+        combatScore.showScorePanel({ profile: {} }, makeFullScoreData(), modal);
+
+        const panel = document.getElementById('mwi-combat-score-panel');
+        expect(panel.querySelector('#mwi-shrine-breakdown').style.display).toBe('none');
+        expect(panel.querySelector('#mwi-skiller-house-breakdown').style.display).toBe('none');
+        expect(panel.querySelector('#mwi-skiller-shrine-breakdown').style.display).toBe('none');
+    });
+
+    test('a complete result shows no "+" suffix on either top-level total', () => {
+        const modal = document.createElement('div');
+        document.body.appendChild(modal);
+        combatScore.showScorePanel({ profile: {} }, makeFullScoreData(), modal);
+
+        const panel = document.getElementById('mwi-combat-score-panel');
+        expect(panel.innerHTML).toContain('Combat Score: 930.0');
+        expect(panel.innerHTML).not.toContain('930.0+');
+        expect(panel.innerHTML).toContain('Skiller Score: 40.0');
+        expect(panel.innerHTML).not.toContain('40.0+');
+    });
+
+    test('F-13: an incomplete Combat result shows the "+" lower-bound suffix on the top-level total only', () => {
+        const modal = document.createElement('div');
+        document.body.appendChild(modal);
+        combatScore.showScorePanel({ profile: {} }, makeFullScoreData({ complete: false }), modal);
+
+        const panel = document.getElementById('mwi-combat-score-panel');
+        expect(panel.innerHTML).toContain('Combat Score: 930.0+');
+        // Category rows stay plain numbers - no "+" on House/Ability/Equipment/Shrines themselves.
+        expect(panel.innerHTML).toContain('House: 100.0');
+        expect(panel.innerHTML).not.toContain('House: 100.0+');
+    });
+
+    test('an incomplete Skiller result shows the "+" suffix on the Skiller total only, independent of Combat', () => {
+        const modal = document.createElement('div');
+        document.body.appendChild(modal);
+        combatScore.showScorePanel({ profile: {} }, makeFullScoreData({ skillerComplete: false }), modal);
+
+        const panel = document.getElementById('mwi-combat-score-panel');
+        expect(panel.innerHTML).toContain('Skiller Score: 40.0+');
+        expect(panel.innerHTML).toContain('Combat Score: 930.0');
+        expect(panel.innerHTML).not.toContain('930.0+');
+    });
+
+    test('the explanatory viewer-relative tooltip is present on both top-level toggles', () => {
+        const modal = document.createElement('div');
+        document.body.appendChild(modal);
+        combatScore.showScorePanel({ profile: {} }, makeFullScoreData(), modal);
+
+        const panel = document.getElementById('mwi-combat-score-panel');
+        const scoreToggle = panel.querySelector('#mwi-score-toggle');
+        const skillerToggle = panel.querySelector('#mwi-skiller-score-toggle');
+        expect(scoreToggle.getAttribute('title')).toContain('reproduce this persistent build');
+        expect(skillerToggle.getAttribute('title')).toContain('reproduce this persistent build');
+    });
+
+    test('no Achievements row and no combined grand total are rendered', () => {
+        const modal = document.createElement('div');
+        document.body.appendChild(modal);
+        combatScore.showScorePanel({ profile: {} }, makeFullScoreData(), modal);
+
+        const panel = document.getElementById('mwi-combat-score-panel');
+        expect(panel.innerHTML).not.toContain('Achievement');
+        expect(panel.innerHTML).not.toContain('Grand Total');
+    });
+});

--- a/src/features/profile/score-calculator.js
+++ b/src/features/profile/score-calculator.js
@@ -1,572 +1,89 @@
 /**
- * Combat Score Calculator
- * Calculates player gear score based on:
- * - House Score: Cost of battle houses
- * - Ability Score: Cost to reach current ability levels
- * - Equipment Score: Cost to enhance equipped items
+ * Combat/Skiller Score Calculator (TLA-041)
+ *
+ * Estimated cost for the viewer to reproduce the viewed persistent build now, using current
+ * acquisition prices and the viewer's own current/manual Enhancing setup. Deliberately
+ * viewer-relative: two different viewers looking at the same profile can get different numbers.
+ *
+ * Combat Score  = Houses + equipped Abilities + Combat/shared Equipment + personal Combat Shrines
+ * Skiller Score = Skilling Houses + Skilling/shared Equipment + personal Skilling Shrines
+ * No Achievements component. No Combat + Skiller grand total.
+ *
+ * Composition root only - the actual valuation logic lives in `./score/*.js`.
  */
 
-import { calculateAbilityCost } from '../../utils/ability-cost-calculator.js';
-import { calculateBattleHousesCost } from '../../utils/house-cost-calculator.js';
-import dataManager from '../../core/data-manager.js';
 import { getEnhancingParams } from '../../utils/enhancement-config.js';
-import { getItemPrice, getItemPrices } from '../../utils/market-data.js';
-import config from '../../core/config.js';
-import { calculateEnhancementBatch } from '../../utils/enhancement-worker-manager.js';
-import { getCheapestProtectionPrice, getRealisticBaseItemPrice } from '../enhancement/tooltip-enhancement.js';
-import { getShopCoinCost } from '../../utils/game-lookups.js';
+import { calculateHouseScore } from './score/house-score.js';
+import { calculateAbilityScore } from './score/ability-score.js';
+import { calculateEquipmentScore } from './score/equipment-score.js';
+import { calculateShrineScore } from './score/shrine-score.js';
+import { mergeCategory } from './score/score-result.js';
 
 /**
- * Token-based item data for untradeable back slot items (capes/cloaks/quivers)
- * These items are purchased with dungeon tokens and have no market data
- */
-const CAPE_ITEM_TOKEN_DATA = {
-    '/items/chimerical_quiver': {
-        tokenCost: 35000,
-        tokenShopItems: [
-            { hrid: '/items/griffin_leather', cost: 600 },
-            { hrid: '/items/manticore_sting', cost: 1000 },
-            { hrid: '/items/jackalope_antler', cost: 1200 },
-            { hrid: '/items/dodocamel_plume', cost: 3000 },
-            { hrid: '/items/griffin_talon', cost: 3000 },
-        ],
-    },
-    '/items/sinister_cape': {
-        tokenCost: 27000,
-        tokenShopItems: [
-            { hrid: '/items/acrobats_ribbon', cost: 2000 },
-            { hrid: '/items/magicians_cloth', cost: 2000 },
-            { hrid: '/items/chaotic_chain', cost: 3000 },
-            { hrid: '/items/cursed_ball', cost: 3000 },
-        ],
-    },
-    '/items/enchanted_cloak': {
-        tokenCost: 27000,
-        tokenShopItems: [
-            { hrid: '/items/royal_cloth', cost: 2000 },
-            { hrid: '/items/knights_ingot', cost: 2000 },
-            { hrid: '/items/bishops_scroll', cost: 2000 },
-            { hrid: '/items/regal_jewel', cost: 3000 },
-            { hrid: '/items/sundering_jewel', cost: 3000 },
-        ],
-    },
-};
-
-/**
- * Skill classification for equipment categorization
- */
-const COMBAT_SKILLS = ['attack', 'melee', 'defense', 'ranged', 'magic', 'prayer'];
-const SKILLING_SKILLS = [
-    'milking',
-    'foraging',
-    'woodcutting',
-    'cheesesmithing',
-    'crafting',
-    'tailoring',
-    'brewing',
-    'cooking',
-    'alchemy',
-    'enhancing',
-];
-
-/**
- * Categorize equipment item by skill requirements
- * @param {string} slot - Item slot HRID (e.g., "/item_locations/neck")
- * @param {Object} equipmentDetail - Equipment detail from item data
- * @returns {Object} {combat: boolean, skiller: boolean}
- */
-function categorizeEquipmentItem(slot, equipmentDetail) {
-    // Tools always go to skiller only (regardless of requirements)
-    if (slot.endsWith('_tool')) {
-        return { combat: false, skiller: true };
-    }
-
-    const requirements = equipmentDetail?.levelRequirements || [];
-
-    // No requirements → both scores
-    if (requirements.length === 0) {
-        return { combat: true, skiller: true };
-    }
-
-    // Check for combat vs skilling requirements
-    const hasCombat = requirements.some((req) => COMBAT_SKILLS.some((skill) => req.skillHrid.includes(skill)));
-    const hasSkilling = requirements.some((req) => SKILLING_SKILLS.some((skill) => req.skillHrid.includes(skill)));
-
-    return { combat: hasCombat, skiller: hasSkilling };
-}
-
-/**
- * Calculate combat score from profile data
+ * Calculate combat/skiller score from profile data.
  * @param {Object} profileData - Profile data from game
- * @returns {Promise<Object>} {total, house, ability, equipment, breakdown}
+ * @returns {Promise<Object>} {total, complete, house, ability, equipment, shrine, breakdown,
+ *   skillerTotal, skillerComplete, skillerHouse, skillerEquipment, skillerShrine, skillerBreakdown,
+ *   equipmentHidden, hasEquipmentData}
  */
 export async function calculateCombatScore(profileData) {
     try {
-        // 1. Calculate House Score
-        const houseResult = calculateHouseScore(profileData);
+        const enhancingParams = getEnhancingParams();
 
-        // 2. Calculate Ability Score
-        const abilityResult = calculateAbilityScore(profileData);
+        const houses = calculateHouseScore(profileData);
+        const abilities = calculateAbilityScore(profileData);
+        const shrines = calculateShrineScore(profileData);
+        const equipment = calculateEquipmentScore(profileData, enhancingParams);
 
-        // 3. Calculate Combat Equipment Score (async - runs first)
-        const combatEquipmentResult = await calculateEquipmentScore(profileData, 'combat');
-
-        // 4. Calculate Skiller Equipment Score (async - runs after combat completes)
-        const skillerEquipmentResult = await calculateEquipmentScore(profileData, 'skiller');
-
-        const combatTotalScore = houseResult.score + abilityResult.score + combatEquipmentResult.score;
-        const skillerTotalScore = skillerEquipmentResult.score;
+        const combat = mergeCategory([houses.combat, abilities, equipment.combat, shrines.combat]);
+        const skiller = mergeCategory([houses.skiller, equipment.skiller, shrines.skiller]);
 
         return {
-            // Combat score (house + ability + combat equipment)
-            total: combatTotalScore,
-            house: houseResult.score,
-            ability: abilityResult.score,
-            equipment: combatEquipmentResult.score,
+            // Combat score (houses + abilities + combat equipment + combat shrines)
+            total: combat.score,
+            complete: combat.complete,
+            house: houses.combat.score,
+            ability: abilities.score,
+            equipment: equipment.combat.score,
+            shrine: shrines.combat.score,
             equipmentHidden: profileData.profile?.hideWearableItems || false,
-            hasEquipmentData: combatEquipmentResult.hasEquipmentData,
+            hasEquipmentData: equipment.hasEquipmentData,
             breakdown: {
-                houses: houseResult.breakdown,
-                abilities: abilityResult.breakdown,
-                equipment: combatEquipmentResult.breakdown,
+                houses: houses.combat.breakdown,
+                abilities: abilities.breakdown,
+                equipment: equipment.combat.breakdown,
+                shrines: shrines.combat.breakdown,
             },
-            // Skiller score (skilling equipment only)
-            skillerTotal: skillerTotalScore,
-            skillerEquipment: skillerEquipmentResult.score,
+            // Skiller score (skilling houses + skilling equipment + skilling shrines)
+            skillerTotal: skiller.score,
+            skillerComplete: skiller.complete,
+            skillerHouse: houses.skiller.score,
+            skillerEquipment: equipment.skiller.score,
+            skillerShrine: shrines.skiller.score,
             skillerBreakdown: {
-                equipment: skillerEquipmentResult.breakdown,
+                houses: houses.skiller.breakdown,
+                equipment: equipment.skiller.breakdown,
+                shrines: shrines.skiller.breakdown,
             },
         };
     } catch (error) {
         console.error('[CombatScore] Error calculating score:', error);
         return {
             total: 0,
+            complete: false,
             house: 0,
             ability: 0,
             equipment: 0,
+            shrine: 0,
             equipmentHidden: false,
             hasEquipmentData: false,
-            breakdown: { houses: [], abilities: [], equipment: [] },
+            breakdown: { houses: [], abilities: [], equipment: [], shrines: [] },
             skillerTotal: 0,
+            skillerComplete: false,
+            skillerHouse: 0,
             skillerEquipment: 0,
-            skillerBreakdown: { equipment: [] },
+            skillerShrine: 0,
+            skillerBreakdown: { houses: [], equipment: [], shrines: [] },
         };
     }
-}
-
-/**
- * Get market price for an item with crafting cost fallback
- * @param {string} itemHrid - Item HRID
- * @param {number} enhancementLevel - Enhancement level
- * @returns {number} Price per item (always uses ask price, falls back to crafting cost)
- */
-function getMarketPriceWithFallback(itemHrid, enhancementLevel = 0) {
-    const gameData = dataManager.getInitClientData();
-
-    // Try ask price first
-    const askPrice = getItemPrice(itemHrid, { enhancementLevel, mode: 'ask' });
-
-    if (askPrice && askPrice > 0) {
-        return askPrice;
-    }
-
-    // For base items (enhancement 0), try crafting cost fallback
-    if (enhancementLevel === 0 && gameData) {
-        // Find the action that produces this item
-        for (const action of Object.values(gameData.actionDetailMap || {})) {
-            if (action.outputItems) {
-                for (const output of action.outputItems) {
-                    if (output.itemHrid === itemHrid) {
-                        // Found the crafting action, calculate material costs
-                        let inputCost = 0;
-
-                        // Add input items
-                        if (action.inputItems && action.inputItems.length > 0) {
-                            for (const input of action.inputItems) {
-                                const inputPrice = getMarketPriceWithFallback(input.itemHrid, 0);
-                                inputCost += inputPrice * input.count;
-                            }
-                        }
-
-                        // Apply Artisan Tea reduction (0.9x) to input materials
-                        inputCost *= 0.9;
-
-                        // Add upgrade item cost (not affected by Artisan Tea)
-                        let upgradeCost = 0;
-                        if (action.upgradeItemHrid) {
-                            const upgradePrice = getMarketPriceWithFallback(action.upgradeItemHrid, 0);
-                            upgradeCost = upgradePrice;
-                        }
-
-                        const totalCost = inputCost + upgradeCost;
-
-                        // Divide by output count to get per-item cost
-                        const perItemCost = totalCost / (output.count || 1);
-
-                        if (perItemCost > 0) {
-                            return perItemCost;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Try shop cost as final fallback (for shop-only items)
-        const shopCost = getShopCoinCost(itemHrid);
-        if (shopCost > 0) {
-            return shopCost;
-        }
-    }
-
-    return 0;
-}
-
-/**
- * Calculate house score from battle houses
- * @param {Object} profileData - Profile data
- * @returns {Object} {score, breakdown}
- */
-function calculateHouseScore(profileData) {
-    const characterHouseRooms = profileData.profile?.characterHouseRoomMap || {};
-
-    const { totalCost, breakdown } = calculateBattleHousesCost(characterHouseRooms);
-
-    // Convert to score (cost / 1 million)
-    const score = totalCost / 1_000_000;
-
-    // Format breakdown for display
-    const formattedBreakdown = breakdown.map((house) => ({
-        name: `${house.name} ${house.level}`,
-        value: (house.cost / 1_000_000).toFixed(1),
-    }));
-
-    return { score, breakdown: formattedBreakdown };
-}
-
-/**
- * Calculate ability score from equipped abilities
- * @param {Object} profileData - Profile data
- * @returns {Object} {score, breakdown}
- */
-function calculateAbilityScore(profileData) {
-    // Use equippedAbilities (not characterAbilities) to match MCS behavior
-    const equippedAbilities = profileData.profile?.equippedAbilities || [];
-
-    let totalCost = 0;
-    const breakdown = [];
-
-    for (const ability of equippedAbilities) {
-        if (!ability.abilityHrid || ability.level === 0) continue;
-
-        const cost = calculateAbilityCost(ability.abilityHrid, ability.level);
-        totalCost += cost;
-
-        // Format ability name for display
-        const abilityName = ability.abilityHrid
-            .replace('/abilities/', '')
-            .split('_')
-            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(' ');
-
-        breakdown.push({
-            name: `${abilityName} ${ability.level}`,
-            value: (cost / 1_000_000).toFixed(1),
-        });
-    }
-
-    // Convert to score (cost / 1 million)
-    const score = totalCost / 1_000_000;
-
-    // Sort by value descending
-    breakdown.sort((a, b) => parseFloat(b.value) - parseFloat(a.value));
-
-    return { score, breakdown };
-}
-
-/**
- * Calculate token-based item value for untradeable back slot items
- * @param {string} itemHrid - Item HRID
- * @returns {number} Item value in coins (0 if not a token-based item)
- */
-function calculateTokenBasedItemValue(itemHrid) {
-    const capeData = CAPE_ITEM_TOKEN_DATA[itemHrid];
-    if (!capeData) {
-        return 0; // Not a token-based item
-    }
-
-    // Find the best value per token from shop items
-    let bestValuePerToken = 0;
-    for (const shopItem of capeData.tokenShopItems) {
-        // Use ask price for shop items (instant buy cost)
-        const shopItemPrice = getItemPrice(shopItem.hrid, { mode: 'ask' }) || 0;
-        if (shopItemPrice > 0) {
-            const valuePerToken = shopItemPrice / shopItem.cost;
-            if (valuePerToken > bestValuePerToken) {
-                bestValuePerToken = valuePerToken;
-            }
-        }
-    }
-
-    // Calculate total item value: best value per token × token cost
-    return bestValuePerToken * capeData.tokenCost;
-}
-
-/**
- * Calculate equipment score from equipped items
- * @param {Object} profileData - Profile data
- * @param {string} scoreType - 'combat' or 'skiller'
- * @returns {Promise<Object>} {score, breakdown, hasEquipmentData}
- */
-async function calculateEquipmentScore(profileData, scoreType = 'combat') {
-    const equippedItems = profileData.profile?.wearableItemMap || {};
-    const hideEquipment = profileData.profile?.hideWearableItems || false;
-
-    // Check if equipment data is actually available
-    // If wearableItemMap is populated, calculate score even if hideEquipment is true
-    // (This happens when viewing party members - game sends equipment data despite privacy setting)
-    const hasEquipmentData = Object.keys(equippedItems).length > 0;
-
-    // If equipment is hidden AND no data available, return 0
-    if (hideEquipment && !hasEquipmentData) {
-        return { score: 0, breakdown: [], hasEquipmentData: false };
-    }
-
-    const gameData = dataManager.getInitClientData();
-    if (!gameData) return { score: 0, breakdown: [], hasEquipmentData: false };
-
-    const useHighEnhancementCost = config.getSetting('networth_highEnhancementUseCost');
-    const minLevel = config.getSetting('networth_highEnhancementMinLevel') || 13;
-    const enhancementParams = getEnhancingParams();
-
-    // Phase 1: Collect items and identify which need worker calculations
-    const itemsToProcess = [];
-    const workerTasks = [];
-
-    for (const [slot, itemData] of Object.entries(equippedItems)) {
-        if (!itemData?.itemHrid) continue;
-
-        const itemHrid = itemData.itemHrid;
-        const itemDetails = gameData.itemDetailMap[itemHrid];
-        if (!itemDetails) continue;
-
-        // Categorize item by skill requirements
-        const category = categorizeEquipmentItem(slot, itemDetails.equipmentDetail);
-
-        // Filter by score type
-        if (scoreType === 'combat' && !category.combat) continue;
-        if (scoreType === 'skiller' && !category.skiller) continue;
-
-        const enhancementLevel = itemData.enhancementLevel || 0;
-        const itemLevel = itemDetails.itemLevel || 1;
-
-        itemsToProcess.push({
-            itemHrid,
-            enhancementLevel,
-            itemDetails,
-            itemLevel,
-            needsEnhancementCalc: false,
-            subLevelTasks: [],
-        });
-
-        // Check if this item needs enhancement calculation via worker
-        const tokenValue = calculateTokenBasedItemValue(itemHrid);
-        if (tokenValue === 0) {
-            // Not a token item, might need enhancement calculation
-            if (enhancementLevel >= 1 && useHighEnhancementCost && enhancementLevel >= minLevel) {
-                // High enhancement mode - calculate cost for all sub-levels (needed for mirror optimization)
-                const subLevelTasks = [];
-                for (let subLevel = 1; subLevel <= enhancementLevel; subLevel++) {
-                    const strategies = [0];
-                    for (let pf = 2; pf <= subLevel; pf++) strategies.push(pf);
-                    const levelStartIndex = workerTasks.length;
-                    for (const protectFrom of strategies) {
-                        workerTasks.push({
-                            enhancingLevel: enhancementParams.enhancingLevel,
-                            toolBonus: enhancementParams.toolBonus || 0,
-                            speedBonus: enhancementParams.speedBonus || 0,
-                            itemLevel,
-                            targetLevel: subLevel,
-                            protectFrom,
-                            blessedTea: enhancementParams.teas.blessed,
-                            guzzlingBonus: enhancementParams.guzzlingBonus,
-                        });
-                    }
-                    subLevelTasks.push({ workerStartIndex: levelStartIndex, strategies });
-                }
-                itemsToProcess[itemsToProcess.length - 1].needsEnhancementCalc = true;
-                itemsToProcess[itemsToProcess.length - 1].subLevelTasks = subLevelTasks;
-            } else if (enhancementLevel > 1) {
-                // Check market price first
-                const marketPrice = getMarketPriceWithFallback(itemHrid, enhancementLevel);
-                if (!marketPrice || marketPrice === 0) {
-                    // No market data - calculate cost for all sub-levels (needed for mirror optimization)
-                    const subLevelTasks = [];
-                    for (let subLevel = 1; subLevel <= enhancementLevel; subLevel++) {
-                        const strategies = [0];
-                        for (let pf = 2; pf <= subLevel; pf++) strategies.push(pf);
-                        const levelStartIndex = workerTasks.length;
-                        for (const protectFrom of strategies) {
-                            workerTasks.push({
-                                enhancingLevel: enhancementParams.enhancingLevel,
-                                toolBonus: enhancementParams.toolBonus || 0,
-                                speedBonus: enhancementParams.speedBonus || 0,
-                                itemLevel,
-                                targetLevel: subLevel,
-                                protectFrom,
-                                blessedTea: enhancementParams.teas.blessed,
-                                guzzlingBonus: enhancementParams.guzzlingBonus,
-                            });
-                        }
-                        subLevelTasks.push({ workerStartIndex: levelStartIndex, strategies });
-                    }
-                    itemsToProcess[itemsToProcess.length - 1].needsEnhancementCalc = true;
-                    itemsToProcess[itemsToProcess.length - 1].subLevelTasks = subLevelTasks;
-                }
-            }
-        }
-    }
-
-    // Phase 2: Execute all worker tasks in parallel
-    let workerResults = [];
-    if (workerTasks.length > 0) {
-        try {
-            workerResults = await calculateEnhancementBatch(workerTasks);
-        } catch (error) {
-            console.warn('[ScoreCalculator] Enhancement batch worker failed, using fallback pricing:', error);
-        }
-    }
-
-    // Phase 3: Calculate costs using worker results
-    let totalValue = 0;
-    const breakdown = [];
-
-    for (const item of itemsToProcess) {
-        let itemCost = 0;
-
-        // Check token value first
-        const tokenValue = calculateTokenBasedItemValue(item.itemHrid);
-        if (tokenValue > 0) {
-            itemCost = tokenValue;
-        } else if (item.needsEnhancementCalc && item.subLevelTasks.length > 0) {
-            // Build targetCosts[0..N], matching tooltip's calculateEnhancementPath
-            const targetCosts = [getRealisticBaseItemPrice(item.itemHrid)]; // level 0 = base item
-            for (let subLevel = 1; subLevel <= item.enhancementLevel; subLevel++) {
-                const { workerStartIndex, strategies } = item.subLevelTasks[subLevel - 1];
-                let minCost = null;
-                for (let s = 0; s < strategies.length; s++) {
-                    const wr = workerResults[workerStartIndex + s];
-                    if (!wr || !wr.attempts) continue;
-                    const cost = calculateEnhancementCostFromWorkerResult(item.itemHrid, strategies[s], wr);
-                    if (minCost === null || cost < minCost) minCost = cost;
-                }
-                targetCosts.push(minCost ?? getRealisticBaseItemPrice(item.itemHrid));
-            }
-            // Apply Philosopher's Mirror optimization (same pass as tooltip)
-            const mirrorPrice = getRealisticBaseItemPrice('/items/philosophers_mirror');
-            if (mirrorPrice > 0) {
-                for (let level = 3; level <= item.enhancementLevel; level++) {
-                    const mirrorCost = targetCosts[level - 2] + targetCosts[level - 1] + mirrorPrice;
-                    if (mirrorCost < targetCosts[level]) {
-                        targetCosts[level] = mirrorCost;
-                    }
-                }
-            }
-            itemCost = targetCosts[item.enhancementLevel];
-        } else {
-            // Use market price (already checked or not needed)
-            const marketPrice = getMarketPriceWithFallback(item.itemHrid, item.enhancementLevel);
-            if (marketPrice > 0) {
-                itemCost = marketPrice;
-            } else if (item.enhancementLevel > 1) {
-                // Fallback to base price
-                itemCost = getMarketPriceWithFallback(item.itemHrid, 0);
-            } else {
-                // Enhancement level 0 or 1
-                itemCost = getMarketPriceWithFallback(item.itemHrid, 0);
-            }
-        }
-
-        totalValue += itemCost;
-
-        // Format item name for display
-        const itemName = item.itemDetails.name || item.itemHrid.replace('/items/', '');
-        const displayName = item.enhancementLevel > 0 ? `${itemName} +${item.enhancementLevel}` : itemName;
-
-        // Only add to breakdown if formatted value is not "0.0"
-        const formattedValue = (itemCost / 1_000_000).toFixed(1);
-        if (formattedValue !== '0.0') {
-            breakdown.push({
-                name: displayName,
-                value: formattedValue,
-            });
-        }
-    }
-
-    // Convert to score (value / 1 million)
-    const score = totalValue / 1_000_000;
-
-    // Sort by value descending
-    breakdown.sort((a, b) => parseFloat(b.value) - parseFloat(a.value));
-
-    return { score, breakdown, hasEquipmentData };
-}
-
-/**
- * Calculate total enhancement cost from worker result
- * Matches tooltip-enhancement.js calculateTotalCost() exactly.
- * @param {string} itemHrid - Item HRID
- * @param {number} protectFrom - Protection threshold used in this calculation
- * @param {Object} workerResult - Worker calculation result
- * @returns {number} Total cost (base item + materials + protection)
- */
-function calculateEnhancementCostFromWorkerResult(itemHrid, protectFrom, workerResult) {
-    const gameData = dataManager.getInitClientData();
-    if (!gameData) return 0;
-
-    const itemDetails = gameData.itemDetailMap[itemHrid];
-    if (!itemDetails || !itemDetails.enhancementCosts) return 0;
-
-    // Base item cost — matches tooltip's getRealisticBaseItemPrice (with inflation guard)
-    const baseItemCost = getRealisticBaseItemPrice(itemHrid);
-
-    // Material cost per attempt — matches tooltip's calculateTotalCost material loop exactly
-    let perActionCost = 0;
-    for (const material of itemDetails.enhancementCosts) {
-        if (!material || !material.itemHrid) continue;
-
-        let price;
-        if (material.itemHrid.startsWith('/items/trainee_')) {
-            price = 250000; // untradeable trainee charms: fixed 250k
-        } else if (material.itemHrid === '/items/coin') {
-            price = 1; // coins at face value
-        } else {
-            const marketPrice = getItemPrices(material.itemHrid, 0);
-            if (marketPrice) {
-                let ask = marketPrice.ask;
-                let bid = marketPrice.bid;
-                // Normalize: if one side is negative (no listings), use the positive side
-                if (ask > 0 && bid < 0) bid = ask;
-                if (bid > 0 && ask < 0) ask = bid;
-                price = ask;
-            } else {
-                // Fallback to sell price if no market data
-                price = gameData.itemDetailMap[material.itemHrid]?.sellPrice || 0;
-            }
-        }
-        perActionCost += price * (material.count || 1);
-    }
-
-    // Total material cost = per-action cost × total expected attempts
-    const materialCost = perActionCost * workerResult.attempts;
-
-    // Protection cost using actual cheapest protection price
-    let protectionCost = 0;
-    if (protectFrom > 0 && workerResult.protectionCount > 0) {
-        const protectionInfo = getCheapestProtectionPrice(itemHrid);
-        if (protectionInfo.price > 0) {
-            protectionCost = protectionInfo.price * workerResult.protectionCount;
-        }
-    }
-
-    return baseItemCost + materialCost + protectionCost;
 }

--- a/src/features/profile/score-calculator.test.js
+++ b/src/features/profile/score-calculator.test.js
@@ -1,0 +1,121 @@
+import { describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    enhancingParams: { enhancingLevel: 50 },
+    house: {
+        combat: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+        skiller: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+    },
+    ability: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+    shrine: {
+        combat: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+        skiller: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+    },
+    equipment: {
+        combat: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+        skiller: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+        hasEquipmentData: true,
+    },
+}));
+
+vi.mock('../../utils/enhancement-config.js', () => ({ getEnhancingParams: vi.fn(() => mocks.enhancingParams) }));
+vi.mock('./score/house-score.js', () => ({ calculateHouseScore: vi.fn(() => mocks.house) }));
+vi.mock('./score/ability-score.js', () => ({ calculateAbilityScore: vi.fn(() => mocks.ability) }));
+vi.mock('./score/shrine-score.js', () => ({ calculateShrineScore: vi.fn(() => mocks.shrine) }));
+vi.mock('./score/equipment-score.js', () => ({ calculateEquipmentScore: vi.fn(() => mocks.equipment) }));
+
+import { calculateCombatScore } from './score-calculator.js';
+
+function resetToComplete() {
+    mocks.house = {
+        combat: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+        skiller: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+    };
+    mocks.ability = { score: 0, complete: true, unpricedCount: 0, breakdown: [] };
+    mocks.shrine = {
+        combat: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+        skiller: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+    };
+    mocks.equipment = {
+        combat: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+        skiller: { score: 0, complete: true, unpricedCount: 0, breakdown: [] },
+        hasEquipmentData: true,
+    };
+}
+
+describe('calculateCombatScore - composition and backward-compatible shape', () => {
+    test('total/house/ability/equipment/skillerTotal/skillerEquipment stay plain numbers (character-card-button.js compatibility)', async () => {
+        resetToComplete();
+        mocks.house.combat.score = 10;
+        mocks.ability.score = 5;
+        mocks.equipment.combat.score = 7;
+        mocks.shrine.combat.score = 3;
+
+        const result = await calculateCombatScore({ profile: {} });
+
+        expect(typeof result.total).toBe('number');
+        expect(result.total).toBeCloseTo(25);
+        expect(typeof result.house).toBe('number');
+        expect(typeof result.ability).toBe('number');
+        expect(typeof result.equipment).toBe('number');
+        expect(typeof result.skillerTotal).toBe('number');
+        expect(typeof result.skillerEquipment).toBe('number');
+    });
+
+    test('no Combat + Skiller grand total exists anywhere on the result (PB-05)', async () => {
+        resetToComplete();
+        const result = await calculateCombatScore({ profile: {} });
+        expect(result.grandTotal).toBeUndefined();
+        expect(result.combinedTotal).toBeUndefined();
+    });
+
+    test('Skiller side has no Ability component (equipped abilities are Combat-only)', async () => {
+        resetToComplete();
+        const result = await calculateCombatScore({ profile: {} });
+        expect(result.skillerBreakdown.abilities).toBeUndefined();
+    });
+});
+
+describe('calculateCombatScore - F-13: partial top-level propagation', () => {
+    test('930.0+ when Equipment has one unpriced item, even though Houses/Abilities/Shrines are complete', async () => {
+        resetToComplete();
+        mocks.house.combat = { score: 100, complete: true, unpricedCount: 0, breakdown: [] };
+        mocks.ability = { score: 50, complete: true, unpricedCount: 0, breakdown: [] };
+        mocks.equipment.combat = { score: 700, complete: false, unpricedCount: 1, breakdown: [] };
+        mocks.shrine.combat = { score: 80, complete: true, unpricedCount: 0, breakdown: [] };
+
+        const result = await calculateCombatScore({ profile: {} });
+
+        expect(result.total).toBeCloseTo(930);
+        expect(result.complete).toBe(false); // renderer appends "+" when complete is false
+    });
+});
+
+describe('calculateCombatScore - F-07: viewer-relative (different getEnhancingParams -> different score)', () => {
+    test('equipment score reflects whatever calculateEquipmentScore computed for the calling viewer', async () => {
+        resetToComplete();
+        mocks.equipment.combat.score = 500; // "Viewer A" reconstruction cost
+        const viewerA = await calculateCombatScore({ profile: {} });
+        expect(viewerA.equipment).toBeCloseTo(500);
+
+        mocks.equipment.combat.score = 700; // "Viewer B" reconstruction cost, same viewed profile/market
+        const viewerB = await calculateCombatScore({ profile: {} });
+        expect(viewerB.equipment).toBeCloseTo(700);
+
+        expect(viewerA.equipment).not.toBe(viewerB.equipment);
+    });
+});
+
+describe('calculateCombatScore - error handling never throws to the caller', () => {
+    test('a calculator throwing still returns a safe, fully-typed zeroed result', async () => {
+        const { calculateHouseScore } = await import('./score/house-score.js');
+        calculateHouseScore.mockImplementationOnce(() => {
+            throw new Error('boom');
+        });
+
+        const result = await calculateCombatScore({ profile: {} });
+        expect(result.total).toBe(0);
+        expect(result.complete).toBe(false);
+        expect(result.breakdown).toEqual({ houses: [], abilities: [], equipment: [], shrines: [] });
+    });
+});

--- a/src/features/profile/score/ability-score.js
+++ b/src/features/profile/score/ability-score.js
@@ -1,0 +1,36 @@
+/**
+ * Ability Score (TLA-041)
+ *
+ * Combat-only category (equipped abilities only, matching current scope). Cost per ability book
+ * is data-driven (`abilityBookDetail.experienceGain`) and Ask-only (F-11).
+ */
+
+import { calculateAbilityBookCostDataDriven } from '../../../utils/ability-cost-calculator.js';
+import { emptyCategory, attribute } from './score-result.js';
+
+/**
+ * @param {Object} profileData - Profile data from game
+ * @returns {Object} category result {score, complete, unpricedCount, breakdown}
+ */
+export function calculateAbilityScore(profileData) {
+    // Use equippedAbilities (not characterAbilities) to match MCS behavior.
+    const equippedAbilities = profileData.profile?.equippedAbilities || [];
+
+    const category = emptyCategory();
+
+    for (const ability of equippedAbilities) {
+        if (!ability.abilityHrid || ability.level === 0) continue;
+
+        const { cost, complete } = calculateAbilityBookCostDataDriven(ability.abilityHrid, ability.level);
+
+        const abilityName = ability.abilityHrid
+            .replace('/abilities/', '')
+            .split('_')
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' ');
+
+        attribute(category, { name: `${abilityName} ${ability.level}`, cost, complete });
+    }
+
+    return category;
+}

--- a/src/features/profile/score/ability-score.test.js
+++ b/src/features/profile/score/ability-score.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from 'vitest';
+
+const { calculateAbilityBookCostDataDriven } = vi.hoisted(() => ({ calculateAbilityBookCostDataDriven: vi.fn() }));
+vi.mock('../../../utils/ability-cost-calculator.js', () => ({ calculateAbilityBookCostDataDriven }));
+
+import { calculateAbilityScore } from './ability-score.js';
+
+describe('calculateAbilityScore (TLA-041)', () => {
+    test('sums equipped abilities only, skipping unequipped/level-0 entries', () => {
+        calculateAbilityBookCostDataDriven.mockReturnValue({ cost: 3_000_000, complete: true });
+
+        const profileData = {
+            profile: {
+                equippedAbilities: [
+                    { abilityHrid: '/abilities/fireball', level: 5 },
+                    { abilityHrid: '/abilities/speed_aura', level: 0 }, // unequipped
+                    { abilityHrid: null, level: 3 }, // malformed, skipped
+                ],
+            },
+        };
+
+        const result = calculateAbilityScore(profileData);
+        expect(calculateAbilityBookCostDataDriven).toHaveBeenCalledTimes(1);
+        expect(result.score).toBeCloseTo(3);
+        expect(result.breakdown).toEqual([{ name: 'Fireball 5', value: '3.0' }]);
+    });
+
+    test('an unpriceable ability book propagates partial state (PB-39)', () => {
+        calculateAbilityBookCostDataDriven.mockReturnValue({ cost: null, complete: false });
+
+        const profileData = { profile: { equippedAbilities: [{ abilityHrid: '/abilities/fireball', level: 5 }] } };
+        const result = calculateAbilityScore(profileData);
+
+        expect(result.complete).toBe(false);
+        expect(result.score).toBe(0);
+    });
+
+    test('missing profile data does not throw', () => {
+        expect(() => calculateAbilityScore({})).not.toThrow();
+    });
+});

--- a/src/features/profile/score/equipment-classifier.js
+++ b/src/features/profile/score/equipment-classifier.js
@@ -1,0 +1,28 @@
+/**
+ * Equipment Domain Classifier
+ *
+ * Classifies an equipped item into Combat/Skiller domains using its actual
+ * `combatStats`/`noncombatStats` data, not skill-requirement names. Verified against the live
+ * Game Reference: 532 equipment items split 344 combat-only / 177 skilling-only / 11 both / 0
+ * neither under this exact rule.
+ */
+
+/**
+ * @param {Object} statsObj - combatStats or noncombatStats object
+ * @returns {boolean} true if at least one key has a non-zero numeric value
+ */
+function hasMeaningfulStats(statsObj) {
+    if (!statsObj) return false;
+    return Object.values(statsObj).some((v) => typeof v === 'number' && v !== 0);
+}
+
+/**
+ * @param {Object} equipmentDetail - itemDetails.equipmentDetail
+ * @returns {{combat: boolean, skiller: boolean}}
+ */
+export function classifyEquipmentItem(equipmentDetail) {
+    return {
+        combat: hasMeaningfulStats(equipmentDetail?.combatStats),
+        skiller: hasMeaningfulStats(equipmentDetail?.noncombatStats),
+    };
+}

--- a/src/features/profile/score/equipment-classifier.test.js
+++ b/src/features/profile/score/equipment-classifier.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+import { classifyEquipmentItem } from './equipment-classifier.js';
+
+describe('classifyEquipmentItem (TLA-041)', () => {
+    test('combatStats with a non-zero key classifies combat-only', () => {
+        const result = classifyEquipmentItem({ combatStats: { armor: 5 }, noncombatStats: {} });
+        expect(result).toEqual({ combat: true, skiller: false });
+    });
+
+    test('noncombatStats with a non-zero key classifies skiller-only', () => {
+        const result = classifyEquipmentItem({ combatStats: {}, noncombatStats: { skillingEfficiency: 0.02 } });
+        expect(result).toEqual({ combat: false, skiller: true });
+    });
+
+    test('non-zero keys in both buckets classifies both (e.g. Guzzling Pouch)', () => {
+        const result = classifyEquipmentItem({
+            combatStats: { maxHitpoints: 20, drinkConcentration: 0.1 },
+            noncombatStats: { drinkConcentration: 0.1 },
+        });
+        expect(result).toEqual({ combat: true, skiller: true });
+    });
+
+    test('all-zero stats in both buckets classifies neither (not defaulted to both)', () => {
+        const result = classifyEquipmentItem({ combatStats: { armor: 0 }, noncombatStats: { gatheringQuantity: 0 } });
+        expect(result).toEqual({ combat: false, skiller: false });
+    });
+
+    test('missing equipmentDetail classifies neither, does not throw', () => {
+        expect(classifyEquipmentItem(undefined)).toEqual({ combat: false, skiller: false });
+    });
+
+    test('no-requirement combat-only accessory is not auto-counted as skiller (PB-17)', () => {
+        // e.g. Fighter Necklace: no levelRequirements, but only combatStats populated
+        const result = classifyEquipmentItem({
+            combatStats: { stabAccuracy: 0.04 },
+            noncombatStats: {},
+        });
+        expect(result).toEqual({ combat: true, skiller: false });
+    });
+
+    test('no-requirement skilling-only accessory is not auto-counted as combat (PB-18)', () => {
+        // e.g. Ring Of Gathering: no levelRequirements, but only noncombatStats populated
+        const result = classifyEquipmentItem({
+            combatStats: {},
+            noncombatStats: { gatheringQuantity: 0.03 },
+        });
+        expect(result).toEqual({ combat: false, skiller: true });
+    });
+
+    test('Stamina/Intelligence Charm shape classifies combat, not dropped (PB-16)', () => {
+        // Charms carry staminaExperience/intelligenceExperience inside combatStats per Game Reference
+        const result = classifyEquipmentItem({
+            combatStats: { staminaExperience: 1 },
+            noncombatStats: {},
+        });
+        expect(result).toEqual({ combat: true, skiller: false });
+    });
+});

--- a/src/features/profile/score/equipment-resolver.js
+++ b/src/features/profile/score/equipment-resolver.js
@@ -1,0 +1,185 @@
+/**
+ * Equipment Replacement Resolver (TLA-041)
+ *
+ * For a viewed `Item +N`, computes the cheapest COMPLETE reproduction candidate using the
+ * viewer's own current/manual Enhancing setup:
+ *   (a) exact positive Ask for Item +N;
+ *   (b) base-item acquisition + viewer-relative 0->N reconstruction (Mirror-aware where the
+ *       shared enhancement-tooltip machinery applies; token items use a direct, non-mirror
+ *       0->N path on top of their real token-opportunity base value instead - see below);
+ *   (c) for every actual live lower-enhancement Ask +K (0 < K < N): Ask(+K) + direct
+ *       viewer-relative K->N enhancement (never a 0-based subtraction shortcut).
+ * The minimum among candidates that price COMPLETELY wins. Zero complete candidates -> the item
+ * is `{cost: null, complete: false}`; missing some candidates is not global failure as long as at
+ * least one full candidate prices.
+ */
+
+import dataManager from '../../../core/data-manager.js';
+import { getItemPrice } from '../../../utils/market-data.js';
+import { getShopCoinCost } from '../../../utils/game-lookups.js';
+import {
+    getProductionCost,
+    calculateEnhancementPath,
+    calculateDirectEnhancementCost,
+} from '../../enhancement/tooltip-enhancement.js';
+
+/**
+ * Untradeable dungeon-shop back-slot items. Each item's own token PURCHASE COST is read
+ * generically from `shopItemDetailMap` (PB-35) via `getTokenPurchaseInfo`; the list of
+ * alternative token-shop items used to derive the best foregone value per token is kept as data
+ * (discovering that set generically is out of scope for this ticket).
+ */
+const TOKEN_SHOP_ALTERNATIVES = {
+    '/items/chimerical_quiver': [
+        { hrid: '/items/griffin_leather', cost: 600 },
+        { hrid: '/items/manticore_sting', cost: 1000 },
+        { hrid: '/items/jackalope_antler', cost: 1200 },
+        { hrid: '/items/dodocamel_plume', cost: 3000 },
+        { hrid: '/items/griffin_talon', cost: 3000 },
+    ],
+    '/items/sinister_cape': [
+        { hrid: '/items/acrobats_ribbon', cost: 2000 },
+        { hrid: '/items/magicians_cloth', cost: 2000 },
+        { hrid: '/items/chaotic_chain', cost: 3000 },
+        { hrid: '/items/cursed_ball', cost: 3000 },
+    ],
+    '/items/enchanted_cloak': [
+        { hrid: '/items/royal_cloth', cost: 2000 },
+        { hrid: '/items/knights_ingot', cost: 2000 },
+        { hrid: '/items/bishops_scroll', cost: 2000 },
+        { hrid: '/items/regal_jewel', cost: 3000 },
+        { hrid: '/items/sundering_jewel', cost: 3000 },
+    ],
+};
+
+/**
+ * @param {string} itemHrid
+ * @returns {{tokenItemHrid: string, tokenCost: number}|null} null if not a token-shop-purchased item
+ */
+function getTokenPurchaseInfo(itemHrid) {
+    const gameData = dataManager.getInitClientData();
+    const shopItem = Object.values(gameData?.shopItemDetailMap || {}).find((s) => s.itemHrid === itemHrid);
+    const cost = shopItem?.costs?.[0];
+    if (!cost || cost.itemHrid === '/items/coin') return null;
+    return { tokenItemHrid: cost.itemHrid, tokenCost: cost.count };
+}
+
+/**
+ * Opportunity-equivalent value of a token-purchased item's base acquisition: best foregone
+ * alternative use of the same tokens, times the item's own token cost.
+ * @param {string} itemHrid
+ * @returns {{cost: number|null, complete: boolean}}
+ */
+function calculateTokenOpportunityValue(itemHrid) {
+    const purchaseInfo = getTokenPurchaseInfo(itemHrid);
+    const alternatives = TOKEN_SHOP_ALTERNATIVES[itemHrid];
+    if (!purchaseInfo || !alternatives) return { cost: null, complete: false };
+
+    let bestValuePerToken = 0;
+    for (const alt of alternatives) {
+        const ask = getItemPrice(alt.hrid, { mode: 'ask' });
+        if (ask > 0) {
+            const perToken = ask / alt.cost;
+            if (perToken > bestValuePerToken) bestValuePerToken = perToken;
+        }
+    }
+    if (!(bestValuePerToken > 0)) return { cost: null, complete: false };
+    return { cost: bestValuePerToken * purchaseInfo.tokenCost, complete: true };
+}
+
+/**
+ * Cheapest defensible base (+0) acquisition cost: direct comparison across every proven source,
+ * never an inflated-Ask heuristic (TLA-041 base-item resolver rule: "If Ask=2.5B and a complete
+ * reproduction path is 650M, use 650M").
+ * @param {string} itemHrid
+ * @returns {{cost: number|null, complete: boolean}}
+ */
+function resolveBaseItemCost(itemHrid) {
+    const candidates = [];
+
+    const tokenValue = calculateTokenOpportunityValue(itemHrid);
+    if (tokenValue.complete) candidates.push(tokenValue.cost);
+
+    const ask = getItemPrice(itemHrid, { mode: 'ask' });
+    if (ask > 0) candidates.push(ask);
+
+    const shopCost = getShopCoinCost(itemHrid);
+    if (shopCost > 0) candidates.push(shopCost);
+
+    const craftCost = getProductionCost(itemHrid, 'ask');
+    if (craftCost > 0) candidates.push(craftCost);
+
+    if (candidates.length === 0) return { cost: null, complete: false };
+    return { cost: Math.min(...candidates), complete: true };
+}
+
+/**
+ * Candidate (b): base acquisition + viewer-relative 0->N reconstruction.
+ *
+ * For ordinary tradeable items, prefers the shared Mirror-aware `calculateEnhancementPath` (its
+ * own base-price heuristic is existing, shared, Net-Worth-tested logic - left untouched) but also
+ * compares against our own min-based base cost + a direct (non-mirror) 0->N path, taking whichever
+ * is cheaper.
+ *
+ * For token items, `calculateEnhancementPath`'s internal base pricing has no concept of token
+ * opportunity value and would price the base leg near zero - using it would silently reintroduce
+ * the F-09 bug. Token items therefore use ONLY the direct (non-mirror) path on top of the correct
+ * token-opportunity base value.
+ * @returns {{cost: number|null, complete: boolean}}
+ */
+function resolveBaseReconstructionCost(itemHrid, targetLevel, enhancingParams, isTokenItem) {
+    const candidates = [];
+
+    if (!isTokenItem) {
+        try {
+            const path = calculateEnhancementPath(itemHrid, targetLevel, enhancingParams);
+            if (path?.optimalStrategy?.totalCost > 0) candidates.push(path.optimalStrategy.totalCost);
+        } catch {
+            // Not enhanceable via the shared path helper - fall through to the direct route below.
+        }
+    }
+
+    const base = resolveBaseItemCost(itemHrid);
+    if (base.complete) {
+        const direct = calculateDirectEnhancementCost(itemHrid, 0, targetLevel, enhancingParams);
+        if (direct.complete) candidates.push(base.cost + direct.cost);
+    }
+
+    if (candidates.length === 0) return { cost: null, complete: false };
+    return { cost: Math.min(...candidates), complete: true };
+}
+
+/**
+ * Resolve the cheapest complete reproduction cost for a viewed equipped item at enhancement +N.
+ * @param {string} itemHrid
+ * @param {number} N - Enhancement level (0-20)
+ * @param {Object} itemDetails - gameData.itemDetailMap[itemHrid]
+ * @param {Object} enhancingParams - Viewer's own params from getEnhancingParams()
+ * @returns {{cost: number|null, complete: boolean}}
+ */
+export function resolveEquipmentItemCost(itemHrid, N, itemDetails, enhancingParams) {
+    if (N === 0) {
+        return resolveBaseItemCost(itemHrid);
+    }
+
+    const isTokenItem = getTokenPurchaseInfo(itemHrid) !== null;
+    const candidates = [];
+
+    const exactAsk = getItemPrice(itemHrid, { enhancementLevel: N, mode: 'ask' });
+    if (exactAsk > 0) candidates.push(exactAsk);
+
+    const reconstruction = resolveBaseReconstructionCost(itemHrid, N, enhancingParams, isTokenItem);
+    if (reconstruction.complete) candidates.push(reconstruction.cost);
+
+    if (itemDetails?.enhancementCosts?.length) {
+        for (let K = 1; K < N; K++) {
+            const kAsk = getItemPrice(itemHrid, { enhancementLevel: K, mode: 'ask' });
+            if (!(kAsk > 0)) continue;
+            const direct = calculateDirectEnhancementCost(itemHrid, K, N, enhancingParams);
+            if (direct.complete) candidates.push(kAsk + direct.cost);
+        }
+    }
+
+    if (candidates.length === 0) return { cost: null, complete: false };
+    return { cost: Math.min(...candidates), complete: true };
+}

--- a/src/features/profile/score/equipment-resolver.test.js
+++ b/src/features/profile/score/equipment-resolver.test.js
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    shopItemDetailMap: {},
+    askPrices: {}, // key: `${itemHrid}|${enhancementLevel ?? 0}` -> ask price
+    shopCoinCost: 0,
+    productionCost: 0,
+    enhancementPathResult: null,
+    directEnhancementResults: {}, // key: `${startLevel}->${targetLevel}` -> {cost, complete}
+}));
+
+vi.mock('../../../core/data-manager.js', () => ({
+    default: {
+        getInitClientData: vi.fn(() => ({ shopItemDetailMap: mocks.shopItemDetailMap })),
+    },
+}));
+
+vi.mock('../../../utils/market-data.js', () => ({
+    getItemPrice: vi.fn((itemHrid, opts = {}) => {
+        const level = opts.enhancementLevel ?? 0;
+        return mocks.askPrices[`${itemHrid}|${level}`] ?? -1;
+    }),
+}));
+
+vi.mock('../../../utils/game-lookups.js', () => ({
+    getShopCoinCost: vi.fn(() => mocks.shopCoinCost),
+}));
+
+vi.mock('../../enhancement/tooltip-enhancement.js', () => ({
+    getProductionCost: vi.fn(() => mocks.productionCost),
+    calculateEnhancementPath: vi.fn(() => mocks.enhancementPathResult),
+    calculateDirectEnhancementCost: vi.fn((itemHrid, startLevel, targetLevel) => {
+        const result = mocks.directEnhancementResults[`${startLevel}->${targetLevel}`];
+        return result ?? { cost: null, complete: false, protectFrom: null };
+    }),
+}));
+
+import { resolveEquipmentItemCost } from './equipment-resolver.js';
+
+const ITEM = '/items/cheese_sword';
+const itemDetails = { enhancementCosts: [{ itemHrid: '/items/mat', count: 1 }] };
+
+function resetMocks() {
+    mocks.shopItemDetailMap = {};
+    mocks.askPrices = {};
+    mocks.shopCoinCost = 0;
+    mocks.productionCost = 0;
+    mocks.enhancementPathResult = null;
+    mocks.directEnhancementResults = {};
+}
+
+describe('resolveEquipmentItemCost - N=0 degeneration', () => {
+    beforeEach(resetMocks);
+
+    test('at +0, only the base-item acquisition leg applies (no enhancement candidates)', () => {
+        mocks.askPrices[`${ITEM}|0`] = 5_000_000;
+        const result = resolveEquipmentItemCost(ITEM, 0, itemDetails, {});
+        expect(result).toEqual({ cost: 5_000_000, complete: true });
+    });
+
+    test('+0 with no priceable source anywhere is incomplete, not zero', () => {
+        const result = resolveEquipmentItemCost(ITEM, 0, itemDetails, {});
+        expect(result).toEqual({ cost: null, complete: false });
+    });
+});
+
+describe('resolveEquipmentItemCost - F-01: exact finished item wins', () => {
+    beforeEach(resetMocks);
+
+    test('exact Ask 400M beats base reconstruction 650M and lower+17 path 510M', () => {
+        mocks.askPrices[`${ITEM}|20`] = 400_000_000;
+        mocks.enhancementPathResult = { optimalStrategy: { totalCost: 650_000_000 } };
+        mocks.askPrices[`${ITEM}|17`] = 150_000_000;
+        mocks.directEnhancementResults['17->20'] = { cost: 360_000_000, complete: true }; // 150M+360M=510M
+
+        const result = resolveEquipmentItemCost(ITEM, 20, itemDetails, {});
+        expect(result).toEqual({ cost: 400_000_000, complete: true });
+    });
+});
+
+describe('resolveEquipmentItemCost - F-02: lower enhancement wins when exact target absent', () => {
+    beforeEach(resetMocks);
+
+    test('missing +20 Ask -> Ask(+17) 150M + direct 17->20 260M = 410M beats base reconstruction 700M', () => {
+        mocks.askPrices[`${ITEM}|17`] = 150_000_000;
+        mocks.directEnhancementResults['17->20'] = { cost: 260_000_000, complete: true };
+        mocks.enhancementPathResult = { optimalStrategy: { totalCost: 700_000_000 } };
+
+        const result = resolveEquipmentItemCost(ITEM, 20, itemDetails, {});
+        expect(result).toEqual({ cost: 410_000_000, complete: true });
+    });
+});
+
+describe('resolveEquipmentItemCost - F-03: inflated exact target loses, no heuristic needed', () => {
+    beforeEach(resetMocks);
+
+    test('exact Ask 2.5B loses to Ask(+17)+direct(17->20)=610M by plain minimum-selection', () => {
+        mocks.askPrices[`${ITEM}|20`] = 2_500_000_000;
+        mocks.askPrices[`${ITEM}|17`] = 350_000_000;
+        mocks.directEnhancementResults['17->20'] = { cost: 260_000_000, complete: true };
+
+        const result = resolveEquipmentItemCost(ITEM, 20, itemDetails, {});
+        expect(result).toEqual({ cost: 610_000_000, complete: true });
+    });
+});
+
+describe('resolveEquipmentItemCost - F-05: missing one candidate is not global failure', () => {
+    beforeEach(resetMocks);
+
+    test('+20 and +17 Ask both missing, but base reconstruction completes at 720M', () => {
+        mocks.enhancementPathResult = { optimalStrategy: { totalCost: 720_000_000 } };
+
+        const result = resolveEquipmentItemCost(ITEM, 20, itemDetails, {});
+        expect(result).toEqual({ cost: 720_000_000, complete: true });
+    });
+});
+
+describe('resolveEquipmentItemCost - F-06: no complete path -> partial, never zero/base-only', () => {
+    beforeEach(resetMocks);
+
+    test('no exact ask, no lower ask, and no complete base reconstruction -> incomplete', () => {
+        mocks.enhancementPathResult = null; // shared path helper found nothing enhanceable/priceable
+        // resolveBaseItemCost also has nothing: no ask, no shop cost, no production cost, not a token item
+        const result = resolveEquipmentItemCost(ITEM, 20, itemDetails, {});
+        expect(result).toEqual({ cost: null, complete: false });
+    });
+
+    test('a live lower-K Ask with an unpriceable direct enhancement is excluded, not zero-substituted', () => {
+        mocks.askPrices[`${ITEM}|17`] = 150_000_000;
+        mocks.directEnhancementResults['17->20'] = { cost: null, complete: false, protectFrom: null };
+        const result = resolveEquipmentItemCost(ITEM, 20, itemDetails, {});
+        expect(result).toEqual({ cost: null, complete: false });
+    });
+});
+
+describe('resolveEquipmentItemCost - F-09: token equipment must include enhancement value', () => {
+    const TOKEN_ITEM = '/items/chimerical_quiver';
+    const tokenItemDetails = { enhancementCosts: [{ itemHrid: '/items/mat', count: 1 }] };
+
+    beforeEach(() => {
+        resetMocks();
+        mocks.shopItemDetailMap['/shop_items/chimerical_quiver'] = {
+            itemHrid: TOKEN_ITEM,
+            costs: [{ itemHrid: '/items/chimerical_token', count: 35000 }],
+        };
+        // Best token-shop alternative resolves to 100M / 35000 tokens = ~2857.14 coins/token opportunity value...
+        // instead pin it directly: griffin_leather ask such that bestValuePerToken * 35000 == 100,000,000
+        mocks.askPrices['/items/griffin_leather|0'] = (100_000_000 / 35000) * 600; // valuePerToken * shop cost 600
+    });
+
+    test('+0 token item prices at the token opportunity value alone', () => {
+        const result = resolveEquipmentItemCost(TOKEN_ITEM, 0, tokenItemDetails, {});
+        expect(result.complete).toBe(true);
+        expect(result.cost).toBeCloseTo(100_000_000, -2);
+    });
+
+    test('+20 token item = token opportunity value (100M) + direct 0->20 enhancement (300M) = 400M, never collapsing to 100M', () => {
+        mocks.directEnhancementResults['0->20'] = { cost: 300_000_000, complete: true };
+        // calculateEnhancementPath must be ignored for token items (it has no concept of token value)
+        mocks.enhancementPathResult = { optimalStrategy: { totalCost: 5_000_000 } };
+
+        const result = resolveEquipmentItemCost(TOKEN_ITEM, 20, tokenItemDetails, {});
+        expect(result.complete).toBe(true);
+        expect(result.cost).toBeCloseTo(400_000_000, -2);
+    });
+});

--- a/src/features/profile/score/equipment-score.js
+++ b/src/features/profile/score/equipment-score.js
@@ -1,0 +1,66 @@
+/**
+ * Equipment Score - value-once-fan-out orchestrator (TLA-041 / PB-19, PB-20)
+ *
+ * Prices each unique equipped `(itemHrid, enhancementLevel)` pair exactly once, classifies it
+ * once, then attributes that single computed cost into the Combat and/or Skiller category
+ * depending on its classification (an item classified into both domains contributes its one
+ * computed cost to both totals - intentional, not a bug to dedupe away).
+ */
+
+import dataManager from '../../../core/data-manager.js';
+import { classifyEquipmentItem } from './equipment-classifier.js';
+import { resolveEquipmentItemCost } from './equipment-resolver.js';
+import { emptyCategory, attribute } from './score-result.js';
+
+/**
+ * @param {Object} profileData - Profile data from game
+ * @param {Object} enhancingParams - Viewer's own params from getEnhancingParams()
+ * @returns {{combat: Object, skiller: Object, hasEquipmentData: boolean}}
+ */
+export function calculateEquipmentScore(profileData, enhancingParams) {
+    const equippedItems = profileData.profile?.wearableItemMap || {};
+    const hideEquipment = profileData.profile?.hideWearableItems || false;
+    const hasEquipmentData = Object.keys(equippedItems).length > 0;
+
+    if (hideEquipment && !hasEquipmentData) {
+        // Hidden with no actual payload: a genuine lower bound, not a deceptively exact 0 (PB-48).
+        const combat = emptyCategory();
+        const skiller = emptyCategory();
+        combat.complete = false;
+        skiller.complete = false;
+        return { combat, skiller, hasEquipmentData: false };
+    }
+
+    const gameData = dataManager.getInitClientData();
+    const itemDetailMap = gameData?.itemDetailMap || {};
+
+    const priced = new Map(); // key: `${itemHrid}|${enhancementLevel}` -> priced leaf + classification
+
+    for (const itemData of Object.values(equippedItems)) {
+        if (!itemData?.itemHrid) continue;
+
+        const enhancementLevel = itemData.enhancementLevel || 0;
+        const key = `${itemData.itemHrid}|${enhancementLevel}`;
+        if (priced.has(key)) continue; // value once (PB-20)
+
+        const itemDetails = itemDetailMap[itemData.itemHrid];
+        if (!itemDetails) continue;
+
+        const resolved = resolveEquipmentItemCost(itemData.itemHrid, enhancementLevel, itemDetails, enhancingParams);
+        const classification = classifyEquipmentItem(itemDetails.equipmentDetail);
+
+        const itemName = itemDetails.name || itemData.itemHrid.replace('/items/', '');
+        const displayName = enhancementLevel > 0 ? `${itemName} +${enhancementLevel}` : itemName;
+
+        priced.set(key, { ...resolved, name: displayName, classification });
+    }
+
+    const combat = emptyCategory();
+    const skiller = emptyCategory();
+    for (const leaf of priced.values()) {
+        if (leaf.classification.combat) attribute(combat, leaf);
+        if (leaf.classification.skiller) attribute(skiller, leaf);
+    }
+
+    return { combat, skiller, hasEquipmentData };
+}

--- a/src/features/profile/score/equipment-score.test.js
+++ b/src/features/profile/score/equipment-score.test.js
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    itemDetailMap: {},
+    resolveEquipmentItemCost: vi.fn(),
+    classifyEquipmentItem: vi.fn(),
+}));
+
+vi.mock('../../../core/data-manager.js', () => ({
+    default: { getInitClientData: vi.fn(() => ({ itemDetailMap: mocks.itemDetailMap })) },
+}));
+
+vi.mock('./equipment-resolver.js', () => ({ resolveEquipmentItemCost: mocks.resolveEquipmentItemCost }));
+vi.mock('./equipment-classifier.js', () => ({ classifyEquipmentItem: mocks.classifyEquipmentItem }));
+
+import { calculateEquipmentScore } from './equipment-score.js';
+
+const resolveEquipmentItemCost = mocks.resolveEquipmentItemCost;
+const classifyEquipmentItem = mocks.classifyEquipmentItem;
+
+function resetMocks() {
+    mocks.itemDetailMap = {};
+    resolveEquipmentItemCost.mockReset();
+    classifyEquipmentItem.mockReset();
+}
+
+describe('calculateEquipmentScore - value-once-fan-out (TLA-041 / PB-19, PB-20)', () => {
+    beforeEach(resetMocks);
+
+    test('same itemHrid+level equipped in two slots, classified both combat+skiller, is priced exactly once and contributes to both totals', () => {
+        mocks.itemDetailMap['/items/ring'] = { name: 'Ring', equipmentDetail: {} };
+        resolveEquipmentItemCost.mockReturnValue({ cost: 10_000_000, complete: true });
+        classifyEquipmentItem.mockReturnValue({ combat: true, skiller: true });
+
+        const profileData = {
+            profile: {
+                wearableItemMap: {
+                    '/item_locations/ring1': { itemHrid: '/items/ring', enhancementLevel: 3 },
+                    '/item_locations/ring2': { itemHrid: '/items/ring', enhancementLevel: 3 },
+                },
+            },
+        };
+
+        const result = calculateEquipmentScore(profileData, {});
+
+        expect(resolveEquipmentItemCost).toHaveBeenCalledTimes(1); // priced once, not twice
+        expect(result.combat.score).toBeCloseTo(10);
+        expect(result.skiller.score).toBeCloseTo(10); // same computed cost fans into both (PB-19)
+    });
+
+    test('combat-only and skiller-only items each contribute to only their own domain', () => {
+        mocks.itemDetailMap['/items/sword'] = { name: 'Sword', equipmentDetail: {} };
+        mocks.itemDetailMap['/items/hoe'] = { name: 'Hoe', equipmentDetail: {} };
+        resolveEquipmentItemCost.mockImplementation((itemHrid) =>
+            itemHrid === '/items/sword' ? { cost: 5_000_000, complete: true } : { cost: 2_000_000, complete: true }
+        );
+        classifyEquipmentItem.mockImplementation((equipmentDetail) =>
+            equipmentDetail === mocks.itemDetailMap['/items/sword'].equipmentDetail
+                ? { combat: true, skiller: false }
+                : { combat: false, skiller: true }
+        );
+
+        const profileData = {
+            profile: {
+                wearableItemMap: {
+                    '/item_locations/main_hand': { itemHrid: '/items/sword', enhancementLevel: 0 },
+                    '/item_locations/tool': { itemHrid: '/items/hoe', enhancementLevel: 0 },
+                },
+            },
+        };
+
+        const result = calculateEquipmentScore(profileData, {});
+        expect(result.combat.score).toBeCloseTo(5);
+        expect(result.skiller.score).toBeCloseTo(2);
+    });
+
+    test('two different itemHrids are each priced once (dedup key is itemHrid+level, not just level)', () => {
+        mocks.itemDetailMap['/items/a'] = { name: 'A', equipmentDetail: {} };
+        mocks.itemDetailMap['/items/b'] = { name: 'B', equipmentDetail: {} };
+        resolveEquipmentItemCost.mockReturnValue({ cost: 1_000_000, complete: true });
+        classifyEquipmentItem.mockReturnValue({ combat: true, skiller: false });
+
+        const profileData = {
+            profile: {
+                wearableItemMap: {
+                    slotA: { itemHrid: '/items/a', enhancementLevel: 0 },
+                    slotB: { itemHrid: '/items/b', enhancementLevel: 0 },
+                },
+            },
+        };
+
+        calculateEquipmentScore(profileData, {});
+        expect(resolveEquipmentItemCost).toHaveBeenCalledTimes(2);
+    });
+
+    test('an incomplete leaf marks its category incomplete without discarding priced leaves', () => {
+        mocks.itemDetailMap['/items/priced'] = { name: 'Priced', equipmentDetail: {} };
+        mocks.itemDetailMap['/items/unpriced'] = { name: 'Unpriced', equipmentDetail: {} };
+        resolveEquipmentItemCost.mockImplementation((itemHrid) =>
+            itemHrid === '/items/priced' ? { cost: 3_000_000, complete: true } : { cost: null, complete: false }
+        );
+        classifyEquipmentItem.mockReturnValue({ combat: true, skiller: false });
+
+        const profileData = {
+            profile: {
+                wearableItemMap: {
+                    slotA: { itemHrid: '/items/priced', enhancementLevel: 0 },
+                    slotB: { itemHrid: '/items/unpriced', enhancementLevel: 0 },
+                },
+            },
+        };
+
+        const result = calculateEquipmentScore(profileData, {});
+        expect(result.combat.complete).toBe(false);
+        expect(result.combat.score).toBeCloseTo(3);
+    });
+});
+
+describe('calculateEquipmentScore - hidden equipment (PB-48, PB-49)', () => {
+    beforeEach(resetMocks);
+
+    test('hidden with no wearable payload yields a lower-bound result, not a deceptively exact 0', () => {
+        const profileData = { profile: { hideWearableItems: true, wearableItemMap: {} } };
+        const result = calculateEquipmentScore(profileData, {});
+        expect(result.hasEquipmentData).toBe(false);
+        expect(result.combat.complete).toBe(false);
+        expect(result.skiller.complete).toBe(false);
+        expect(result.combat.score).toBe(0);
+    });
+
+    test('hidden flag does not force partial when the payload actually contains wearable data (party member case)', () => {
+        mocks.itemDetailMap['/items/ring'] = { name: 'Ring', equipmentDetail: {} };
+        resolveEquipmentItemCost.mockReturnValue({ cost: 1_000_000, complete: true });
+        classifyEquipmentItem.mockReturnValue({ combat: true, skiller: false });
+
+        const profileData = {
+            profile: {
+                hideWearableItems: true,
+                wearableItemMap: { slot: { itemHrid: '/items/ring', enhancementLevel: 0 } },
+            },
+        };
+
+        const result = calculateEquipmentScore(profileData, {});
+        expect(result.hasEquipmentData).toBe(true);
+        expect(result.combat.complete).toBe(true);
+        expect(result.combat.score).toBeCloseTo(1);
+    });
+});

--- a/src/features/profile/score/house-score.js
+++ b/src/features/profile/score/house-score.js
@@ -1,0 +1,33 @@
+/**
+ * House Score (TLA-041)
+ *
+ * Combat/Skiller House investment, derived from `usableInActionTypeMap` (PB-08) rather than a
+ * hardcoded room-name list, priced with pure Ask (F-10).
+ */
+
+import { calculateHousesCostByDomain } from '../../../utils/house-cost-calculator.js';
+import { emptyCategory, attribute } from './score-result.js';
+
+/**
+ * @param {Object} profileData - Profile data from game
+ * @returns {{combat: Object, skiller: Object}}
+ */
+export function calculateHouseScore(profileData) {
+    const characterHouseRooms = profileData.profile?.characterHouseRoomMap || {};
+
+    const combat = emptyCategory();
+    const skiller = emptyCategory();
+
+    for (const [domain, category] of [
+        ['combat', combat],
+        ['skilling', skiller],
+    ]) {
+        const { complete, breakdown } = calculateHousesCostByDomain(characterHouseRooms, domain);
+        for (const house of breakdown) {
+            attribute(category, { name: `${house.name} ${house.level}`, cost: house.cost, complete: true });
+        }
+        category.complete = complete;
+    }
+
+    return { combat, skiller };
+}

--- a/src/features/profile/score/house-score.test.js
+++ b/src/features/profile/score/house-score.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, test, vi } from 'vitest';
+
+const { calculateHousesCostByDomain } = vi.hoisted(() => ({ calculateHousesCostByDomain: vi.fn() }));
+vi.mock('../../../utils/house-cost-calculator.js', () => ({ calculateHousesCostByDomain }));
+
+import { calculateHouseScore } from './house-score.js';
+
+describe('calculateHouseScore (TLA-041)', () => {
+    test('sums combat and skilling domains independently into separate categories', () => {
+        calculateHousesCostByDomain.mockImplementation((rooms, domain) =>
+            domain === 'combat'
+                ? { totalCost: 5_000_000, complete: true, breakdown: [{ name: 'Dojo', level: 3, cost: 5_000_000 }] }
+                : { totalCost: 2_000_000, complete: true, breakdown: [{ name: 'Garden', level: 1, cost: 2_000_000 }] }
+        );
+
+        const result = calculateHouseScore({ profile: { characterHouseRoomMap: {} } });
+
+        expect(result.combat.score).toBeCloseTo(5);
+        expect(result.combat.breakdown).toEqual([{ name: 'Dojo 3', value: '5.0' }]);
+        expect(result.skiller.score).toBeCloseTo(2);
+        expect(result.skiller.breakdown).toEqual([{ name: 'Garden 1', value: '2.0' }]);
+    });
+
+    test('an incomplete domain propagates incompleteness to the category', () => {
+        calculateHousesCostByDomain.mockReturnValue({ totalCost: 0, complete: false, breakdown: [] });
+
+        const result = calculateHouseScore({ profile: { characterHouseRoomMap: {} } });
+        expect(result.combat.complete).toBe(false);
+        expect(result.skiller.complete).toBe(false);
+    });
+
+    test('missing profile data does not throw', () => {
+        calculateHousesCostByDomain.mockReturnValue({ totalCost: 0, complete: true, breakdown: [] });
+        expect(() => calculateHouseScore({})).not.toThrow();
+    });
+});

--- a/src/features/profile/score/score-result.js
+++ b/src/features/profile/score/score-result.js
@@ -1,0 +1,59 @@
+/**
+ * Score Result Plumbing
+ *
+ * Shared {score, complete, unpricedCount, breakdown} shape used by every TLA-041 Score
+ * category (Houses/Abilities/Equipment/Shrines) and by the Combat/Skiller top-level totals.
+ * `complete: false` means at least one contributing leaf could not be priced — the category's
+ * `score` is then a lower bound, never a substituted zero.
+ */
+
+/**
+ * @returns {{score: number, complete: boolean, unpricedCount: number, breakdown: Array<{name: string, value: string}>}}
+ */
+export function emptyCategory() {
+    return { score: 0, complete: true, unpricedCount: 0, breakdown: [] };
+}
+
+/**
+ * Add one priced leaf into a category, in place.
+ * @param {{score: number, complete: boolean, unpricedCount: number, breakdown: Array}} category
+ * @param {{name: string, cost: number|null, complete: boolean}} leaf - cost is in raw coins
+ */
+export function attribute(category, leaf) {
+    if (!leaf.complete || !(leaf.cost > 0)) {
+        category.complete = category.complete && leaf.complete;
+        if (!leaf.complete) category.unpricedCount += 1;
+        if (!(leaf.cost > 0)) return;
+    }
+
+    const scoreValue = leaf.cost / 1_000_000;
+    category.score += scoreValue;
+    category.breakdown.push({ name: leaf.name, value: scoreValue.toFixed(1) });
+}
+
+/**
+ * Combine several category results (e.g. Houses + Abilities + Equipment + Shrines into a
+ * top-level Combat/Skiller total).
+ * @param {Array<{score: number, complete: boolean, unpricedCount: number, breakdown: Array}>} parts
+ */
+export function mergeCategory(parts) {
+    const merged = emptyCategory();
+    for (const part of parts) {
+        merged.score += part.score;
+        merged.complete = merged.complete && part.complete;
+        merged.unpricedCount += part.unpricedCount;
+        merged.breakdown.push(...part.breakdown);
+    }
+    merged.breakdown.sort((a, b) => parseFloat(b.value) - parseFloat(a.value));
+    return merged;
+}
+
+/**
+ * Format a Score-point number for display, with a "+" lower-bound suffix when incomplete.
+ * @param {number} score
+ * @param {boolean} complete
+ * @returns {string}
+ */
+export function formatScoreValue(score, complete) {
+    return `${score.toFixed(1)}${complete ? '' : '+'}`;
+}

--- a/src/features/profile/score/shrine-score.js
+++ b/src/features/profile/score/shrine-score.js
@@ -1,0 +1,107 @@
+/**
+ * Guild Shrine / Credit / Token Valuation (TLA-041)
+ *
+ * Prices the viewed character's personally purchased Shrine buff levels
+ * (`profile.profile.guildBuffLevelMap`), splitting Combat/Skiller via `guildBuffDetail.isCombat`.
+ * Guild Credits are priced via the cheapest Ask-side tradeable conversion, excluding Guild Token
+ * itself as a source item to avoid a circular value (real risk: `/items/guild_token` carries its
+ * own `guildCreditConversions`). Guild Token's own coin-equivalent value is the MAXIMUM foregone
+ * native Token->Credit alternative (F-12), not the minimum.
+ */
+
+import dataManager from '../../../core/data-manager.js';
+import { buildCheapestPerCredit } from '../../../utils/guild-credit-conversion.js';
+import { buildGuildBuffDisplayName } from '../../networth/networth-calculator.js';
+import { emptyCategory, attribute } from './score-result.js';
+
+const GUILD_TOKEN_HRID = '/items/guild_token';
+
+/**
+ * @param {Object} itemDetailMap
+ * @param {Object} creditValueTable - creditItemHrid -> coin value per credit
+ * @returns {number} coin value per Guild Token (0 if unresolved)
+ */
+function calculateGuildTokenOpportunityValue(itemDetailMap, creditValueTable) {
+    const tokenItem = itemDetailMap[GUILD_TOKEN_HRID];
+    let best = 0;
+    for (const conv of tokenItem?.guildCreditConversions || []) {
+        const creditValue = creditValueTable[conv.creditItemHrid];
+        if (!(creditValue > 0)) continue;
+        const perToken = (conv.creditCount / conv.itemCount) * creditValue;
+        if (perToken > best) best = perToken;
+    }
+    return best;
+}
+
+/**
+ * Sum a buff's `levelCosts[1..level]` using the resolved credit/token coin values.
+ * @returns {{cost: number, complete: boolean, tokenCount: number}}
+ */
+function sumLevelCosts(buff, level, creditValueTable, tokenValue) {
+    let cost = 0;
+    let complete = true;
+    let tokenCount = 0;
+
+    for (let lvl = 1; lvl <= level; lvl++) {
+        const levelCost = buff.levelCosts?.[String(lvl)];
+        if (!levelCost) {
+            complete = false;
+            continue;
+        }
+
+        for (const { itemHrid, count } of levelCost.creditCosts || []) {
+            const perCredit = creditValueTable[itemHrid];
+            if (!(perCredit > 0)) {
+                complete = false;
+                continue;
+            }
+            cost += perCredit * count;
+        }
+
+        if (levelCost.guildTokenCost > 0) {
+            tokenCount += levelCost.guildTokenCost; // natural units, preserved regardless of pricing (PB-44)
+            if (!(tokenValue > 0)) {
+                complete = false;
+            } else {
+                cost += tokenValue * levelCost.guildTokenCost;
+            }
+        }
+    }
+
+    return { cost, complete, tokenCount };
+}
+
+/**
+ * @param {Object} profileData - Profile data from game (of the VIEWED character)
+ * @returns {{combat: Object, skiller: Object}}
+ */
+export function calculateShrineScore(profileData) {
+    const gameData = dataManager.getInitClientData();
+    const guildBuffDetailMap = gameData?.guildBuffDetailMap || {};
+    const itemDetailMap = gameData?.itemDetailMap || {};
+    const guildBuffLevelMap = profileData.profile?.guildBuffLevelMap || {};
+
+    const { sell: creditValueTable } = buildCheapestPerCredit(itemDetailMap, [GUILD_TOKEN_HRID]);
+    const tokenValue = calculateGuildTokenOpportunityValue(itemDetailMap, creditValueTable);
+
+    const combat = emptyCategory();
+    const skiller = emptyCategory();
+
+    for (const [buffHrid, buff] of Object.entries(guildBuffDetailMap)) {
+        const level = guildBuffLevelMap[buffHrid] || 0;
+        if (level === 0) continue;
+
+        const { cost, complete, tokenCount } = sumLevelCosts(buff, level, creditValueTable, tokenValue);
+        const category = buff.isCombat ? combat : skiller;
+        // Natural Guild Token count is preserved in the breakdown label even though the numeric
+        // Score uses the coin-equivalent opportunity value (PB-44).
+        const tokenSuffix = tokenCount > 0 ? ` (${tokenCount.toLocaleString()} tokens)` : '';
+        attribute(category, {
+            name: `${buildGuildBuffDisplayName(buffHrid, buff)} ${level}${tokenSuffix}`,
+            cost,
+            complete,
+        });
+    }
+
+    return { combat, skiller };
+}

--- a/src/features/profile/score/shrine-score.test.js
+++ b/src/features/profile/score/shrine-score.test.js
@@ -1,0 +1,163 @@
+import { describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    itemDetailMap: {},
+    guildBuffDetailMap: {},
+    buildCheapestPerCredit: vi.fn(),
+}));
+
+vi.mock('../../../core/data-manager.js', () => ({
+    default: {
+        getInitClientData: vi.fn(() => ({
+            itemDetailMap: mocks.itemDetailMap,
+            guildBuffDetailMap: mocks.guildBuffDetailMap,
+        })),
+    },
+}));
+
+vi.mock('../../../utils/guild-credit-conversion.js', () => ({ buildCheapestPerCredit: mocks.buildCheapestPerCredit }));
+
+vi.mock('../../networth/networth-calculator.js', () => ({
+    buildGuildBuffDisplayName: (hrid, buff) => `Shrine (${buff.isCombat ? 'Combat' : 'Skilling'})`,
+}));
+
+import { calculateShrineScore } from './shrine-score.js';
+
+const buildCheapestPerCredit = mocks.buildCheapestPerCredit;
+
+const GUILD_TOKEN = '/items/guild_token';
+
+describe('calculateShrineScore - F-12: Guild Token opportunity value uses MAXIMUM foregone alternative', () => {
+    test('gold-credit path wins (1,166.67 coins/token) over cheaper-looking paths, proving max not min', () => {
+        mocks.itemDetailMap = {
+            [GUILD_TOKEN]: {
+                guildCreditConversions: [
+                    { creditItemHrid: '/items/brown_guild_credit', itemCount: 1, creditCount: 10 },
+                    { creditItemHrid: '/items/purple_guild_credit', itemCount: 1, creditCount: 1 },
+                    { creditItemHrid: '/items/silver_guild_credit', itemCount: 10, creditCount: 1 },
+                    { creditItemHrid: '/items/gold_guild_credit', itemCount: 60, creditCount: 1 },
+                ],
+            },
+        };
+        mocks.guildBuffDetailMap = {
+            '/guild_buffs/force_combat': {
+                isCombat: true,
+                levelCosts: { 1: { guildTokenCost: 60, creditCosts: [] } },
+            },
+        };
+        buildCheapestPerCredit.mockReturnValue({
+            sell: {
+                '/items/brown_guild_credit': 100,
+                '/items/purple_guild_credit': 900,
+                '/items/silver_guild_credit': 8000,
+                '/items/gold_guild_credit': 70000,
+            },
+        });
+
+        const result = calculateShrineScore({ profile: { guildBuffLevelMap: { '/guild_buffs/force_combat': 1 } } });
+
+        // Alternatives: brown 1000, purple 900, silver 800/token, gold 1166.67/token -> max wins.
+        // levelCosts[1].guildTokenCost = 60 -> cost = 60 * 1166.67 = 70,000.02
+        expect(result.combat.score).toBeCloseTo(70000.02 / 1_000_000, 3);
+    });
+
+    test('excludes Guild Token itself when building the credit value table (regression against circularity)', () => {
+        buildCheapestPerCredit.mockClear();
+        mocks.itemDetailMap = { [GUILD_TOKEN]: { guildCreditConversions: [] } };
+        mocks.guildBuffDetailMap = {};
+        calculateShrineScore({ profile: { guildBuffLevelMap: {} } });
+
+        expect(buildCheapestPerCredit).toHaveBeenCalledWith(mocks.itemDetailMap, [GUILD_TOKEN]);
+    });
+
+    test('PB-44: the natural Guild Token count is preserved in the breakdown label alongside the coin-equivalent Score', () => {
+        mocks.itemDetailMap = {
+            [GUILD_TOKEN]: {
+                guildCreditConversions: [{ creditItemHrid: '/items/gold_guild_credit', itemCount: 60, creditCount: 1 }],
+            },
+        };
+        mocks.guildBuffDetailMap = {
+            '/guild_buffs/force_combat': {
+                isCombat: true,
+                levelCosts: { 1: { guildTokenCost: 400, creditCosts: [] } },
+            },
+        };
+        buildCheapestPerCredit.mockReturnValue({ sell: { '/items/gold_guild_credit': 70000 } });
+
+        const result = calculateShrineScore({ profile: { guildBuffLevelMap: { '/guild_buffs/force_combat': 1 } } });
+
+        expect(result.combat.breakdown[0].name).toContain('400 tokens');
+    });
+});
+
+describe('calculateShrineScore - level cost summing and completeness', () => {
+    test('sums levelCosts[1..viewedLevel], splitting Combat/Skiller via isCombat', () => {
+        mocks.itemDetailMap = { [GUILD_TOKEN]: { guildCreditConversions: [] } };
+        mocks.guildBuffDetailMap = {
+            '/guild_buffs/force_combat': {
+                isCombat: true,
+                levelCosts: {
+                    1: { guildTokenCost: 0, creditCosts: [{ itemHrid: '/items/brown_guild_credit', count: 100 }] },
+                    2: { guildTokenCost: 0, creditCosts: [{ itemHrid: '/items/brown_guild_credit', count: 200 }] },
+                },
+            },
+            '/guild_buffs/wisdom_skilling': {
+                isCombat: false,
+                levelCosts: {
+                    1: { guildTokenCost: 0, creditCosts: [{ itemHrid: '/items/brown_guild_credit', count: 50 }] },
+                },
+            },
+        };
+        buildCheapestPerCredit.mockReturnValue({ sell: { '/items/brown_guild_credit': 100 } });
+
+        const result = calculateShrineScore({
+            profile: {
+                guildBuffLevelMap: { '/guild_buffs/force_combat': 2, '/guild_buffs/wisdom_skilling': 1 },
+            },
+        });
+
+        expect(result.combat.score).toBeCloseTo((100 * 100 + 200 * 100) / 1_000_000);
+        expect(result.skiller.score).toBeCloseTo((50 * 100) / 1_000_000);
+    });
+
+    test('a buff at level 0 (not purchased) is skipped entirely', () => {
+        mocks.itemDetailMap = { [GUILD_TOKEN]: { guildCreditConversions: [] } };
+        mocks.guildBuffDetailMap = {
+            '/guild_buffs/force_combat': { isCombat: true, levelCosts: { 1: { guildTokenCost: 0, creditCosts: [] } } },
+        };
+        buildCheapestPerCredit.mockReturnValue({ sell: {} });
+
+        const result = calculateShrineScore({ profile: { guildBuffLevelMap: {} } });
+        expect(result.combat.breakdown).toEqual([]);
+    });
+
+    test('an unresolvable credit value marks the buff (and category) partial, not zero-filled (PB-46)', () => {
+        mocks.itemDetailMap = { [GUILD_TOKEN]: { guildCreditConversions: [] } };
+        mocks.guildBuffDetailMap = {
+            '/guild_buffs/force_combat': {
+                isCombat: true,
+                levelCosts: {
+                    1: { guildTokenCost: 0, creditCosts: [{ itemHrid: '/items/brown_guild_credit', count: 100 }] },
+                },
+            },
+        };
+        buildCheapestPerCredit.mockReturnValue({ sell: {} }); // brown credit unresolved
+
+        const result = calculateShrineScore({ profile: { guildBuffLevelMap: { '/guild_buffs/force_combat': 1 } } });
+        expect(result.combat.complete).toBe(false);
+    });
+
+    test('an unresolvable Guild Token value marks the buff partial when a level requires tokens', () => {
+        mocks.itemDetailMap = { [GUILD_TOKEN]: { guildCreditConversions: [] } }; // no conversions -> tokenValue stays 0
+        mocks.guildBuffDetailMap = {
+            '/guild_buffs/force_combat': {
+                isCombat: true,
+                levelCosts: { 1: { guildTokenCost: 400, creditCosts: [] } },
+            },
+        };
+        buildCheapestPerCredit.mockReturnValue({ sell: {} });
+
+        const result = calculateShrineScore({ profile: { guildBuffLevelMap: { '/guild_buffs/force_combat': 1 } } });
+        expect(result.combat.complete).toBe(false);
+    });
+});

--- a/src/utils/ability-cost-calculator.js
+++ b/src/utils/ability-cost-calculator.js
@@ -6,6 +6,7 @@
 
 import dataManager from '../core/data-manager.js';
 import marketAPI from '../api/marketplace.js';
+import { getItemPrice } from './market-data.js';
 
 /**
  * List of starter abilities that give 50 XP per book (others give 500)
@@ -127,4 +128,31 @@ export function calculateAbilityLevelUpCost(abilityHrid, currentLevel, currentXp
     const weightedPrice = (ask + bid) / 2;
 
     return booksNeeded * weightedPrice;
+}
+
+/**
+ * Calculate the cost to reach a specific ability level from level 0, reading real per-item
+ * `abilityBookDetail.experienceGain` instead of a hardcoded starter/non-starter split, and
+ * pricing the book with pure Ask (TLA-041 / F-11). Never falls back to 0 silently — a missing
+ * `experienceGain` or Ask price marks the result incomplete.
+ * @param {string} abilityHrid - Ability HRID
+ * @param {number} targetLevel - Target level to reach
+ * @returns {{cost: number|null, complete: boolean}}
+ */
+export function calculateAbilityBookCostDataDriven(abilityHrid, targetLevel) {
+    const gameData = dataManager.getInitClientData();
+    const levelXpTable = gameData?.levelExperienceTable;
+    if (!levelXpTable) return { cost: null, complete: false };
+
+    const itemHrid = abilityHrid.replace('/abilities/', '/items/');
+    const xpPerBook = gameData.itemDetailMap?.[itemHrid]?.abilityBookDetail?.experienceGain;
+    if (!(xpPerBook > 0)) return { cost: null, complete: false };
+
+    const targetXp = levelXpTable[targetLevel] || 0;
+    const booksNeeded = Math.ceil(targetXp / xpPerBook) + 1; // +1 = initial learn book
+
+    const ask = getItemPrice(itemHrid, { mode: 'ask' });
+    if (!(ask > 0)) return { cost: null, complete: false };
+
+    return { cost: booksNeeded * ask, complete: true };
 }

--- a/src/utils/ability-cost-calculator.test.js
+++ b/src/utils/ability-cost-calculator.test.js
@@ -3,11 +3,16 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
     levelExperienceTable: [],
     prices: {},
+    itemDetailMap: {},
+    askPrice: 0,
 }));
 
 vi.mock('../core/data-manager.js', () => ({
     default: {
-        getInitClientData: vi.fn(() => ({ levelExperienceTable: mocks.levelExperienceTable })),
+        getInitClientData: vi.fn(() => ({
+            levelExperienceTable: mocks.levelExperienceTable,
+            itemDetailMap: mocks.itemDetailMap,
+        })),
     },
 }));
 
@@ -17,7 +22,16 @@ vi.mock('../api/marketplace.js', () => ({
     },
 }));
 
-import { calculateAbilityCost, calculateAbilityLevelUpCost, isStarterAbility } from './ability-cost-calculator.js';
+vi.mock('./market-data.js', () => ({
+    getItemPrice: vi.fn(() => mocks.askPrice),
+}));
+
+import {
+    calculateAbilityCost,
+    calculateAbilityLevelUpCost,
+    isStarterAbility,
+    calculateAbilityBookCostDataDriven,
+} from './ability-cost-calculator.js';
 
 describe('isStarterAbility', () => {
     test('starter abilities give 50 XP per book', () => {
@@ -93,5 +107,36 @@ describe('calculateAbilityCost / calculateAbilityLevelUpCost - integer book coun
         const xpNeeded = targetXp - mocks.levelExperienceTable[5];
         const weightedPrice = (mocks.prices.ask + mocks.prices.bid) / 2;
         expect(cost).toBeCloseTo(Math.ceil(xpNeeded / 500) * weightedPrice);
+    });
+});
+
+describe('calculateAbilityBookCostDataDriven - data-driven XP/book, Ask-only (TLA-041 / F-11)', () => {
+    beforeEach(() => {
+        mocks.levelExperienceTable = [0, 1001]; // index 1 = target level used below
+        mocks.itemDetailMap = { '/items/speed_aura': { abilityBookDetail: { experienceGain: 125 } } };
+        mocks.askPrice = 10000;
+    });
+
+    test('F-11: 125 XP/book, target 1001 XP, Ask 10,000/book -> 10 books = 100,000', () => {
+        const result = calculateAbilityBookCostDataDriven('/abilities/speed_aura', 1);
+        expect(result).toEqual({ cost: 100000, complete: true });
+    });
+
+    test('is not hardwired to 50/500 - a starter-named ability still uses its own experienceGain', () => {
+        mocks.itemDetailMap = { '/items/fireball': { abilityBookDetail: { experienceGain: 125 } } };
+        const result = calculateAbilityBookCostDataDriven('/abilities/fireball', 1);
+        expect(result).toEqual({ cost: 100000, complete: true });
+    });
+
+    test('missing experienceGain marks the result incomplete instead of falling back to a hardcoded value', () => {
+        mocks.itemDetailMap = { '/items/speed_aura': {} };
+        const result = calculateAbilityBookCostDataDriven('/abilities/speed_aura', 1);
+        expect(result).toEqual({ cost: null, complete: false });
+    });
+
+    test('missing Ask price marks the result incomplete rather than returning a zero cost', () => {
+        mocks.askPrice = 0;
+        const result = calculateAbilityBookCostDataDriven('/abilities/speed_aura', 1);
+        expect(result).toEqual({ cost: null, complete: false });
     });
 });

--- a/src/utils/guild-credit-conversion.js
+++ b/src/utils/guild-credit-conversion.js
@@ -10,12 +10,16 @@ import { getItemPrice } from './market-data.js';
 /**
  * Build cheapest-gold-per-credit maps for both sell and buy sides.
  * @param {Object} itemDetailMap
+ * @param {string[]} [excludeHrids=[]] - Source item hrids to skip (e.g. Guild Token itself, which
+ *   carries its own guildCreditConversions and would otherwise create a circular credit value —
+ *   TLA-041).
  * @returns {{ sell: Object, buy: Object }} Map of creditItemHrid -> cheapest gold cost per credit
  */
-export function buildCheapestPerCredit(itemDetailMap) {
+export function buildCheapestPerCredit(itemDetailMap, excludeHrids = []) {
     const sell = {};
     const buy = {};
     for (const [hrid, item] of Object.entries(itemDetailMap)) {
+        if (excludeHrids.includes(hrid)) continue;
         for (const conv of item.guildCreditConversions || []) {
             const creditHrid = conv.creditItemHrid;
             const sellPrice = getItemPrice(hrid, { mode: 'ask' });

--- a/src/utils/guild-credit-conversion.test.js
+++ b/src/utils/guild-credit-conversion.test.js
@@ -64,4 +64,33 @@ describe('buildCheapestPerCredit', () => {
         expect(sell[CREDIT]).toBeUndefined();
         expect(buy[CREDIT]).toBeCloseTo(0.5);
     });
+
+    test('excludeHrids skips a source item entirely, e.g. Guild Token pricing itself into the credit table (TLA-041)', () => {
+        const GUILD_TOKEN = '/items/guild_token';
+        mockGetItemPrice.mockImplementation((hrid, opts) => {
+            if (opts.mode !== 'ask') return 0;
+            if (hrid === GUILD_TOKEN) return 1; // would win as "cheapest" if not excluded
+            if (hrid === ITEM_A) return 100;
+            return 0;
+        });
+
+        const itemDetailMap = {
+            [GUILD_TOKEN]: { guildCreditConversions: [{ creditItemHrid: CREDIT, itemCount: 1, creditCount: 10 }] },
+            [ITEM_A]: { guildCreditConversions: [{ creditItemHrid: CREDIT, itemCount: 1, creditCount: 10 }] },
+        };
+
+        const withoutExclusion = buildCheapestPerCredit(itemDetailMap);
+        expect(withoutExclusion.sell[CREDIT]).toBeCloseTo(0.1); // guild_token's own price leaks in
+
+        const { sell } = buildCheapestPerCredit(itemDetailMap, [GUILD_TOKEN]);
+        expect(sell[CREDIT]).toBeCloseTo(10); // only ITEM_A considered
+    });
+
+    test('default excludeHrids ([]) preserves existing behavior for the sole existing caller', () => {
+        mockGetItemPrice.mockImplementation((hrid, opts) => (opts.mode === 'ask' ? 100 : 0));
+        const itemDetailMap = {
+            [ITEM_A]: { guildCreditConversions: [{ creditItemHrid: CREDIT, itemCount: 1, creditCount: 10 }] },
+        };
+        expect(buildCheapestPerCredit(itemDetailMap)).toEqual(buildCheapestPerCredit(itemDetailMap, []));
+    });
 });

--- a/src/utils/house-cost-calculator.js
+++ b/src/utils/house-cost-calculator.js
@@ -6,6 +6,7 @@
 
 import dataManager from '../core/data-manager.js';
 import marketAPI from '../api/marketplace.js';
+import { getItemPrice } from './market-data.js';
 
 /**
  * Calculate the total cost to build a house room to a specific level
@@ -111,4 +112,91 @@ export function calculateBattleHousesCost(characterHouseRooms) {
     breakdown.sort((a, b) => b.cost - a.cost);
 
     return { totalCost, breakdown };
+}
+
+/**
+ * Determine whether a house room is Combat or Skiller domain, from actual game data
+ * (`usableInActionTypeMap`) rather than a hardcoded room-name list (TLA-041 / PB-08).
+ * @param {string} houseRoomHrid - House room HRID
+ * @returns {'combat'|'skilling'|null} null if the room is unknown
+ */
+export function getHouseRoomDomain(houseRoomHrid) {
+    const gameData = dataManager.getInitClientData();
+    const houseDetail = gameData?.houseRoomDetailMap?.[houseRoomHrid];
+    if (!houseDetail) return null;
+
+    const usableInActionTypeMap = houseDetail.usableInActionTypeMap || {};
+    return usableInActionTypeMap['/action_types/combat'] ? 'combat' : 'skilling';
+}
+
+/**
+ * Calculate the cost to build a house room to a specific level using pure Ask pricing
+ * (never `(ask+bid)/2` — TLA-041 / F-10). A required material with no positive Ask marks the
+ * whole room incomplete instead of silently contributing 0.
+ * @param {string} houseRoomHrid - House room HRID
+ * @param {number} currentLevel - Target level
+ * @returns {{cost: number, complete: boolean}}
+ */
+export function calculateHouseRoomCostAskOnly(houseRoomHrid, currentLevel) {
+    const gameData = dataManager.getInitClientData();
+    const upgradeCostsMap = gameData?.houseRoomDetailMap?.[houseRoomHrid]?.upgradeCostsMap;
+    if (!upgradeCostsMap) return { cost: 0, complete: false };
+
+    let cost = 0;
+    let complete = true;
+
+    for (let level = 1; level <= currentLevel; level++) {
+        const levelUpgrades = upgradeCostsMap[level];
+        if (!levelUpgrades) {
+            complete = false;
+            continue;
+        }
+
+        for (const item of levelUpgrades) {
+            if (item.itemHrid === '/items/coin') {
+                cost += item.count;
+                continue;
+            }
+
+            const ask = getItemPrice(item.itemHrid, { mode: 'ask' });
+            if (!(ask > 0)) {
+                complete = false;
+                continue;
+            }
+            cost += item.count * ask;
+        }
+    }
+
+    return { cost, complete };
+}
+
+/**
+ * Sum Ask-only build cost across every owned room in the given domain.
+ * @param {Object} characterHouseRooms - Map of character house rooms from profile data
+ * @param {'combat'|'skilling'} domain
+ * @returns {{totalCost: number, complete: boolean, breakdown: Array<{name: string, level: number, cost: number}>}}
+ */
+export function calculateHousesCostByDomain(characterHouseRooms, domain) {
+    const gameData = dataManager.getInitClientData();
+    const houseRoomDetailMap = gameData?.houseRoomDetailMap || {};
+
+    let totalCost = 0;
+    let complete = true;
+    const breakdown = [];
+
+    for (const [houseRoomHrid, houseData] of Object.entries(characterHouseRooms || {})) {
+        const level = houseData.level || 0;
+        if (level === 0) continue;
+        if (getHouseRoomDomain(houseRoomHrid) !== domain) continue;
+
+        const { cost, complete: roomComplete } = calculateHouseRoomCostAskOnly(houseRoomHrid, level);
+        totalCost += cost;
+        complete = complete && roomComplete;
+
+        const houseName = houseRoomDetailMap[houseRoomHrid]?.name || houseRoomHrid.replace('/house_rooms/', '');
+        breakdown.push({ name: houseName, level, cost });
+    }
+
+    breakdown.sort((a, b) => b.cost - a.cost);
+    return { totalCost, complete, breakdown };
 }

--- a/src/utils/house-cost-calculator.test.js
+++ b/src/utils/house-cost-calculator.test.js
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    houseRoomDetailMap: {},
+    askPrices: {},
+}));
+
+vi.mock('../core/data-manager.js', () => ({
+    default: {
+        getInitClientData: vi.fn(() => ({ houseRoomDetailMap: mocks.houseRoomDetailMap })),
+    },
+}));
+
+vi.mock('../api/marketplace.js', () => ({
+    default: {
+        getPrice: vi.fn(() => ({ ask: -1, bid: -1 })),
+    },
+}));
+
+vi.mock('./market-data.js', () => ({
+    getItemPrice: vi.fn((itemHrid) => mocks.askPrices[itemHrid] ?? -1),
+}));
+
+import {
+    getHouseRoomDomain,
+    calculateHouseRoomCostAskOnly,
+    calculateHousesCostByDomain,
+} from './house-cost-calculator.js';
+
+describe('getHouseRoomDomain - data-driven from usableInActionTypeMap (TLA-041 / PB-08)', () => {
+    beforeEach(() => {
+        mocks.houseRoomDetailMap = {
+            '/house_rooms/dojo': { name: 'Dojo', usableInActionTypeMap: { '/action_types/combat': true } },
+            '/house_rooms/garden': { name: 'Garden', usableInActionTypeMap: { '/action_types/foraging': true } },
+        };
+    });
+
+    test('a room usable for combat classifies as combat', () => {
+        expect(getHouseRoomDomain('/house_rooms/dojo')).toBe('combat');
+    });
+
+    test('a room usable only for a skilling action type classifies as skilling', () => {
+        expect(getHouseRoomDomain('/house_rooms/garden')).toBe('skilling');
+    });
+
+    test('an unknown room returns null rather than guessing a domain', () => {
+        expect(getHouseRoomDomain('/house_rooms/nonexistent')).toBeNull();
+    });
+});
+
+describe('calculateHouseRoomCostAskOnly - pure Ask pricing (TLA-041 / F-10)', () => {
+    beforeEach(() => {
+        mocks.houseRoomDetailMap = {
+            '/house_rooms/dojo': {
+                name: 'Dojo',
+                usableInActionTypeMap: { '/action_types/combat': true },
+                upgradeCostsMap: { 1: [{ itemHrid: '/items/plank', count: 100 }] },
+            },
+        };
+        mocks.askPrices = { '/items/plank': 1000 };
+    });
+
+    test('F-10: 100 units at Ask 1,000 (Bid 400 ignored) costs exactly 100,000, never the 70,000 midpoint', () => {
+        const result = calculateHouseRoomCostAskOnly('/house_rooms/dojo', 1);
+        expect(result).toEqual({ cost: 100000, complete: true });
+    });
+
+    test('coins are priced at face value 1, not looked up on the market', () => {
+        mocks.houseRoomDetailMap['/house_rooms/dojo'].upgradeCostsMap = {
+            1: [{ itemHrid: '/items/coin', count: 500 }],
+        };
+        const result = calculateHouseRoomCostAskOnly('/house_rooms/dojo', 1);
+        expect(result).toEqual({ cost: 500, complete: true });
+    });
+
+    test('a required material with no positive Ask marks the room incomplete, not silently zero', () => {
+        mocks.askPrices = {};
+        const result = calculateHouseRoomCostAskOnly('/house_rooms/dojo', 1);
+        expect(result.complete).toBe(false);
+    });
+
+    test('a missing level entry within the requested range marks the room incomplete', () => {
+        const result = calculateHouseRoomCostAskOnly('/house_rooms/dojo', 2);
+        expect(result.complete).toBe(false);
+    });
+
+    test('unknown room returns incomplete with zero cost', () => {
+        expect(calculateHouseRoomCostAskOnly('/house_rooms/nonexistent', 1)).toEqual({ cost: 0, complete: false });
+    });
+});
+
+describe('calculateHousesCostByDomain - sums only owned rooms in the requested domain', () => {
+    beforeEach(() => {
+        mocks.houseRoomDetailMap = {
+            '/house_rooms/dojo': {
+                name: 'Dojo',
+                usableInActionTypeMap: { '/action_types/combat': true },
+                upgradeCostsMap: { 1: [{ itemHrid: '/items/plank', count: 10 }] },
+            },
+            '/house_rooms/garden': {
+                name: 'Garden',
+                usableInActionTypeMap: { '/action_types/foraging': true },
+                upgradeCostsMap: { 1: [{ itemHrid: '/items/seed', count: 10 }] },
+            },
+        };
+        mocks.askPrices = { '/items/plank': 100, '/items/seed': 50 };
+    });
+
+    test('combat domain sums only the combat room, skilling room excluded', () => {
+        const rooms = { '/house_rooms/dojo': { level: 1 }, '/house_rooms/garden': { level: 1 } };
+        const result = calculateHousesCostByDomain(rooms, 'combat');
+        expect(result.totalCost).toBe(1000);
+        expect(result.breakdown).toEqual([{ name: 'Dojo', level: 1, cost: 1000 }]);
+    });
+
+    test('skilling domain sums only the skilling room, combat room excluded', () => {
+        const rooms = { '/house_rooms/dojo': { level: 1 }, '/house_rooms/garden': { level: 1 } };
+        const result = calculateHousesCostByDomain(rooms, 'skilling');
+        expect(result.totalCost).toBe(500);
+        expect(result.breakdown).toEqual([{ name: 'Garden', level: 1, cost: 500 }]);
+    });
+
+    test('a room owned at level 0 is not counted', () => {
+        const rooms = { '/house_rooms/dojo': { level: 0 } };
+        const result = calculateHousesCostByDomain(rooms, 'combat');
+        expect(result.totalCost).toBe(0);
+        expect(result.breakdown).toEqual([]);
+    });
+
+    test('an incomplete room propagates incompleteness to the domain total', () => {
+        mocks.askPrices = {};
+        const rooms = { '/house_rooms/dojo': { level: 1 } };
+        const result = calculateHousesCostByDomain(rooms, 'combat');
+        expect(result.complete).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Rewrites Combat/Skiller Score (the profile "reproduce this build" estimate) to fix several correctness gaps against the actual game data and against its own stated economic contract.

**Product definition (unchanged, now correctly implemented):** estimated cost for the viewer to reproduce the viewed persistent build now, using current acquisition prices and the viewer's own current/manual Enhancing setup. Deliberately viewer-relative — two different viewers looking at the same profile can get different numbers.

- Combat Score = Houses + equipped Abilities + Combat/shared Equipment + personal Combat Shrines
- Skiller Score = Skilling Houses + Skilling/shared Equipment + personal Skilling Shrines
- No Achievements component, no Combat + Skiller grand total (unchanged)

## What was wrong

- **Equipment classifier**: used a hardcoded skill-requirement name list instead of actual `combatStats`/`noncombatStats`. Verified 34 concrete mismatches against the live Game Reference (independently reproduced the exact 344 combat-only / 177 skilling-only / 11 both / 0 neither split across all 532 equipment items).
- **Pricing**: mixed Bid/midpoint, Net-Worth-setting-gated worker fallbacks, and silent zero for unpriced items. Now Ask-only, compares every proven acquisition route (exact listing, base + enhancement reconstruction, cheaper lower-enhancement listing + direct enhancement), and never substitutes zero — an unpriceable component makes its category (and the top-level total) a disclosed lower bound (`930.0+`) instead.
- **Token equipment** (Chimerical Quiver, Sinister Cape, Enchanted Cloak): priced by token opportunity value *before* enhancement was considered, so +0 and +20 of the same item priced identically. Now enhancement value is always added on top.
- **Duplicate work**: Combat and Skiller equipment were each computed in a full separate pass, pricing shared items (and running enhancement math) twice. Now priced once per unique `(item, level)` and fanned into whichever domain(s) it belongs to.
- **Missing components**: no Skilling Houses and no Shrines (Combat or Skiller) at all. Both added, driven by real game data (`usableInActionTypeMap` for house domain, `guildBuffDetailMap`/`guildBuffLevelMap` for Shrines) rather than another hardcoded list.
- **Ability book cost**: hardcoded an 8-ability "starter" list at 50 XP/book vs. 500 for everything else. Now reads the real per-item `abilityBookDetail.experienceGain`.

## Compatibility / regression safety

`ability-cost-calculator.js`, `house-cost-calculator.js`, and `tooltip-enhancement.js` are also used by Net Worth and Upgrade Advisor — every change to those files is a new additive export; none of their existing exported functions changed. `score-calculator.js`'s public `calculateCombatScore()` signature and top-level field names/types are unchanged (`character-card-button.js` still reads `scoreResult.total` as a plain number).

## Test coverage

74 new tests across 10 new/extended files, mapped to the reviewed acceptance matrix (PB-01..PB-55) and numeric fixtures (F-01..F-13) for this ticket, including:
- Equipment classifier stats-based split (charms, pouches, no-requirement accessories)
- Equipment replacement resolver: exact listing vs. reconstruction vs. lower-enhancement-listing candidates, inflated-listing rejection, direct K→N Markov math (never a 0-based subtraction shortcut), token enhancement value
- Value-once-fan-out (call-count assertions proving shared equipment is priced exactly once)
- House domain classification from real game data
- Guild Token opportunity value (maximum foregone alternative, not minimum; self-exclusion from the credit table to avoid circularity)
- Partial/lower-bound propagation from leaf → category → top-level total
- Existing TLA-038 panel-positioning tests untouched and passing

Every existing test file for the shared modules above (`networth-calculator.test.js`, `upgrade-advisor-cost.test.js`, `tooltip-enhancement.test.js` and its other consumers, `ability-cost-calculator.test.js`) passes unmodified — no fixture edits needed.

## Test plan

- [x] Full suite: 177 files / 2382 tests passing
- [x] `npm run lint` / `npm run format:check` clean
- [x] `npm run build:dev` and `npm run build` succeed
- [x] `npm run check:loadout-state` — integrity verified
- [ ] Manual: open a profile with houses/shrines/token equipment and confirm the new rows render correctly and collapsed by default